### PR TITLE
feat(contacts): save/delete a number in the WhatsApp account addressbook

### DIFF
--- a/apps/api/src/modules/contacts/contacts.controller.ts
+++ b/apps/api/src/modules/contacts/contacts.controller.ts
@@ -9,7 +9,7 @@ import { ContactsService } from './contacts.service';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-auth.guard';
 import { TenantGuard } from '../../common/tenant/tenant.guard';
 import { RequireTenant } from '../../common/tenant/require-tenant.decorator';
-import { CreateContactDto, UpdateContactDto, ImportContactsDto, ImportCsvDto, ValidateBulkDto } from './dto';
+import { CreateContactDto, UpdateContactDto, ImportContactsDto, ImportCsvDto, ValidateBulkDto, SaveWhatsAppContactDto } from './dto';
 
 @ApiTags('Contacts')
 @Controller('contacts')
@@ -169,5 +169,31 @@ export class ContactsController {
       throw new BadRequestException('profileId is required as query param');
     }
     return this.service.syncFromWhatsApp(profileId);
+  }
+
+  // Save a number into the WhatsApp account's addressbook (whatsapp-web.js only).
+  // Writes to WhatsApp itself (not just the MultiWA DB), turning an unknown number
+  // into a known contact.
+  @Post('profile/:profileId/save-to-whatsapp')
+  @RequireTenant({ from: 'param', key: 'profileId', resource: 'profile' })
+  @ApiOperation({ summary: "Save a contact into the WhatsApp account's addressbook (whatsapp-web-js only)" })
+  @ApiValidationError()
+  @ApiNotFound('Profile')
+  async saveToWhatsApp(
+    @Param('profileId') profileId: string,
+    @Body() dto: SaveWhatsAppContactDto,
+  ) {
+    return this.service.saveToWhatsApp(profileId, dto.phone, dto.firstName, dto.lastName, dto.syncToPhone);
+  }
+
+  @Delete('profile/:profileId/whatsapp/:phone')
+  @RequireTenant({ from: 'param', key: 'profileId', resource: 'profile' })
+  @ApiOperation({ summary: "Delete a contact from the WhatsApp account's addressbook (whatsapp-web-js only)" })
+  @ApiNotFound('Profile')
+  async deleteFromWhatsApp(
+    @Param('profileId') profileId: string,
+    @Param('phone') phone: string,
+  ) {
+    return this.service.deleteFromWhatsApp(profileId, phone);
   }
 }

--- a/apps/api/src/modules/contacts/contacts.service.ts
+++ b/apps/api/src/modules/contacts/contacts.service.ts
@@ -383,6 +383,49 @@ export class ContactsService {
     };
   }
 
