### PR TITLE
feat(profiles): warm-up daily-cap ramp + delay jitter (anti-ban pacing v2)

### DIFF
--- a/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
@@ -89,6 +89,12 @@ const WIB_OFFSET_MS = 7 * 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const wibDay = (ms: number) => Math.floor((ms + WIB_OFFSET_MS) / DAY_MS);
 
+// Preset options for the delay/jitter selects. A stored value set via the API
+// that isn't a preset is surfaced as a synthetic option so it stays visible and
+// preservable rather than rendering a blank trigger.
+const DELAY_PRESETS = [1500, 3000, 6000, 10000];
+const JITTER_PRESETS = [0, 1500, 3000, 6000];
+
 const fmtPhone = (raw: string | null | undefined): string => {
   if (!raw) return '—';
   const digits = raw.replace(/\D/g, '');
@@ -434,10 +440,10 @@ export default function ProfileDetailPage() {
   const handleSaveGuardrails = async () => {
     const trimmed = dailyLimit.trim();
     const parsedLimit = trimmed === '' ? null : Math.floor(Number(trimmed));
-    if (parsedLimit != null && (!Number.isFinite(parsedLimit) || parsedLimit < 0)) {
+    if (parsedLimit != null && (!Number.isFinite(parsedLimit) || parsedLimit < 1)) {
       toast({
         title: 'Invalid daily limit',
-        description: 'Enter a whole number, or leave empty for unlimited.',
+        description: 'Enter a whole number of 1 or more, or leave empty for unlimited.',
         variant: 'destructive',
       });
       return;
@@ -595,7 +601,13 @@ export default function ProfileDetailPage() {
     if (!warmupEnabled || hard == null || warmupStartN == null || warmupRampN == null || warmupRampN < 1 || Number.isNaN(warmupStartN)) {
       return hard;
     }
-    const anchor = profile.warmupStartedAt ? new Date(profile.warmupStartedAt).getTime() : Date.now();
+    // Match the server's re-anchor rule: the stored anchor is authoritative only
+    // when warm-up is already enabled in the DB. If it is off in the DB, saving
+    // (a false->true transition) will re-anchor to now, so preview from now.
+    const anchor =
+      profile.warmupEnabled && profile.warmupStartedAt
+        ? new Date(profile.warmupStartedAt).getTime()
+        : Date.now();
     const dayIndex = wibDay(Date.now()) - wibDay(anchor);
     if (dayIndex < 0) return Math.max(0, Math.min(hard, warmupStartN));
     if (dayIndex >= warmupRampN - 1) return hard;
@@ -823,6 +835,11 @@ export default function ProfileDetailPage() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
+                {!DELAY_PRESETS.includes(delayMs) && (
+                  <SelectItem value={String(delayMs)}>
+                    Custom ({(delayMs / 1000).toFixed(1)}s)
+                  </SelectItem>
+                )}
                 <SelectItem value="1500">1.5 seconds</SelectItem>
                 <SelectItem value="3000">3 seconds</SelectItem>
                 <SelectItem value="6000">6 seconds</SelectItem>
@@ -842,6 +859,11 @@ export default function ProfileDetailPage() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
+                  {!JITTER_PRESETS.includes(jitterMs) && (
+                    <SelectItem value={String(jitterMs)}>
+                      Custom (up to +{(jitterMs / 1000).toFixed(1)}s)
+                    </SelectItem>
+                  )}
                   <SelectItem value="0">Off (fixed spacing)</SelectItem>
                   <SelectItem value="1500">up to +1.5s</SelectItem>
                   <SelectItem value="3000">up to +3s</SelectItem>

--- a/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
@@ -67,8 +67,13 @@ interface Profile {
   createdAt: string;
   updatedAt: string;
   messageDelayMs?: number;
+  messageDelayJitterMs?: number;
   dailyMessageLimit?: number | null;
   dailyMessageCount?: number;
+  warmupEnabled?: boolean;
+  warmupStartPerDay?: number | null;
+  warmupRampDays?: number | null;
+  warmupStartedAt?: string | null;
   sessionData?: {
     jid?: string;
     name?: string;
@@ -77,6 +82,12 @@ interface Profile {
 }
 
 type WireStatus = 'connected' | 'disconnected' | 'connecting' | 'error' | 'qr_ready' | string;
+
+// WIB day math, mirroring the server-side send gate so the "today's effective
+// cap" preview matches what the gate will actually enforce.
+const WIB_OFFSET_MS = 7 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const wibDay = (ms: number) => Math.floor((ms + WIB_OFFSET_MS) / DAY_MS);
 
 const fmtPhone = (raw: string | null | undefined): string => {
   if (!raw) return '—';
@@ -202,7 +213,11 @@ export default function ProfileDetailPage() {
 
   // Sending-guardrail form state (delay + daily limit), prefilled from the profile.
   const [delayMs, setDelayMs] = useState<number>(1500);
+  const [jitterMs, setJitterMs] = useState<number>(0);
   const [dailyLimit, setDailyLimit] = useState<string>(''); // '' means unlimited
+  const [warmupEnabled, setWarmupEnabled] = useState(false);
+  const [warmupStart, setWarmupStart] = useState<string>(''); // per-day start, string for number input
+  const [warmupRampDays, setWarmupRampDays] = useState<string>('');
   const [savingGuardrails, setSavingGuardrails] = useState(false);
 
   const profileId = params.id as string;
@@ -406,9 +421,13 @@ export default function ProfileDetailPage() {
   useEffect(() => {
     if (!profile) return;
     setDelayMs(profile.messageDelayMs ?? 1500);
+    setJitterMs(profile.messageDelayJitterMs ?? 0);
     setDailyLimit(
       profile.dailyMessageLimit != null ? String(profile.dailyMessageLimit) : '',
     );
+    setWarmupEnabled(profile.warmupEnabled ?? false);
+    setWarmupStart(profile.warmupStartPerDay != null ? String(profile.warmupStartPerDay) : '');
+    setWarmupRampDays(profile.warmupRampDays != null ? String(profile.warmupRampDays) : '');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profile?.id]);
 
@@ -423,6 +442,28 @@ export default function ProfileDetailPage() {
       });
       return;
     }
+    // Warm-up ramps toward the daily limit, so it needs a numeric target + a valid
+    // start and ramp length.
+    const parsedStart = warmupStart.trim() === '' ? null : Math.floor(Number(warmupStart));
+    const parsedRampDays = warmupRampDays.trim() === '' ? null : Math.floor(Number(warmupRampDays));
+    if (warmupEnabled) {
+      if (parsedLimit == null) {
+        toast({
+          title: 'Warm-up needs a daily limit',
+          description: 'Set a daily message limit — the ramp climbs up to it.',
+          variant: 'destructive',
+        });
+        return;
+      }
+      if (parsedStart == null || !Number.isFinite(parsedStart) || parsedStart < 1) {
+        toast({ title: 'Invalid warm-up start', description: 'Enter a start-per-day of 1 or more.', variant: 'destructive' });
+        return;
+      }
+      if (parsedRampDays == null || !Number.isFinite(parsedRampDays) || parsedRampDays < 1) {
+        toast({ title: 'Invalid ramp days', description: 'Enter a ramp length of 1 day or more.', variant: 'destructive' });
+        return;
+      }
+    }
     setSavingGuardrails(true);
     try {
       const token = localStorage.getItem('accessToken');
@@ -432,7 +473,14 @@ export default function ProfileDetailPage() {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ messageDelayMs: delayMs, dailyMessageLimit: parsedLimit }),
+        body: JSON.stringify({
+          messageDelayMs: delayMs,
+          messageDelayJitterMs: jitterMs,
+          dailyMessageLimit: parsedLimit,
+          warmupEnabled,
+          warmupStartPerDay: parsedStart,
+          warmupRampDays: parsedRampDays,
+        }),
       });
       if (res.ok) {
         toast({ title: 'Guardrails saved', description: 'Sending limits updated.' });
@@ -537,8 +585,30 @@ export default function ProfileDetailPage() {
   // Guardrail form: derived "unlimited" flag + dirty check (disables Save when unchanged).
   const unlimited = dailyLimit.trim() === '';
   const normalizedFormLimit = unlimited ? null : Math.floor(Number(dailyLimit));
+  const warmupStartN = warmupStart.trim() === '' ? null : Math.floor(Number(warmupStart));
+  const warmupRampN = warmupRampDays.trim() === '' ? null : Math.floor(Number(warmupRampDays));
+
+  // Today's effective cap preview, using the same ramp formula as the send gate.
+  // Falls back to the plain limit when warm-up is off or misconfigured.
+  const effectiveCapToday: number | null = (() => {
+    const hard = normalizedFormLimit;
+    if (!warmupEnabled || hard == null || warmupStartN == null || warmupRampN == null || warmupRampN < 1 || Number.isNaN(warmupStartN)) {
+      return hard;
+    }
+    const anchor = profile.warmupStartedAt ? new Date(profile.warmupStartedAt).getTime() : Date.now();
+    const dayIndex = wibDay(Date.now()) - wibDay(anchor);
+    if (dayIndex < 0) return Math.max(0, Math.min(hard, warmupStartN));
+    if (dayIndex >= warmupRampN - 1) return hard;
+    const progress = dayIndex / Math.max(1, warmupRampN - 1);
+    return Math.max(0, Math.min(hard, Math.round(warmupStartN + (hard - warmupStartN) * progress)));
+  })();
+
   const guardrailsDirty =
     delayMs !== (profile.messageDelayMs ?? 1500) ||
+    jitterMs !== (profile.messageDelayJitterMs ?? 0) ||
+    warmupEnabled !== (profile.warmupEnabled ?? false) ||
+    (warmupStartN ?? null) !== (profile.warmupStartPerDay ?? null) ||
+    (warmupRampN ?? null) !== (profile.warmupRampDays ?? null) ||
     (Number.isNaN(normalizedFormLimit as number)
       ? true
       : normalizedFormLimit !== (profile.dailyMessageLimit ?? null));
@@ -760,6 +830,26 @@ export default function ProfileDetailPage() {
               </SelectContent>
             </Select>
             <p className="text-[11px] text-slate-500">Minimum gap enforced between two sends.</p>
+            <div className="pt-2 space-y-1.5">
+              <Label htmlFor="jitter" className="text-xs text-slate-300">
+                Delay jitter
+              </Label>
+              <Select value={String(jitterMs)} onValueChange={(v) => setJitterMs(Number(v))}>
+                <SelectTrigger
+                  id="jitter"
+                  className="bg-slate-950/40 border-slate-800 text-slate-100"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="0">Off (fixed spacing)</SelectItem>
+                  <SelectItem value="1500">up to +1.5s</SelectItem>
+                  <SelectItem value="3000">up to +3s</SelectItem>
+                  <SelectItem value="6000">up to +6s</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-[11px] text-slate-500">Random extra delay per send so timing looks less robotic.</p>
+            </div>
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="limit" className="text-xs text-slate-300">
@@ -790,6 +880,72 @@ export default function ProfileDetailPage() {
             </div>
           </div>
         </div>
+
+        {/* Warm-up ramp */}
+        <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-4 space-y-3 max-w-2xl">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <Label htmlFor="warmup" className="text-xs font-medium text-slate-200 cursor-pointer">
+                Warm-up ramp
+              </Label>
+              <p className="text-[11px] text-slate-500 mt-0.5">
+                Gradually raise the daily cap from a low start up to the limit — recommended for
+                new or recently rate-locked numbers.
+              </p>
+            </div>
+            <Switch id="warmup" checked={warmupEnabled} onCheckedChange={setWarmupEnabled} />
+          </div>
+          {warmupEnabled && (
+            <>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="warmupStart" className="text-xs text-slate-300">
+                    Start per day
+                  </Label>
+                  <Input
+                    id="warmupStart"
+                    type="number"
+                    min={1}
+                    inputMode="numeric"
+                    placeholder="20"
+                    value={warmupStart}
+                    onChange={(e) => setWarmupStart(e.target.value)}
+                    className="bg-slate-950/40 border-slate-800 text-slate-100"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="warmupDays" className="text-xs text-slate-300">
+                    Ramp days
+                  </Label>
+                  <Input
+                    id="warmupDays"
+                    type="number"
+                    min={1}
+                    inputMode="numeric"
+                    placeholder="14"
+                    value={warmupRampDays}
+                    onChange={(e) => setWarmupRampDays(e.target.value)}
+                    className="bg-slate-950/40 border-slate-800 text-slate-100"
+                  />
+                </div>
+              </div>
+              <p className="text-[11px] text-slate-500">
+                Ramps from <span className="font-mono text-slate-300">{warmupStart || '—'}</span> to{' '}
+                <span className="font-mono text-slate-300">
+                  {unlimited ? '(set a daily limit)' : dailyLimit}
+                </span>
+                /day over <span className="font-mono text-slate-300">{warmupRampDays || '—'}</span> days.
+                {!unlimited && effectiveCapToday != null && (
+                  <>
+                    {' '}Today&apos;s effective cap:{' '}
+                    <span className="font-mono text-emerald-300">{effectiveCapToday}</span>.
+                  </>
+                )}
+              </p>
+            </>
+          )}
+        </div>
+
         <div className="flex items-center justify-between gap-3 flex-wrap">
           <p className="text-[11px] text-slate-500">
             Sent today:{' '}
@@ -797,7 +953,9 @@ export default function ProfileDetailPage() {
             {!unlimited && (
               <>
                 {' / '}
-                <span className="font-mono text-slate-300">{dailyLimit}</span>
+                <span className="font-mono text-slate-300">
+                  {warmupEnabled && effectiveCapToday != null ? effectiveCapToday : dailyLimit}
+                </span>
               </>
             )}
           </p>

--- a/apps/api/src/modules/messages/messages.service.ts
+++ b/apps/api/src/modules/messages/messages.service.ts
@@ -18,7 +18,7 @@ import {
   SendPollDto,
 } from './dto';
 import { EngineManagerService } from '../profiles/engine-manager.service';
-import { SendGateService } from '@multiwa/engine-runtime';
+import { SendGateService, effectiveDailyCap } from '@multiwa/engine-runtime';
 import { AppEvents, isWhatsAppRecipient } from '@multiwa/core';
 import {
   OUTBOUND_SEND_QUEUE,
@@ -235,16 +235,19 @@ export class MessagesService {
       // 429 (the send gate in the consumer is the authoritative increment).
       const now = new Date();
       const resetDue = !profile.dailyResetAt || profile.dailyResetAt <= now;
+      // Effective cap accounts for the warm-up ramp (mirrors the authoritative
+      // send-gate check so warm-up-limited sends get a synchronous 429 too).
+      const effectiveLimit = effectiveDailyCap(profile, now);
       if (
-        profile.dailyMessageLimit != null &&
+        effectiveLimit != null &&
         !resetDue &&
-        (profile.dailyMessageCount ?? 0) >= profile.dailyMessageLimit
+        (profile.dailyMessageCount ?? 0) >= effectiveLimit
       ) {
         await prisma.message.update({ where: { id: message.id }, data: { status: 'failed' } });
         throw new HttpException(
           {
             error: 'DAILY_LIMIT_REACHED',
-            limit: profile.dailyMessageLimit,
+            limit: effectiveLimit,
             count: profile.dailyMessageCount,
             resetAt: profile.dailyResetAt,
           },

--- a/apps/api/src/modules/profiles/dto/index.ts
+++ b/apps/api/src/modules/profiles/dto/index.ts
@@ -2,7 +2,7 @@
 // apps/api/src/modules/profiles/dto/index.ts
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsOptional, IsUrl, IsEnum, IsInt, Min } from 'class-validator';
+import { IsString, IsOptional, IsUrl, IsEnum, IsInt, IsBoolean, Min } from 'class-validator';
 
 export enum EngineType {
   WHATSAPP_WEB_JS = 'whatsapp-web-js',
@@ -76,4 +76,39 @@ export class UpdateProfileDto {
   @IsInt()
   @Min(1)
   dailyMessageLimit?: number | null;
+
+  @ApiPropertyOptional({
+    example: 3000,
+    description: 'Max extra random milliseconds added on top of messageDelayMs per send (anti-ban jitter). 0 = fixed spacing. Actual delay is always >= messageDelayMs.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  messageDelayJitterMs?: number;
+
+  @ApiPropertyOptional({
+    example: true,
+    description: 'Enable the warm-up ramp: the effective daily cap climbs from warmupStartPerDay to dailyMessageLimit over warmupRampDays days. Requires dailyMessageLimit to be set.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  warmupEnabled?: boolean;
+
+  @ApiPropertyOptional({
+    example: 20,
+    description: 'Starting daily cap on day 0 of the warm-up ramp.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  warmupStartPerDay?: number | null;
+
+  @ApiPropertyOptional({
+    example: 14,
+    description: 'Number of days for the warm-up ramp to climb from warmupStartPerDay to the daily limit.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  warmupRampDays?: number | null;
 }

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,6 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
+import { effectiveDailyCap } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -1119,17 +1120,19 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           };
 
           // Fast-fail guard: skip automation entirely when the profile is at its
-          // daily cap. The actual counter increment is owned by SendGateService
-          // (every automation reply ultimately goes through MessagesService →
-          // the send gate), so incrementing here too would double-count.
-          // null dailyMessageLimit means unlimited.
+          // daily cap. Uses the same warm-up-aware effective cap as the send gate
+          // so this short-circuit matches what the gate would enforce. The actual
+          // counter increment is owned by SendGateService (every automation reply
+          // ultimately goes through MessagesService → the send gate), so
+          // incrementing here too would double-count. null cap means unlimited.
           const currentProfile = await prisma.profile.findUnique({ where: { id: profileId } });
+          const effectiveCap = currentProfile ? effectiveDailyCap(currentProfile, new Date()) : null;
           if (
             currentProfile &&
-            currentProfile.dailyMessageLimit != null &&
-            currentProfile.dailyMessageCount >= currentProfile.dailyMessageLimit
+            effectiveCap != null &&
+            currentProfile.dailyMessageCount >= effectiveCap
           ) {
-            this.logger.warn(`Daily message limit reached for profile ${profileId}: ${currentProfile.dailyMessageCount}/${currentProfile.dailyMessageLimit}, skipping automation`);
+            this.logger.warn(`Daily message limit reached for profile ${profileId}: ${currentProfile.dailyMessageCount}/${effectiveCap}, skipping automation`);
           } else {
             const results = await this.ruleEngineService.processMessage(incomingMsg);
 

--- a/apps/api/src/modules/profiles/profiles.service.ts
+++ b/apps/api/src/modules/profiles/profiles.service.ts
@@ -107,6 +107,17 @@ export class ProfilesService {
     };
     if (dto.messageDelayMs !== undefined) data.messageDelayMs = dto.messageDelayMs;
     if (dto.dailyMessageLimit !== undefined) data.dailyMessageLimit = dto.dailyMessageLimit;
+    if (dto.messageDelayJitterMs !== undefined) data.messageDelayJitterMs = dto.messageDelayJitterMs;
+    if (dto.warmupStartPerDay !== undefined) data.warmupStartPerDay = dto.warmupStartPerDay;
+    if (dto.warmupRampDays !== undefined) data.warmupRampDays = dto.warmupRampDays;
+    if (dto.warmupEnabled !== undefined) {
+      data.warmupEnabled = dto.warmupEnabled;
+      // Anchor the ramp at "today" each time warm-up is turned on (false -> true),
+      // so the cap always starts fresh from warmupStartPerDay. Tweaking the numbers
+      // while it is already on does not restart the ramp.
+      const wasEnabled = (existing as any).warmupEnabled === true;
+      if (dto.warmupEnabled && !wasEnabled) data.warmupStartedAt = new Date();
+    }
     if (dto.engine !== undefined) data.engine = dto.engine;
 
     const updated = await prisma.profile.update({ where: { id }, data });

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,6 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
+import { effectiveDailyCap } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -913,13 +914,15 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           };
 
           // Fast-fail guard: skip automation when the profile is at its daily cap.
-          // The send gate owns the single counter increment (automation replies go
-          // through it), so this guard must NOT increment. null = unlimited.
+          // Uses the same warm-up-aware effective cap as the send gate. The send
+          // gate owns the single counter increment (automation replies go through
+          // it), so this guard must NOT increment. null cap = unlimited.
           const currentProfile = await prisma.profile.findUnique({ where: { id: profileId } });
+          const effectiveCap = currentProfile ? effectiveDailyCap(currentProfile, new Date()) : null;
           if (
             currentProfile &&
-            currentProfile.dailyMessageLimit != null &&
-            currentProfile.dailyMessageCount >= currentProfile.dailyMessageLimit
+            effectiveCap != null &&
+            currentProfile.dailyMessageCount >= effectiveCap
           ) {
             this.logger.warn(`Daily message limit reached for profile ${profileId}, skipping automation`);
           } else {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -135,9 +135,20 @@ model Profile {
   webhookSecret   String?
   settings        Json     @default("{}")
   messageDelayMs  Int      @default(1500)
+  // Max extra random ms added on top of messageDelayMs per send (anti-ban jitter).
+  // 0 = fixed spacing. Actual delay is always >= messageDelayMs (base is the floor).
+  messageDelayJitterMs Int @default(0)
   dailyMessageLimit Int?
   dailyMessageCount Int    @default(0)
   dailyResetAt    DateTime?
+  // Warm-up ramp: when enabled, the effective daily cap climbs from
+  // warmupStartPerDay up to dailyMessageLimit over warmupRampDays days, anchored
+  // at warmupStartedAt (WIB day boundaries). Reduces cold-outreach risk for new
+  // or recovering numbers. All nullable so `prisma db push` applies them safely.
+  warmupEnabled     Boolean  @default(false)
+  warmupStartPerDay Int?
+  warmupRampDays    Int?
+  warmupStartedAt   DateTime?
   // Per-profile engine selection. whatsapp-web-js (default, production) | baileys (EXPERIMENTAL) | mock (testing).
   engine          String   @default("whatsapp-web-js")
   lastConnectedAt DateTime?

--- a/packages/engine-runtime/src/send-gate.service.ts
+++ b/packages/engine-runtime/src/send-gate.service.ts
@@ -57,7 +57,9 @@ export function effectiveDailyCap(profile: WarmupCapInput, now: Date = new Date(
   if (start == null || rampDays == null || rampDays < 1 || !startedAt) return hardLimit;
 
   const dayIndex = wibDayNumber(now) - wibDayNumber(startedAt);
-  if (dayIndex < 0) return Math.max(0, Math.min(hardLimit, start)); // anchor in the future
+  // Day 0 (and any future anchor) is exactly the start cap. This also makes a
+  // 1-day ramp behave sanely: day 0 = start, day 1+ = full limit.
+  if (dayIndex <= 0) return Math.max(0, Math.min(hardLimit, start));
   if (dayIndex >= rampDays - 1) return hardLimit; // ramp complete
 
   const progress = dayIndex / Math.max(1, rampDays - 1);

--- a/packages/engine-runtime/src/send-gate.service.ts
+++ b/packages/engine-runtime/src/send-gate.service.ts
@@ -17,6 +17,53 @@ import { prisma } from '@multiwa/database';
 
 /** WIB (Asia/Jakarta) is a fixed UTC+7 offset with no DST. */
 const WIB_OFFSET_MS = 7 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Integer index of the WIB calendar day containing `d` (same boundary as the daily reset). */
+function wibDayNumber(d: Date): number {
+  return Math.floor((d.getTime() + WIB_OFFSET_MS) / DAY_MS);
+}
+
+/** Minimal profile shape the warm-up cap needs (subset of the Prisma Profile row). */
+export interface WarmupCapInput {
+  dailyMessageLimit?: number | null;
+  warmupEnabled?: boolean | null;
+  warmupStartPerDay?: number | null;
+  warmupRampDays?: number | null;
+  warmupStartedAt?: Date | null;
+}
+
+/**
+ * Effective daily send cap for a profile at instant `now`, accounting for the
+ * warm-up ramp. Returns null when unlimited.
+ *
+ * When warm-up is enabled AND a daily limit (the ramp target) is set, the cap
+ * climbs linearly from warmupStartPerDay up to dailyMessageLimit over
+ * warmupRampDays WIB days, anchored at warmupStartedAt. Day 0 is the WIB day of
+ * the anchor. Missing/invalid warm-up config falls back to the plain daily limit
+ * (no surprise cap). Warm-up with an unlimited target is a no-op (needs a target).
+ * The result never exceeds the hard daily limit and never goes below 0.
+ */
+export function effectiveDailyCap(profile: WarmupCapInput, now: Date = new Date()): number | null {
+  const hardLimit = profile.dailyMessageLimit ?? null;
+  if (!profile.warmupEnabled) return hardLimit;
+  // Warm-up ramps toward the daily limit; with no numeric target there is nothing
+  // to ramp to, so leave it unlimited.
+  if (hardLimit == null) return null;
+
+  const start = profile.warmupStartPerDay;
+  const rampDays = profile.warmupRampDays;
+  const startedAt = profile.warmupStartedAt;
+  if (start == null || rampDays == null || rampDays < 1 || !startedAt) return hardLimit;
+
+  const dayIndex = wibDayNumber(now) - wibDayNumber(startedAt);
+  if (dayIndex < 0) return Math.max(0, Math.min(hardLimit, start)); // anchor in the future
+  if (dayIndex >= rampDays - 1) return hardLimit; // ramp complete
+
+  const progress = dayIndex / Math.max(1, rampDays - 1);
+  const capped = Math.round(start + (hardLimit - start) * progress);
+  return Math.max(0, Math.min(hardLimit, capped));
+}
 
 /**
  * The next 00:00 WIB after `from`, returned as the equivalent UTC instant.
@@ -80,15 +127,23 @@ export class SendGateService {
       where: { id: profileId },
       select: {
         messageDelayMs: true,
+        messageDelayJitterMs: true,
         dailyMessageLimit: true,
         dailyMessageCount: true,
         dailyResetAt: true,
+        warmupEnabled: true,
+        warmupStartPerDay: true,
+        warmupRampDays: true,
+        warmupStartedAt: true,
       },
     });
     if (!profile) throw new NotFoundException('Profile not found');
 
-    // 1. Inter-message delay (block-and-wait).
-    const delayMs = profile.messageDelayMs ?? 1500;
+    // 1. Inter-message delay (block-and-wait), with optional additive jitter.
+    // The base messageDelayMs is always the floor; jitter only ever slows sends.
+    const baseDelay = profile.messageDelayMs ?? 1500;
+    const jitterMax = Math.max(0, profile.messageDelayJitterMs ?? 0);
+    const delayMs = baseDelay + (jitterMax > 0 ? Math.floor(Math.random() * (jitterMax + 1)) : 0);
     const last = this.lastSentAt.get(profileId) ?? 0;
     const wait = Math.max(0, delayMs - (Date.now() - last));
     if (wait > 0) await sleep(wait);
@@ -106,8 +161,8 @@ export class SendGateService {
         data: { dailyMessageCount: 0, dailyResetAt: nextMidnightWIB(now) },
       });
     }
-    const limit = profile.dailyMessageLimit;
-    // null/undefined limit means unlimited.
+    // Effective cap accounts for the warm-up ramp; null means unlimited.
+    const limit = effectiveDailyCap(profile, now);
     if (limit != null && count >= limit) {
       throw new HttpException(
         {


### PR DESCRIPTION
## What & why

Adds two **legitimate** anti-cold-outreach controls on top of the existing
per-profile send guardrails (`messageDelayMs` / `dailyMessageLimit`). There is no
code bypass for WhatsApp's reach-out lock (error 463) — these reduce the risk of
tripping it by pacing/ramping, which is what the OpenWA/whatsapp-web.js community
and Meta's own quality guidance recommend.

### 1. Warm-up ramp
When enabled with a daily limit set (the ramp target), the **effective daily cap
climbs linearly** from `warmupStartPerDay` up to `dailyMessageLimit` over
`warmupRampDays` WIB days, anchored at `warmupStartedAt` (set the moment warm-up
is turned on; re-anchors fresh on every off→on). Day 0 = start, day
`rampDays-1` = full limit. Recommended for new or recently rate-locked numbers
(e.g. EXTERNAL 459). Missing/invalid config falls back to the plain limit; an
unlimited target is a no-op.

### 2. Delay jitter
`messageDelayJitterMs` adds up to N random ms **on top of** the base delay per
send, so pacing looks less robotic. The base delay stays the floor — jitter only
ever slows a send, never below the configured minimum.

## Design
- **Single source of truth:** `SendGateService.gatedRun` computes the cap via the
  new exported `effectiveDailyCap()` helper. Every real send funnels through the
  gate (HTTP, bulk, broadcast, scheduled, automation, durable queue) in both
  `apps/api` and `apps/worker`, so one helper covers them all. The synchronous
  pre-enqueue 429 check and both automation fast-fail guards reuse the same
  helper for consistency.
- **Target = the daily limit** (no separate target field) → no two-cap ambiguity.
- **Schema:** 5 new nullable/defaulted `Profile` columns → `prisma db push`
  applies them non-destructively. No route changes (API contract in sync, 216).

## UI
New sub-section in the profile "Sending guardrails" card: warm-up enable toggle,
start-per-day + ramp-days inputs, a live **"today's effective cap"** readout, and
a delay-jitter select. Custom (API-set) delay/jitter values surface as a synthetic
option so they stay visible/preservable.

## Testing
- `effectiveDailyCap` ramp math verified over 10 cases: day0=start, midpoint,
  completion, past-ramp, future anchor, `start>limit` clamp, `rampDays=1`
  (day0=start, day1=full), and off/unlimited/no-config fallbacks.
- `api` + `worker` + `engine-runtime` + `admin` typecheck clean (3 remaining
  admin errors pre-exist in settings/MessageChart, untouched).
- Ran an adversarial review pass (5 dimensions → per-finding verify); all 6
  confirmed findings fixed in the second commit.

## Deploy note
wagw runs `ENGINE_HOST=worker`, so enforcement lives in the worker — deploy
**api + worker + admin** (db push on api start adds the columns).