### PR TITLE
feat(admin): server-side contact search + pagination (show all contacts)

### DIFF
--- a/apps/admin/src/app/dashboard/contacts/page.tsx
+++ b/apps/admin/src/app/dashboard/contacts/page.tsx
@@ -57,6 +57,9 @@ export default function ContactsPage() {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [total, setTotal] = useState(0);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const PAGE_SIZE = 50;
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [syncing, setSyncing] = useState(false);
@@ -74,11 +77,13 @@ export default function ContactsPage() {
     loadProfiles();
   }, []);
 
+  // Debounced server-side fetch whenever the profile, search, or tag changes.
   useEffect(() => {
-    if (selectedProfile) {
-      fetchContacts();
-    }
-  }, [selectedProfile]);
+    if (!selectedProfile) return;
+    const t = setTimeout(() => fetchContacts(true), 250);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProfile, search, selectedTag]);
 
   const loadProfiles = async () => {
     const res = await api.getProfiles();
@@ -91,20 +96,28 @@ export default function ContactsPage() {
     if (!res.data?.length) setLoading(false);
   };
 
-  const fetchContacts = async () => {
+  // Server-side search + pagination. reset=true replaces the list (new query);
+  // reset=false appends the next page ("Load more").
+  const fetchContacts = async (reset = true) => {
     if (!selectedProfile) return;
-    setLoading(true);
+    const offset = reset ? 0 : contacts.length;
+    reset ? setLoading(true) : setLoadingMore(true);
     try {
-      const res = await api.getContacts(selectedProfile);
-      if (res.data) {
-        // API returns { contacts: [...], total, limit, offset }
-        const contactsList = (res.data as any).contacts || (Array.isArray(res.data) ? res.data : []);
-        setContacts(contactsList);
-      }
+      const res = await api.getContacts(selectedProfile, {
+        search: search.trim() || undefined,
+        tags: selectedTag || undefined,
+        limit: PAGE_SIZE,
+        offset,
+      });
+      const data: any = res.data || {};
+      const list: Contact[] = data.contacts || (Array.isArray(res.data) ? res.data : []);
+      setTotal(typeof data.total === 'number' ? data.total : list.length);
+      setContacts(prev => (reset ? list : [...prev, ...list]));
     } catch (error) {
       console.error('Failed to fetch contacts:', error);
     } finally {
       setLoading(false);
+      setLoadingMore(false);
     }
   };
 
@@ -121,7 +134,7 @@ export default function ContactsPage() {
           title: 'Contacts synced from WhatsApp',
           description: `Synced: ${res.data.synced}, Created: ${res.data.created}, Updated: ${res.data.updated}`,
         });
-        fetchContacts(); // Refresh the list
+        fetchContacts(true); // Refresh the list
       } else {
         toast({ title: 'Sync failed', description: res.error || 'Unknown error', variant: 'destructive' });
       }
