### PR TITLE
fix(admin): keep contact search focused + server-side contact picker in Messages

### DIFF
--- a/apps/admin/src/app/dashboard/contacts/page.tsx
+++ b/apps/admin/src/app/dashboard/contacts/page.tsx
@@ -59,6 +59,10 @@ export default function ContactsPage() {
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [total, setTotal] = useState(0);
   const [loadingMore, setLoadingMore] = useState(false);
+  // True once the first fetch has resolved. Search/stats bars gate on this
+  // (not `loading`) so a search-triggered refetch never unmounts the search
+  // input — which would otherwise steal focus mid-typing.
+  const [hasLoaded, setHasLoaded] = useState(false);
   const PAGE_SIZE = 50;
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -118,6 +122,7 @@ export default function ContactsPage() {
     } finally {
       setLoading(false);
       setLoadingMore(false);
+      setHasLoaded(true);
     }
   };
 
@@ -330,7 +335,7 @@ export default function ContactsPage() {
       </div>
 
       {/* Stats Bar */}
-      {!loading && (contacts.length > 0 || !!search || !!selectedTag) && (
+      {hasLoaded && (contacts.length > 0 || !!search || !!selectedTag) && (
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2 py-3 px-4 bg-secondary/40 border border-border/60 rounded-xl text-sm">
           <div className="flex items-center gap-2">
             <Users className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
@@ -346,7 +351,7 @@ export default function ContactsPage() {
       )}
 
       {/* Search & Filters */}
-      {!loading && (contacts.length > 0 || !!search || !!selectedTag) && (
+      {hasLoaded && (contacts.length > 0 || !!search || !!selectedTag) && (
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="relative flex-1">
             <Search
@@ -384,7 +389,7 @@ export default function ContactsPage() {
       )}
 
       {/* Contacts Table */}
-      {loading ? (
+      {loading && !hasLoaded ? (
         <div className="bg-card rounded-2xl border border-border p-4">
           <LoadingTable />
         </div>

--- a/apps/admin/src/app/dashboard/messages/page.tsx
+++ b/apps/admin/src/app/dashboard/messages/page.tsx
@@ -117,6 +117,7 @@ export default function MessagesPage() {
   const [loadingRecipients, setLoadingRecipients] = useState(false);
   const [recipientSearch, setRecipientSearch] = useState('');
   const [selectedRecipientName, setSelectedRecipientName] = useState('');
+  const [contactTotal, setContactTotal] = useState(0);
   
   // Template picker state
   const [showTemplatePicker, setShowTemplatePicker] = useState(false);
@@ -196,6 +197,14 @@ export default function MessagesPage() {
     }
   }, [selectedProfile]);
 
+  // Debounced server-side contact search while the Contact picker is open.
+  useEffect(() => {
+    if (!selectedProfile || recipientMode !== 'contact') return;
+    const t = setTimeout(() => fetchContacts(selectedProfile, recipientSearch), 250);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProfile, recipientMode, recipientSearch]);
+
   const fetchProfiles = async () => {
     try {
       const token = localStorage.getItem('accessToken');
@@ -265,22 +274,34 @@ export default function MessagesPage() {
     }
   };
 
-  const fetchContactsAndGroups = async (profileId: string) => {
+  // Server-side contact search (one page of 50). An empty query returns the
+  // first page. This replaces the old "load 1000 and filter in the browser"
+  // approach so contacts beyond the first 1000 are reachable.
+  const fetchContacts = async (profileId: string, q: string) => {
     setLoadingRecipients(true);
     const token = localStorage.getItem('accessToken');
-    
     try {
-      // Fetch contacts
-      const contactsRes = await fetch(`/api/v1/contacts?profileId=${profileId}&limit=1000`, {
+      const qs = `profileId=${profileId}&limit=50${q.trim() ? `&search=${encodeURIComponent(q.trim())}` : ''}`;
+      const res = await fetch(`/api/v1/contacts?${qs}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (contactsRes.ok) {
-        const data = await contactsRes.json();
-        const contactsList = Array.isArray(data) ? data : (data.contacts || data.data || []);
-        setContacts(contactsList);
+      if (res.ok) {
+        const data = await res.json();
+        const list = Array.isArray(data) ? data : (data.contacts || data.data || []);
+        setContacts(list);
+        setContactTotal(typeof data?.total === 'number' ? data.total : list.length);
       }
+    } catch (error) {
+      console.error('Failed to fetch contacts:', error);
+    } finally {
+      setLoadingRecipients(false);
+    }
+  };
 
-      // Fetch groups
+  const fetchContactsAndGroups = async (profileId: string) => {
+    fetchContacts(profileId, '');
+    const token = localStorage.getItem('accessToken');
+    try {
       const groupsRes = await fetch(`/api/v1/groups/profile/${profileId}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -290,9 +311,7 @@ export default function MessagesPage() {
         setGroups(groupsList);
       }
     } catch (error) {
-      console.error('Failed to fetch contacts/groups:', error);
-    } finally {
-      setLoadingRecipients(false);
+      console.error('Failed to fetch groups:', error);
     }
   };
 
@@ -308,13 +327,9 @@ export default function MessagesPage() {
     setSelectedRecipientName(group.name);
   };
 
-  // Filter contacts/groups by search
-  const filteredContacts = contacts.filter(c => 
-    c.name.toLowerCase().includes(recipientSearch.toLowerCase()) ||
-    c.phone.includes(recipientSearch)
-  );
-
-  const filteredGroups = groups.filter(g => 
+  // Contacts are filtered server-side (see fetchContacts); render `contacts`
+  // directly. Groups are small enough to filter in the browser.
+  const filteredGroups = groups.filter(g =>
     g.name.toLowerCase().includes(recipientSearch.toLowerCase())
   );
 
@@ -663,7 +678,7 @@ export default function MessagesPage() {
                       }`}
                     >
                       <User className="w-3.5 h-3.5" aria-hidden="true" />
-                      Contact ({contacts.length})
+                      Contact ({contactTotal})
                     </button>
                     <button
                       type="button"
@@ -720,12 +735,12 @@ export default function MessagesPage() {
                           <div className="max-h-40 overflow-y-auto border border-border rounded-xl">
                             {loadingRecipients ? (
                               <div className="p-4 text-center text-muted-foreground text-sm">Loading...</div>
-                            ) : filteredContacts.length === 0 ? (
+                            ) : contacts.length === 0 ? (
                               <div className="p-4 text-center text-muted-foreground text-sm">
-                                {contacts.length === 0 ? 'No contacts saved yet' : 'No contacts match'}
+                                {recipientSearch.trim() ? 'No contacts match' : 'No contacts saved yet'}
                               </div>
                             ) : (
-                              filteredContacts.map((contact) => (
+                              contacts.map((contact) => (
                                 <button
                                   key={contact.id}
                                   onClick={() => selectContact(contact)}


### PR DESCRIPTION
## What & why

Two UX issues surfaced on the deployed Contacts/Messages pages after #15:

### 1. Contacts search input lost focus while typing
The search + stats bars were gated on `!loading`. When you paused typing, the
debounced refetch ran `setLoading(true)`, which **unmounted** the whole search
`<input>` (replaced by the skeleton) and remounted it when the request
finished — so the caret dropped and you had to click back into the box.

Fix: gate those bars on a new `hasLoaded` flag (true after the first fetch)
instead of `!loading`. The input now stays mounted across refetches, and the
full skeleton only shows on the very first load.

### 2. Messages recipient picker capped at 1000 contacts
The picker fetched `?limit=1000` once and filtered client-side, so any contact
past the first 1000 (e.g. `628111017195`) returned "No contacts match".

Fix: debounced **server-side** search (`?search=…&limit=50`), and the Contact
tab now shows the real total from the API instead of `contacts.length`.

## Scope
- Admin frontend only. **No API changes** — reuses the existing
  `/contacts?search=&limit=&offset=` contract shipped in #15.

## Testing
- `pnpm --filter @multiwa/admin typecheck` — no new errors (the 3 remaining are
  pre-existing in `settings/page.tsx` and `MessageChart.tsx`, untouched here).
- Deployed to wagw and verified: search keeps focus while typing; Messages
  picker finds contacts beyond the first 1000.