### PR TITLE
docs(contributing): codify PR-only workflow and issue linking

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,11 @@
 ## Description
 Brief description of what this PR does.
 
+## Related Issues
+<!-- Link the issues this PR resolves so they close automatically on merge. -->
+<!-- Use "Closes #123" / "Fixes #123", or "Refs #123" if it only relates. -->
+Closes #
+
 ## Type of Change
 - [ ] 🐛 Bug fix
 - [ ] ✨ New feature
@@ -21,7 +26,11 @@ Brief description of what this PR does.
 If applicable, add screenshots of the changes.
 
 ## Checklist
+- [ ] Branched off `main` (not pushing directly to `main`)
+- [ ] Linked the resolved issue(s) above with `Closes #`
+- [ ] Conventional Commit message(s) (e.g. `fix(engine): ...`)
 - [ ] Code follows the project's style guidelines
 - [ ] Self-review of the code completed
 - [ ] Documentation updated (if needed)
+- [ ] Release Gate passes locally (`pnpm check:release`)
 - [ ] No new warnings introduced

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,34 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 
 ### Pull Requests
 
-1. Fork the repo and create your branch from `main`
-2. If you've added code that should be tested, add tests
-3. If you've changed APIs, update the documentation
-4. Ensure the test suite passes
-5. Make sure your code lints
-6. Issue that pull request!
+All changes — including those by maintainers — land through a Pull Request.
+The `main` branch is protected: direct pushes are rejected, and every PR must
+pass the Release Gate CI and receive a review before it can be merged.
+
+**Workflow**
+
+1. Create a topic branch off `main`. Use a descriptive prefix:
+   - `feat/<slug>` — new functionality
+   - `fix/<slug>` — bug fix
+   - `docs/<slug>` — documentation only
+   - `chore/` · `refactor/` · `test/<slug>` — everything else
+2. Keep the change focused — one logical change per PR.
+3. Add or update tests for the behavior you change.
+4. If you touch an API route, update the docs and route snapshot (see
+   [Release Checks](#release-checks)).
+5. Run the checks locally before pushing:
+   `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm check:release`.
+6. Write [Conventional Commit](https://www.conventionalcommits.org/) messages,
+   e.g. `fix(engine): resolve canonical group id before sending`.
+7. Self-review your diff, then open the PR and fill in the template.
+8. **Link the issues your PR resolves** by putting `Closes #<number>` (or
+   `Fixes #<number>`) in the PR description. Referenced issues close
+   automatically when the PR merges — please don't close them by hand.
+9. A maintainer reviews and merges. Squash-merge is preferred to keep the
+   `main` history linear and readable.
+
+> First time contributing? `git clone` your fork, then follow
+> [Development Setup](#development-setup).
 
 ## Development Setup
 


### PR DESCRIPTION
## Description
Documents the PR-based workflow now that `main` is a protected branch.

`main` protection was enabled alongside this PR:
- PR + **1 review** required to merge (no direct pushes)
- **Release Gate** CI (`Public boundary and API contract checks`) must pass
- No force-pushes / no deletions; conversation resolution required
- `enforce_admins: false` so the sole maintainer can still merge their own PRs without a second reviewer

## Related Issues
None — governance/docs only.

## Changes Made
- **CONTRIBUTING.md** — expanded the *Pull Requests* section: branch-per-change workflow, branch-name prefixes (`feat/` `fix/` `docs/` `chore/`…), Conventional Commits, running the checks locally, and linking issues with `Closes #<n>` so they auto-close on merge (don't close by hand).
- **.github/PULL_REQUEST_TEMPLATE.md** — added a prominent *Related Issues* block (`Closes #`) and checklist items for branching off `main`, issue linking, conventional commits, and the Release Gate.

## Testing
- [x] Docs only — no runtime code changes
- [x] `git diff --check` clean (matches the Release Gate whitespace check)

## Checklist
- [x] Branched off `main` (not pushing directly to `main`)
- [x] Conventional Commit message
- [x] Self-review completed
- [x] No new warnings introduced