@@ -135,18 +148,7 @@ export default function ContactsPage() {
   // Get unique tags from all contacts
   const allTags = [...new Set(contacts.flatMap(c => c.tags || []))];
 
-  // Filter contacts
-  const filteredContacts = contacts.filter(contact => {
-    const matchesSearch = !search || 
-      contact.name?.toLowerCase().includes(search.toLowerCase()) ||
-      contact.phone?.includes(search) ||
-      contact.email?.toLowerCase().includes(search.toLowerCase());
-    
-    const matchesTag = !selectedTag ||
-      contact.tags?.includes(selectedTag);
-    
-    return matchesSearch && matchesTag;
-  });
+  // Search + tag filtering are now server-side (see fetchContacts); render `contacts` directly.
 
   const handleAddContact = async () => {
     if (!newContact.name || !newContact.phone) {
@@ -328,11 +330,11 @@ export default function ContactsPage() {
       </div>
 
       {/* Stats Bar */}
-      {!loading && contacts.length > 0 && (
+      {!loading && (contacts.length > 0 || !!search || !!selectedTag) && (
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2 py-3 px-4 bg-secondary/40 border border-border/60 rounded-xl text-sm">
           <div className="flex items-center gap-2">
             <Users className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
-            <span className="font-semibold text-foreground tabular-nums">{contacts.length}</span>
+            <span className="font-semibold text-foreground tabular-nums">{total}</span>
             <span className="text-muted-foreground">Contacts</span>
           </div>
           <div className="flex items-center gap-2">
@@ -344,7 +346,7 @@ export default function ContactsPage() {
       )}
 
       {/* Search & Filters */}
-      {!loading && contacts.length > 0 && (
+      {!loading && (contacts.length > 0 || !!search || !!selectedTag) && (
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="relative flex-1">
             <Search
@@ -386,9 +388,9 @@ export default function ContactsPage() {
         <div className="bg-card rounded-2xl border border-border p-4">
           <LoadingTable />
         </div>
-      ) : contacts.length === 0 ? (
+      ) : contacts.length === 0 && !search && !selectedTag ? (
         <EmptyContacts />
-      ) : filteredContacts.length === 0 ? (
+      ) : contacts.length === 0 ? (
         <div className="bg-card rounded-2xl p-12 border border-border text-center">
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-secondary/60 text-muted-foreground">
             <SearchX className="w-7 h-7" aria-hidden="true" />
@@ -411,7 +413,7 @@ export default function ContactsPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredContacts.map(contact => (
+              {contacts.map(contact => (
                 <TableRow key={contact.id} className="group">
                   <TableCell>
                     <Avatar className="w-10 h-10">
@@ -469,7 +471,7 @@ export default function ContactsPage() {
 
         {/* Mobile card list */}
         <div className="md:hidden space-y-2">
-          {filteredContacts.map(contact => (
+          {contacts.map(contact => (
             <div key={contact.id} className="bg-card border border-border rounded-xl p-4 flex items-start gap-3">
               <Avatar className="w-10 h-10 flex-shrink-0">
                 <AvatarImage src={contact.avatar} />
@@ -510,6 +512,17 @@ export default function ContactsPage() {
             </div>
           ))}
         </div>
+        {contacts.length < total && (
+          <div className="flex justify-center pt-2">
+            <Button
+              variant="outline"
+              onClick={() => fetchContacts(false)}
+              disabled={loadingMore}
+            >
+              {loadingMore ? 'Loading…' : `Load more (${contacts.length} of ${total})`}
+            </Button>
+          </div>
+        )}
         </>
       )}
 

--- a/apps/admin/src/lib/api.ts
+++ b/apps/admin/src/lib/api.ts
@@ -325,8 +325,20 @@ class ApiClient {
   }
 
   // Contacts
-  async getContacts(profileId: string) {
-    return this.request<Contact[]>(`/contacts?profileId=${profileId}&limit=1000`);
+  async getContacts(
+    profileId: string,
+    opts?: { search?: string; tags?: string; limit?: number; offset?: number },
+  ) {
+    const p = new URLSearchParams({
+      profileId,
+      limit: String(opts?.limit ?? 50),
+      offset: String(opts?.offset ?? 0),
+    });
+    if (opts?.search) p.set('search', opts.search);
+    if (opts?.tags) p.set('tags', opts.tags);
+    return this.request<{ contacts: Contact[]; total: number; limit: number; offset: number }>(
+      `/contacts?${p.toString()}`,
+    );
   }
 
   async createContact(data: { profileId: string; phone: string; name?: string; email?: string; tags?: string[]; notes?: string }) {

--- a/apps/api/src/modules/contacts/contacts.controller.ts
+++ b/apps/api/src/modules/contacts/contacts.controller.ts
@@ -39,11 +39,13 @@ export class ContactsController {
   async findAll(
     @Query('profileId') profileId: string,
     @Query('search') search?: string,
-    @Query('tags') tags?: string[],
+    @Query('tags') tags?: string[] | string,
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
   ) {
-    return this.service.findAll(profileId, { search, tags, limit, offset });
+    // A single ?tags=x arrives as a string; the service expects an array.
+    const tagList = tags ? (Array.isArray(tags) ? tags : [tags]) : undefined;
+    return this.service.findAll(profileId, { search, tags: tagList, limit, offset });
   }
 
   @Get(':id')


### PR DESCRIPTION
## Description
Fixes the Contacts page only showing/searching the first **1000** contacts. The list fetched a capped page and filtered **client-side**, so search missed anyone beyond the first page (e.g. a synced contact not in the first 1000) and the count was capped. The backend already supports server-side `search`/`tags`/`limit`/`offset` and returns `total` — this wires the UI to it.

## Related Issues
None.

## Changes Made
- `api.getContacts(profileId, { search, tags, limit, offset })` → returns `{ contacts, total, limit, offset }`.
- **Debounced server-side search** over ALL contacts (name / phone / whatsappName) + server-side tag filter; **50 per page** with a **"Load more (n of total)"** button.
- Header shows the **real total**; the search/stats bar stays visible on an empty-result search so it can be cleared.
- Controller coerces a single `?tags=x` value to an array (`hasSome` expects an array).

## Testing
- [x] `tsc --noEmit` clean (api + admin, changed files)
- [x] `pnpm check:api-contract` in sync (no route change)
- [x] `git diff --check` clean
- [ ] Visual check after deploy (search a contact beyond the first page; Load more; total count).

## Checklist
- [x] Branched off `main`
- [x] Conventional Commit message
- [x] Self-review completed
- [x] No new warnings introduced