+  // Save a number into the WhatsApp ACCOUNT's addressbook (whatsapp-web.js only).
+  // Unlike create()/import (MultiWA DB only), this writes to WhatsApp itself, so an
+  // "unknown" number becomes a known contact — which WhatsApp treats more leniently.
+  async saveToWhatsApp(
+    profileId: string,
+    phone: string,
+    firstName?: string,
+    lastName?: string,
+    syncToPhone?: boolean,
+  ) {
+    const normalized = this.normalizePhone(phone);
+    const profile = await prisma.profile.findUnique({ where: { id: profileId } });
+    if (!profile) throw new NotFoundException('Profile not found');
+    if (profile.status !== 'connected') {
+      throw new BadRequestException('Profile must be connected to save a WhatsApp contact');
+    }
+    const engine = isWorkerEngine() ? null : this.engineManager.getEngine(profileId);
+    if (!engine || typeof engine.saveWhatsAppContact !== 'function') {
+      throw new BadRequestException(
+        'This engine does not support saving WhatsApp contacts (whatsapp-web-js only)',
+      );
+    }
+    await engine.saveWhatsAppContact(normalized, firstName || normalized, lastName || '', !!syncToPhone);
+    return {
+      success: true,
+      phone: normalized,
+      savedToWhatsAppAddressbook: true,
+      syncedToPhone: !!syncToPhone,
+    };
+  }
+
+  async deleteFromWhatsApp(profileId: string, phone: string) {
+    const normalized = this.normalizePhone(phone);
+    const engine = isWorkerEngine() ? null : this.engineManager.getEngine(profileId);
+    if (!engine || typeof engine.deleteWhatsAppContact !== 'function') {
+      throw new BadRequestException(
+        'This engine does not support WhatsApp addressbook deletion (whatsapp-web-js only)',
+      );
+    }
+    await engine.deleteWhatsAppContact(normalized);
+    return { success: true, phone: normalized, deletedFromWhatsAppAddressbook: true };
+  }
+
   // Normalize phone number
   private normalizePhone(phone: string): string {
     let normalized = phone.replace(/\D/g, '');

--- a/apps/api/src/modules/contacts/dto/index.ts
+++ b/apps/api/src/modules/contacts/dto/index.ts
@@ -8,11 +8,34 @@ import {
   IsArray,
   IsObject,
   IsNotEmpty,
+  IsBoolean,
   ValidateNested,
   ArrayNotEmpty,
   IsPhoneNumber,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+
+export class SaveWhatsAppContactDto {
+  @ApiProperty({ example: '6281234567890', description: 'Phone with country code' })
+  @IsString()
+  @IsNotEmpty()
+  phone: string;
+
+  @ApiPropertyOptional({ example: 'John' })
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @ApiPropertyOptional({ example: 'Doe' })
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @ApiPropertyOptional({ example: false, description: "Also mirror to the phone's address book" })
+  @IsOptional()
+  @IsBoolean()
+  syncToPhone?: boolean;
+}
 
 export class CreateContactDto {
   @ApiProperty({ example: 'profile-uuid' })

--- a/docs/07-api-specification.md
+++ b/docs/07-api-specification.md
@@ -229,6 +229,8 @@ The tables below mirror the `@Controller(...)` decorators in `apps/api/src/`. Us
 | `GET` | `/contacts/profile/:profileId/validate/:phone` | Validate a single phone number on WhatsApp |
 | `POST` | `/contacts/profile/:profileId/validate` | Validate a batch of phone numbers |
 | `POST` | `/contacts/sync/whatsapp` | Sync contacts from WhatsApp |
+| `POST` | `/contacts/profile/:profileId/save-to-whatsapp` | Save a contact into the WhatsApp account addressbook (whatsapp-web-js only) |
+| `DELETE` | `/contacts/profile/:profileId/whatsapp/:phone` | Delete a contact from the WhatsApp account addressbook (whatsapp-web-js only) |
 
 ### Templates (`/templates`)
 

--- a/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
+++ b/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
@@ -775,7 +775,15 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
     if (!this.isReady() || !this.client) throw new Error('Client not ready');
     const digits = (phone || '').replace(/\D/g, '');
     if (!digits) throw new Error('Invalid phone number');
-    await (this.client as any).deleteAddressbookContact(digits);
+    // whatsapp-web.js's own deleteAddressbookContact feeds BARE digits to createWid(),
+    // which needs a full "<user>@c.us" wid and throws otherwise. Call the WA delete
+    // action directly with a correctly-formed wid instead.
+    const page: any = (this.client as any).pupPage;
+    if (!page) throw new Error('Client page not available');
+    await page.evaluate((jid: string) => {
+      const wid = (window as any).require('WAWebWidFactory').createWid(jid);
+      return (window as any).require('WAWebDeleteContactAction').deleteContactAction({ phoneNumber: wid });
+    }, `${digits}@c.us`);
     console.log(`[WhatsApp-WebJS] Deleted addressbook contact ${digits}`);
   }
 

--- a/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
+++ b/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
@@ -754,6 +754,31 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
 
   // ========== CONTACTS ==========
 
+  // Save (or edit) a contact in the WhatsApp account's addressbook. Writes to WhatsApp
+  // itself (WAWebSaveContactAction), unlike the MultiWA contacts DB. Number must be
+  // digits with country code (e.g. "6281234567890"). syncToPhone also mirrors it to the
+  // phone's address book.
+  async saveWhatsAppContact(
+    phone: string,
+    firstName: string,
+    lastName = '',
+    syncToPhone = false,
+  ): Promise<void> {
+    if (!this.isReady() || !this.client) throw new Error('Client not ready');
+    const digits = (phone || '').replace(/\D/g, '');
+    if (!digits) throw new Error('Invalid phone number');
+    await (this.client as any).saveOrEditAddressbookContact(digits, firstName, lastName, syncToPhone);
+    console.log(`[WhatsApp-WebJS] Saved addressbook contact ${digits} (${firstName} ${lastName}, syncToPhone=${syncToPhone})`);
+  }
+
+  async deleteWhatsAppContact(phone: string): Promise<void> {
+    if (!this.isReady() || !this.client) throw new Error('Client not ready');
+    const digits = (phone || '').replace(/\D/g, '');
+    if (!digits) throw new Error('Invalid phone number');
+    await (this.client as any).deleteAddressbookContact(digits);
+    console.log(`[WhatsApp-WebJS] Deleted addressbook contact ${digits}`);
+  }
+
   async getContacts(): Promise<import('../types').ContactInfo[]> {
     try {
       if (!this.isReady() || !this.client) {

--- a/packages/engines/src/types.ts
+++ b/packages/engines/src/types.ts
@@ -174,6 +174,13 @@ export interface IWhatsAppEngine {
   // Contacts - fetch contacts from WhatsApp
   getContacts(): Promise<ContactInfo[]>;
 
+  // Save/remove a contact in the WhatsApp ACCOUNT's addressbook (optional; supported
+  // by whatsapp-web.js, not Baileys). Unlike the MultiWA contacts DB, this writes to
+  // WhatsApp itself, moving an "unknown" number into a known contact — which WhatsApp
+  // treats more leniently. syncToPhone=true also saves it to the phone's address book.
+  saveWhatsAppContact?(phone: string, firstName: string, lastName?: string, syncToPhone?: boolean): Promise<void>;
+  deleteWhatsAppContact?(phone: string): Promise<void>;
+
   // Resolve a JID's real identity (maps @lid <-> phone number + best name).
   // Returns null when the engine can't resolve it.
   resolveIdentity(jid: string): Promise<ResolvedIdentity | null>;

--- a/scripts/api-routes.snapshot.json
+++ b/scripts/api-routes.snapshot.json
@@ -7,7 +7,7 @@
     "@ApiExcludeController()",
     "@ApiExcludeEndpoint()"
   ],
-  "routeCount": 214,
+  "routeCount": 216,
   "routes": [
     {
       "method": "DELETE",
@@ -387,11 +387,19 @@
     },
     {
       "method": "POST",
+      "path": "/api/v1/contacts/profile/:profileId/save-to-whatsapp"
+    },
+    {
+      "method": "POST",
       "path": "/api/v1/contacts/profile/:profileId/validate"
     },
     {
       "method": "GET",
       "path": "/api/v1/contacts/profile/:profileId/validate/:phone"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/contacts/profile/:profileId/whatsapp/:phone"
     },
     {
       "method": "POST",


### PR DESCRIPTION
## Description
Exposes whatsapp-web.js's ability to write to the **WhatsApp account's addressbook** (`saveOrEditAddressbookContact` / `deleteAddressbookContact`). Unlike `POST /contacts` (which only writes the MultiWA DB — WhatsApp never sees it), this turns an "unknown" number into a **known contact in WhatsApp itself**, which WhatsApp's anti-spam treats more leniently.

Purpose: test whether saving a cold number as a real WhatsApp contact improves deliverability from a reach-out-limited profile — and give the gateway a genuinely useful capability either way.

## Related Issues
None.

## Changes Made
- **Engine interface** (`IWhatsAppEngine`): optional `saveWhatsAppContact` / `deleteWhatsAppContact`.
- **whatsapp-web-js adapter**: implemented (digits+country code; `syncToPhone` also mirrors to the phone's address book). **Baileys does not support it** (methods absent) — service returns a clear error.
- **ContactsService**: `saveToWhatsApp` / `deleteFromWhatsApp` — require a connected whatsapp-web-js profile.
- **Endpoints**: `POST /contacts/profile/:profileId/save-to-whatsapp`, `DELETE /contacts/profile/:profileId/whatsapp/:phone`.
- **Docs + route snapshot** updated (Release Gate).

## Honest caveat
This makes the number a known contact, which *helps at the margin* — but it does **not** override WhatsApp's newer unanswered-message / reach-out limit. Whether it unblocks a specific reach-out-limited profile is empirical; this PR is exactly what lets us test it.

## Testing
- [x] `tsc --noEmit` clean (engines + api)
- [x] `pnpm check:api-contract` in sync (216 routes; docs + snapshot updated)
- [x] `git diff --check` clean
- [ ] Live send test to two numbers after deploy (part of this task).

## Checklist
- [x] Branched off `main`
- [x] Conventional Commit message
- [x] Self-review completed
- [x] No new warnings introduced