### PR TITLE
feat(send-policy): window-aware reply vs cold lanes (Send Policy Engine Phase 1)

### DIFF
--- a/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
@@ -608,7 +608,8 @@ export default function ProfileDetailPage() {
   const coldLimitN = coldDailyLimit.trim() === '' ? null : Math.floor(Number(coldDailyLimit));
   const serviceWindowN = serviceWindowHours.trim() === '' ? null : Math.floor(Number(serviceWindowHours));
   // The warm-up ramp climbs toward the COLD cap target: coldDailyLimit → daily
-  // limit → the conservative default (250).
+  // limit → the conservative default. Mirrors the server's COLD_DEFAULT_DAILY_LIMIT
+  // (env-overridable) — this preview assumes the built-in 250 default.
   const COLD_DEFAULT = 250;
   const coldTarget = coldLimitN ?? normalizedFormLimit ?? COLD_DEFAULT;
 
@@ -626,7 +627,7 @@ export default function ProfileDetailPage() {
         ? new Date(profile.warmupStartedAt).getTime()
         : Date.now();
     const dayIndex = wibDay(Date.now()) - wibDay(anchor);
-    if (dayIndex < 0) return Math.max(0, Math.min(hard, warmupStartN));
+    if (dayIndex <= 0) return Math.max(0, Math.min(hard, warmupStartN));
     if (dayIndex >= warmupRampN - 1) return hard;
     const progress = dayIndex / Math.max(1, warmupRampN - 1);
     return Math.max(0, Math.min(hard, Math.round(warmupStartN + (hard - warmupStartN) * progress)));

--- a/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
@@ -74,6 +74,9 @@ interface Profile {
   warmupStartPerDay?: number | null;
   warmupRampDays?: number | null;
   warmupStartedAt?: string | null;
+  serviceWindowHours?: number;
+  coldDailyLimit?: number | null;
+  coldMessageCount?: number;
   sessionData?: {
     jid?: string;
     name?: string;
@@ -224,6 +227,8 @@ export default function ProfileDetailPage() {
   const [warmupEnabled, setWarmupEnabled] = useState(false);
   const [warmupStart, setWarmupStart] = useState<string>(''); // per-day start, string for number input
   const [warmupRampDays, setWarmupRampDays] = useState<string>('');
+  const [coldDailyLimit, setColdDailyLimit] = useState<string>(''); // '' = fall back to default
+  const [serviceWindowHours, setServiceWindowHours] = useState<string>('24');
   const [savingGuardrails, setSavingGuardrails] = useState(false);
 
   const profileId = params.id as string;
@@ -434,6 +439,8 @@ export default function ProfileDetailPage() {
     setWarmupEnabled(profile.warmupEnabled ?? false);
     setWarmupStart(profile.warmupStartPerDay != null ? String(profile.warmupStartPerDay) : '');
     setWarmupRampDays(profile.warmupRampDays != null ? String(profile.warmupRampDays) : '');
+    setColdDailyLimit(profile.coldDailyLimit != null ? String(profile.coldDailyLimit) : '');
+    setServiceWindowHours(profile.serviceWindowHours != null ? String(profile.serviceWindowHours) : '24');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profile?.id]);
 
@@ -448,19 +455,22 @@ export default function ProfileDetailPage() {
       });
       return;
     }
-    // Warm-up ramps toward the daily limit, so it needs a numeric target + a valid
-    // start and ramp length.
+    // Cold-traffic controls.
+    const parsedCold = coldDailyLimit.trim() === '' ? null : Math.floor(Number(coldDailyLimit));
+    if (parsedCold != null && (!Number.isFinite(parsedCold) || parsedCold < 1)) {
+      toast({ title: 'Invalid cold daily limit', description: 'Enter a whole number of 1 or more, or leave empty for the default.', variant: 'destructive' });
+      return;
+    }
+    const parsedWindow = serviceWindowHours.trim() === '' ? null : Math.floor(Number(serviceWindowHours));
+    if (parsedWindow != null && (!Number.isFinite(parsedWindow) || parsedWindow < 1)) {
+      toast({ title: 'Invalid service window', description: 'Enter a whole number of hours (1 or more).', variant: 'destructive' });
+      return;
+    }
+    // Warm-up ramps the COLD cap toward its target (coldDailyLimit → dailyMessageLimit
+    // → default), so it needs a valid start + ramp length.
     const parsedStart = warmupStart.trim() === '' ? null : Math.floor(Number(warmupStart));
     const parsedRampDays = warmupRampDays.trim() === '' ? null : Math.floor(Number(warmupRampDays));
     if (warmupEnabled) {
-      if (parsedLimit == null) {
-        toast({
-          title: 'Warm-up needs a daily limit',
-          description: 'Set a daily message limit — the ramp climbs up to it.',
-          variant: 'destructive',
-        });
-        return;
-      }
       if (parsedStart == null || !Number.isFinite(parsedStart) || parsedStart < 1) {
         toast({ title: 'Invalid warm-up start', description: 'Enter a start-per-day of 1 or more.', variant: 'destructive' });
         return;
@@ -486,6 +496,8 @@ export default function ProfileDetailPage() {
           warmupEnabled,
           warmupStartPerDay: parsedStart,
           warmupRampDays: parsedRampDays,
+          coldDailyLimit: parsedCold,
+          serviceWindowHours: parsedWindow ?? 24,
         }),
       });
       if (res.ok) {
@@ -593,11 +605,16 @@ export default function ProfileDetailPage() {
   const normalizedFormLimit = unlimited ? null : Math.floor(Number(dailyLimit));
   const warmupStartN = warmupStart.trim() === '' ? null : Math.floor(Number(warmupStart));
   const warmupRampN = warmupRampDays.trim() === '' ? null : Math.floor(Number(warmupRampDays));
+  const coldLimitN = coldDailyLimit.trim() === '' ? null : Math.floor(Number(coldDailyLimit));
+  const serviceWindowN = serviceWindowHours.trim() === '' ? null : Math.floor(Number(serviceWindowHours));
+  // The warm-up ramp climbs toward the COLD cap target: coldDailyLimit → daily
+  // limit → the conservative default (250).
+  const COLD_DEFAULT = 250;
+  const coldTarget = coldLimitN ?? normalizedFormLimit ?? COLD_DEFAULT;
 
-  // Today's effective cap preview, using the same ramp formula as the send gate.
-  // Falls back to the plain limit when warm-up is off or misconfigured.
+  // Today's effective COLD cap preview, using the same ramp formula as the send gate.
   const effectiveCapToday: number | null = (() => {
-    const hard = normalizedFormLimit;
+    const hard = coldTarget;
     if (!warmupEnabled || hard == null || warmupStartN == null || warmupRampN == null || warmupRampN < 1 || Number.isNaN(warmupStartN)) {
       return hard;
     }
@@ -621,6 +638,8 @@ export default function ProfileDetailPage() {
     warmupEnabled !== (profile.warmupEnabled ?? false) ||
     (warmupStartN ?? null) !== (profile.warmupStartPerDay ?? null) ||
     (warmupRampN ?? null) !== (profile.warmupRampDays ?? null) ||
+    (coldLimitN ?? null) !== (profile.coldDailyLimit ?? null) ||
+    (serviceWindowN ?? 24) !== (profile.serviceWindowHours ?? 24) ||
     (Number.isNaN(normalizedFormLimit as number)
       ? true
       : normalizedFormLimit !== (profile.dailyMessageLimit ?? null));
@@ -903,6 +922,52 @@ export default function ProfileDetailPage() {
           </div>
         </div>
 
+        {/* Cold-traffic (business-initiated) limits */}
+        <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-4 space-y-3 max-w-2xl">
+          <div>
+            <Label className="text-xs font-medium text-slate-200">Cold-traffic limits</Label>
+            <p className="text-[11px] text-slate-500 mt-0.5">
+              &ldquo;Cold&rdquo; = messages to people who have not messaged this number within the
+              service window (first contact, OTP, notifications). These carry the reach-out-lock
+              risk; replies inside the window are never capped by this.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="coldLimit" className="text-xs text-slate-300">
+                Cold daily limit
+              </Label>
+              <Input
+                id="coldLimit"
+                type="number"
+                min={1}
+                inputMode="numeric"
+                placeholder="250 (default)"
+                value={coldDailyLimit}
+                onChange={(e) => setColdDailyLimit(e.target.value)}
+                className="bg-slate-950/40 border-slate-800 text-slate-100"
+              />
+              <p className="text-[11px] text-slate-500">Max cold sends/day. Empty = 250 default.</p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="serviceWindow" className="text-xs text-slate-300">
+                Service window (hours)
+              </Label>
+              <Input
+                id="serviceWindow"
+                type="number"
+                min={1}
+                inputMode="numeric"
+                placeholder="24"
+                value={serviceWindowHours}
+                onChange={(e) => setServiceWindowHours(e.target.value)}
+                className="bg-slate-950/40 border-slate-800 text-slate-100"
+              />
+              <p className="text-[11px] text-slate-500">A reply within this window isn&apos;t &ldquo;cold&rdquo;.</p>
+            </div>
+          </div>
+        </div>
+
         {/* Warm-up ramp */}
         <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-4 space-y-3 max-w-2xl">
           <div className="flex items-start justify-between gap-3">
@@ -911,8 +976,9 @@ export default function ProfileDetailPage() {
                 Warm-up ramp
               </Label>
               <p className="text-[11px] text-slate-500 mt-0.5">
-                Gradually raise the daily cap from a low start up to the limit — recommended for
-                new or recently rate-locked numbers.
+                Gradually raise the <strong className="font-medium text-slate-300">cold</strong> cap
+                from a low start up to its target — recommended for new or recently rate-locked
+                numbers. Replies are never throttled.
               </p>
             </div>
             <Switch id="warmup" checked={warmupEnabled} onCheckedChange={setWarmupEnabled} />
@@ -952,14 +1018,12 @@ export default function ProfileDetailPage() {
                 </div>
               </div>
               <p className="text-[11px] text-slate-500">
-                Ramps from <span className="font-mono text-slate-300">{warmupStart || '—'}</span> to{' '}
-                <span className="font-mono text-slate-300">
-                  {unlimited ? '(set a daily limit)' : dailyLimit}
-                </span>
+                Cold sends ramp from <span className="font-mono text-slate-300">{warmupStart || '—'}</span> to{' '}
+                <span className="font-mono text-slate-300">{coldTarget}</span>
                 /day over <span className="font-mono text-slate-300">{warmupRampDays || '—'}</span> days.
-                {!unlimited && effectiveCapToday != null && (
+                {effectiveCapToday != null && (
                   <>
-                    {' '}Today&apos;s effective cap:{' '}
+                    {' '}Today&apos;s effective cold cap:{' '}
                     <span className="font-mono text-emerald-300">{effectiveCapToday}</span>.
                   </>
                 )}
@@ -975,9 +1039,15 @@ export default function ProfileDetailPage() {
             {!unlimited && (
               <>
                 {' / '}
-                <span className="font-mono text-slate-300">
-                  {warmupEnabled && effectiveCapToday != null ? effectiveCapToday : dailyLimit}
-                </span>
+                <span className="font-mono text-slate-300">{dailyLimit}</span>
+              </>
+            )}
+            {' · cold '}
+            <span className="font-mono text-slate-300">{profile.coldMessageCount || 0}</span>
+            {effectiveCapToday != null && (
+              <>
+                {' / '}
+                <span className="font-mono text-slate-300">{effectiveCapToday}</span>
               </>
             )}
           </p>

--- a/apps/api/src/modules/messages/daily-reset.cron.ts
+++ b/apps/api/src/modules/messages/daily-reset.cron.ts
@@ -18,7 +18,7 @@ export class DailyResetCron {
   async handleReset(): Promise<void> {
     const resetAt = nextMidnightWIB(new Date());
     const res = await prisma.profile.updateMany({
-      data: { dailyMessageCount: 0, dailyResetAt: resetAt },
+      data: { dailyMessageCount: 0, coldMessageCount: 0, dailyResetAt: resetAt },
     });
     this.logger.log(
       `Daily message counters reset for ${res.count} profile(s); next reset ${resetAt.toISOString()}`,

--- a/apps/api/src/modules/messages/messages.service.ts
+++ b/apps/api/src/modules/messages/messages.service.ts
@@ -18,7 +18,7 @@ import {
   SendPollDto,
 } from './dto';
 import { EngineManagerService } from '../profiles/engine-manager.service';
-import { SendGateService, effectiveDailyCap } from '@multiwa/engine-runtime';
+import { SendGateService, classifyColdSend, effectiveCapForLane } from '@multiwa/engine-runtime';
 import { AppEvents, isWhatsAppRecipient } from '@multiwa/core';
 import {
   OUTBOUND_SEND_QUEUE,
@@ -235,20 +235,20 @@ export class MessagesService {
       // 429 (the send gate in the consumer is the authoritative increment).
       const now = new Date();
       const resetDue = !profile.dailyResetAt || profile.dailyResetAt <= now;
-      // Effective cap accounts for the warm-up ramp (mirrors the authoritative
-      // send-gate check so warm-up-limited sends get a synchronous 429 too).
-      const effectiveLimit = effectiveDailyCap(profile, now);
-      if (
-        effectiveLimit != null &&
-        !resetDue &&
-        (profile.dailyMessageCount ?? 0) >= effectiveLimit
-      ) {
+      // Lane-aware pre-enqueue check (mirrors the authoritative send-gate): a cold
+      // send hits the cold cap on the cold counter; a reply hits the overall
+      // backstop. Gives the common case a synchronous 429 instead of an async fail.
+      const isCold = await classifyColdSend(profileId, jid, profile.serviceWindowHours ?? 24, now);
+      const laneCap = effectiveCapForLane(profile, isCold, now);
+      const laneCount = isCold ? (profile.coldMessageCount ?? 0) : (profile.dailyMessageCount ?? 0);
+      if (laneCap != null && !resetDue && laneCount >= laneCap) {
         await prisma.message.update({ where: { id: message.id }, data: { status: 'failed' } });
         throw new HttpException(
           {
-            error: 'DAILY_LIMIT_REACHED',
-            limit: effectiveLimit,
-            count: profile.dailyMessageCount,
+            error: isCold ? 'COLD_DAILY_LIMIT_REACHED' : 'DAILY_LIMIT_REACHED',
+            lane: isCold ? 'cold' : 'service',
+            limit: laneCap,
+            count: laneCount,
             resetAt: profile.dailyResetAt,
           },
           HttpStatus.TOO_MANY_REQUESTS,
@@ -288,8 +288,10 @@ export class MessagesService {
 
     let result: any;
     try {
-      result = await this.sendGate.executeWithGate(profileId, () =>
-        this.dispatchToEngine(engine, type, jid, content, quotedMessageId),
+      result = await this.sendGate.executeWithGate(
+        profileId,
+        () => this.dispatchToEngine(engine, type, jid, content, quotedMessageId),
+        jid,
       );
     } catch (error: any) {
       await prisma.message.update({
@@ -433,8 +435,10 @@ export class MessagesService {
     }
 
     try {
-      const result = await this.sendGate.executeWithGate(profileId, () =>
-        this.dispatchToEngine(engine, type, to, content, quotedMessageId),
+      const result = await this.sendGate.executeWithGate(
+        profileId,
+        () => this.dispatchToEngine(engine, type, to, content, quotedMessageId),
+        to,
       );
       await prisma.message.update({
         where: { id: messageDbId },

--- a/apps/api/src/modules/profiles/dto/index.ts
+++ b/apps/api/src/modules/profiles/dto/index.ts
@@ -111,4 +111,22 @@ export class UpdateProfileDto {
   @IsInt()
   @Min(1)
   warmupRampDays?: number | null;
+
+  @ApiPropertyOptional({
+    example: 24,
+    description: 'Customer-service window (hours). A send is a "reply" (unthrottled) if the recipient messaged within this window; otherwise it is "cold".',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  serviceWindowHours?: number;
+
+  @ApiPropertyOptional({
+    example: 250,
+    description: 'Daily cap for COLD (business-initiated / out-of-window) sends only — replies are not counted against it. Omit to fall back to dailyMessageLimit, then a conservative default.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  coldDailyLimit?: number | null;
 }

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -1129,9 +1129,13 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           // backstop — never the cold/warm-up cap, which would wrongly skip replies.
           const currentProfile = await prisma.profile.findUnique({ where: { id: profileId } });
           const backstop = currentProfile?.dailyMessageLimit ?? null;
+          // A pending WIB reset means the counter is stale; let automation through
+          // so the send gate performs its lazy reset (mirrors the pre-enqueue guard).
+          const resetDue = !currentProfile?.dailyResetAt || currentProfile.dailyResetAt <= new Date();
           if (
             currentProfile &&
             backstop != null &&
+            !resetDue &&
             currentProfile.dailyMessageCount >= backstop
           ) {
             this.logger.warn(`Daily message limit reached for profile ${profileId}: ${currentProfile.dailyMessageCount}/${backstop}, skipping automation`);

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,7 +9,6 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { effectiveDailyCap } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -1125,14 +1124,17 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           // counter increment is owned by SendGateService (every automation reply
           // ultimately goes through MessagesService → the send gate), so
           // incrementing here too would double-count. null cap means unlimited.
+          // Automation replies are within the customer-service window (the sender
+          // just messaged us), so they are SERVICE traffic and hit only the overall
+          // backstop — never the cold/warm-up cap, which would wrongly skip replies.
           const currentProfile = await prisma.profile.findUnique({ where: { id: profileId } });
-          const effectiveCap = currentProfile ? effectiveDailyCap(currentProfile, new Date()) : null;
+          const backstop = currentProfile?.dailyMessageLimit ?? null;
           if (
             currentProfile &&
-            effectiveCap != null &&
-            currentProfile.dailyMessageCount >= effectiveCap
+            backstop != null &&
+            currentProfile.dailyMessageCount >= backstop
           ) {
-            this.logger.warn(`Daily message limit reached for profile ${profileId}: ${currentProfile.dailyMessageCount}/${effectiveCap}, skipping automation`);
+            this.logger.warn(`Daily message limit reached for profile ${profileId}: ${currentProfile.dailyMessageCount}/${backstop}, skipping automation`);
           } else {
             const results = await this.ruleEngineService.processMessage(incomingMsg);
 

--- a/apps/api/src/modules/profiles/profiles.service.ts
+++ b/apps/api/src/modules/profiles/profiles.service.ts
@@ -110,6 +110,8 @@ export class ProfilesService {
     if (dto.messageDelayJitterMs !== undefined) data.messageDelayJitterMs = dto.messageDelayJitterMs;
     if (dto.warmupStartPerDay !== undefined) data.warmupStartPerDay = dto.warmupStartPerDay;
     if (dto.warmupRampDays !== undefined) data.warmupRampDays = dto.warmupRampDays;
+    if (dto.serviceWindowHours !== undefined) data.serviceWindowHours = dto.serviceWindowHours;
+    if (dto.coldDailyLimit !== undefined) data.coldDailyLimit = dto.coldDailyLimit;
     if (dto.warmupEnabled !== undefined) {
       data.warmupEnabled = dto.warmupEnabled;
       // Anchor the ramp at "today" each time warm-up is turned on (false -> true),

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,7 +9,6 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { effectiveDailyCap } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -917,12 +916,14 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           // Uses the same warm-up-aware effective cap as the send gate. The send
           // gate owns the single counter increment (automation replies go through
           // it), so this guard must NOT increment. null cap = unlimited.
+          // Automation replies are within the customer-service window, so they are
+          // SERVICE traffic and hit only the overall backstop — not the cold/warm-up cap.
           const currentProfile = await prisma.profile.findUnique({ where: { id: profileId } });
-          const effectiveCap = currentProfile ? effectiveDailyCap(currentProfile, new Date()) : null;
+          const backstop = currentProfile?.dailyMessageLimit ?? null;
           if (
             currentProfile &&
-            effectiveCap != null &&
-            currentProfile.dailyMessageCount >= effectiveCap
+            backstop != null &&
+            currentProfile.dailyMessageCount >= backstop
           ) {
             this.logger.warn(`Daily message limit reached for profile ${profileId}, skipping automation`);
           } else {

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -920,9 +920,13 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           // SERVICE traffic and hit only the overall backstop — not the cold/warm-up cap.
           const currentProfile = await prisma.profile.findUnique({ where: { id: profileId } });
           const backstop = currentProfile?.dailyMessageLimit ?? null;
+          // A pending WIB reset means the counter is stale; let automation through
+          // so the send gate performs its lazy reset (mirrors the pre-enqueue guard).
+          const resetDue = !currentProfile?.dailyResetAt || currentProfile.dailyResetAt <= new Date();
           if (
             currentProfile &&
             backstop != null &&
+            !resetDue &&
             currentProfile.dailyMessageCount >= backstop
           ) {
             this.logger.warn(`Daily message limit reached for profile ${profileId}, skipping automation`);

--- a/apps/worker/src/engine/messages.service.ts
+++ b/apps/worker/src/engine/messages.service.ts
@@ -92,8 +92,10 @@ export class WorkerMessagesService {
     }
 
     try {
-      const result = await this.sendGate.executeWithGate(profileId, () =>
-        this.dispatchToEngine(engine, type, jid, content, quotedMessageId),
+      const result = await this.sendGate.executeWithGate(
+        profileId,
+        () => this.dispatchToEngine(engine, type, jid, content, quotedMessageId),
+        jid,
       );
       if (result?.messageId) {
         await prisma.message.update({ where: { id: message.id }, data: { messageId: result.messageId, status: 'sent' } });
@@ -119,8 +121,10 @@ export class WorkerMessagesService {
       throw new Error(`Profile ${profileId} not connected; retrying queued send`);
     }
     try {
-      const result = await this.sendGate.executeWithGate(profileId, () =>
-        this.dispatchToEngine(engine, type, to, content, quotedMessageId),
+      const result = await this.sendGate.executeWithGate(
+        profileId,
+        () => this.dispatchToEngine(engine, type, to, content, quotedMessageId),
+        to,
       );
       await prisma.message.update({
         where: { id: messageDbId },

--- a/docs/send-policy-engine.md
+++ b/docs/send-policy-engine.md
@@ -1,0 +1,192 @@
+# Send Policy Engine — Design
+
+Status: **Draft for approval** · Owner: MultiWA · Last updated: 2026-07-04
+
+A window-aware, multi-lane outbound governor that lets a WhatsApp gateway keep
+customer **replies flowing freely** while **pacing and protecting cold /
+business-initiated traffic** (OTP, notifications, marketing) — the traffic that
+actually trips WhatsApp's anti-abuse **reach-out lock** (ack error `463`,
+`NackCallerReachoutTimelocked`).
+
+This builds directly on the per-profile send gate
+(`packages/engine-runtime/src/send-gate.service.ts`) and the anti-ban pacing v2
+(warm-up ramp + delay jitter) already shipped.
+
+---
+
+## 1. Background & motivation
+
+WhatsApp itself distinguishes two kinds of outbound message via the **24-hour
+customer service window**:
+
+- **In-window replies** — the recipient messaged the business within the last
+  24 h; the business replies. **Not** subject to the reach-out lock. Safe.
+- **Cold / business-initiated** — first contact, or outside the window (OTP,
+  notifications, marketing). **Subject** to the reach-out lock. This is what gets
+  a number rate-locked when abused.
+
+A single flat "daily message limit" cannot tell these apart, so it either
+throttles safe replies (hurting a support bot) or fails to protect against the
+cold-outreach that causes bans. Real deployments run **both** kinds on one
+number (e.g. a support bot that also sends login OTP), which is exactly the
+situation that locks a number.
+
+**Goal:** classify each outbound message by *service window* + *category*, then
+apply independent pacing/caps per lane, with delivery confirmation and failover
+for the risky lanes.
+
+### Empirical basis
+On a production number that was reach-out-locked: replies delivered normally
+(hundreds delivered/read in a day) while a cold send to a never-inbound number
+stuck at ack `unknown`, and a healthy sibling number reached `sent` to the same
+recipient. Replies flow; cold outreach is restricted. The design mirrors that
+reality instead of fighting it.
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+- Never throttle in-window replies because of cold-traffic limits.
+- Govern cold traffic (cap, pace, warm-up) per category, independently.
+- Make OTP delivery robust: confirm delivery, fail over when the number is locked.
+- Be generic and configurable — useful to any WhatsApp gateway operator (OSS).
+
+**Non-goals**
+- Bypassing WhatsApp's reach-out lock (impossible and against platform policy).
+- Replacing the official WhatsApp Cloud API — instead, integrate it as a
+  first-class fallback channel for the traffic that needs it.
+
+---
+
+## 3. Categories & window classification
+
+**Message category** (mirrors WhatsApp's own template taxonomy so it is familiar
+to any operator):
+
+| Category | Meaning | Default lane |
+|---|---|---|
+| `service` | Reply / conversational | Reply lane (safe) |
+| `utility` | Transactional notification | Cold lane |
+| `authentication` | OTP / login codes | Cold lane (OTP sub-policy) |
+| `marketing` | Promotional | Cold lane (strictest) |
+
+- The **caller declares** the category on send (e.g. the OTP app sends
+  `category: "authentication"`). Default when omitted: `utility`.
+- **Window classifier** `isWithinServiceWindow(profileId, recipient)` = there
+  exists an **inbound** message from `recipient` to `profileId` within
+  `serviceWindowHours` (default 24). If true, the effective lane is **always
+  `service`** regardless of declared category — an in-window message is a reply.
+
+Effective lane resolution:
+
+```
+effectiveLane(profile, recipient, category):
+  if isWithinServiceWindow(profile, recipient): return SERVICE
+  return category            # utility | authentication | marketing
+```
+
+---
+
+## 4. Lane governance
+
+Each lane has an independent policy. Only cold lanes are capped/warmed:
+
+| Lane | Daily cap | Pacing | Warm-up | Notes |
+|---|---|---|---|---|
+| **SERVICE** | high safety backstop only | base delay + jitter | no | Replies always flow |
+| **UTILITY** | `coldDailyLimit` | base delay + jitter | yes | Transactional |
+| **AUTHENTICATION** | dedicated OTP budget | priority, tighter timeout | optional | Delivery-confirmed (Phase 2) |
+| **MARKETING** | strictest sub-cap of cold | heaviest | yes | Most ban-prone |
+
+**Counters** are per-lane and reset on the same WIB midnight boundary as today's
+`dailyMessageCount`:
+- `dailyMessageCount` (existing) = total safety backstop.
+- `coldMessageCount` (new) = cold-lane traffic; the warm-up ramp + `coldDailyLimit`
+  are enforced against **this**, not the total. This corrects the current
+  behaviour where warm-up caps *all* sends including replies.
+
+---
+
+## 5. Phase 1 — Window-aware multi-lane governor (this PR)
+
+### 5.1 Data model (`Profile`, all nullable/defaulted for `prisma db push`)
+- `serviceWindowHours Int @default(24)` — window that makes a send a reply.
+- `coldDailyLimit Int?` — cap for cold-lane sends. Resolution: `coldDailyLimit`
+  → else `dailyMessageLimit` → else **a conservative default of 250/day**
+  (`COLD_DEFAULT_DAILY_LIMIT`, mirrors WhatsApp Cloud API's entry tier) so cold
+  traffic is safe-by-default on an unconfigured number. Set explicitly (incl. a
+  high value) to widen it.
+- `coldMessageCount Int @default(0)` — cold-lane counter (reset with `dailyResetAt`).
+- Warm-up columns (already exist) are **re-scoped to the cold lane**.
+
+`Message` gains:
+- `category String?` — the declared/derived category, for audit + Phase 2 health.
+
+### 5.2 Send-gate changes (`send-gate.service.ts`)
+`executeWithGate(profileId, sendFn, meta?)` gains an optional `meta`:
+`{ recipient, category }`.
+
+`gatedRun`:
+1. Resolve `effectiveLane` (window classifier query + declared category).
+2. Apply base delay + jitter (unchanged, all lanes).
+3. **Reply lane:** check only the high `dailyMessageLimit` backstop; increment
+   `dailyMessageCount`.
+4. **Cold lane:** compute the effective cold cap = `effectiveDailyCap` over
+   `coldDailyLimit` (warm-up ramps toward it); 429 when `coldMessageCount >= cap`;
+   on success increment **both** `coldMessageCount` and `dailyMessageCount`.
+
+The window classifier is a single indexed query (latest inbound from the
+recipient's conversation). Result cached briefly per (profile, recipient) to
+avoid a DB hit on bursts.
+
+### 5.3 API
+- `BaseMessageDto` gains optional `category` (enum: service | utility |
+  authentication | marketing). No route changes → API contract unchanged.
+- The pre-enqueue 429 path mirrors the lane logic for a synchronous 429.
+
+### 5.4 Admin UI
+Profile "Sending guardrails" card gains a **cold-traffic** sub-section: cold
+daily limit, service-window hours, and the warm-up controls move under it
+(clarifying that warm-up governs cold traffic, not replies). A read-out shows
+today's `service` vs `cold` counts.
+
+### 5.5 Backward compatibility
+- No `category` + within window → SERVICE (replies unaffected).
+- No `category` + cold → `utility` with `coldDailyLimit` (or `dailyMessageLimit`
+  fallback). Existing single-limit behaviour is preserved when cold columns are
+  unset.
+
+---
+
+## 6. Phase 2 — Delivery confirmation, health, circuit breaker (outline)
+- Track per-lane ack outcomes (`delivered`/`read` vs `unknown`/`failed`) over a
+  rolling window → per-profile **cold delivery-success rate**.
+- **Circuit breaker:** on sustained cold failures (the number is locked), auto-pause
+  the cold lanes and raise an alert, while SERVICE keeps flowing.
+- Per-send confirmation for `authentication`: await ack up to `otpAckTimeoutMs`
+  (e.g. 8 s); `unknown`/timeout → trigger failover (Phase 3).
+
+## 7. Phase 3 — Pluggable multi-channel failover (outline)
+- `SendChannel` interface: `whatsapp-web-js` (unofficial, primary), an optional
+  secondary channel, and optional SMS. The interface is generic; any concrete
+  channel is provided by the operator.
+- Per-category routing + failover: OTP primary = unofficial number; on
+  non-confirmation, fail over to a secondary channel (e.g. an official
+  authentication-template channel, reliable for OTP with no reach-out-lock).
+- All channel endpoints and credentials are read from environment variables
+  only, never committed. Concrete provider wiring (endpoints, account IDs,
+  tokens) is deployment-specific and lives outside this repository.
+
+---
+
+## 8. Testing & verification
+- Unit: window classifier (in/out of window, no history), lane resolution,
+  per-lane cap + warm-up math (extends the existing `effectiveDailyCap` cases).
+- Integration: a cold send over cap → 429 while an in-window reply to the same
+  profile still succeeds (the core guarantee).
+- Live (reversible): confirm a reply and a cold send land on different counters.
+
+## 9. Open questions
+- OTP sub-policy defaults (dedicated budget size, ack timeout).
+- Whether marketing should be off by default on recovering numbers.

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -149,6 +149,12 @@ model Profile {
   warmupStartPerDay Int?
   warmupRampDays    Int?
   warmupStartedAt   DateTime?
+  // Send Policy Engine: a send is a "reply" (safe) if the recipient messaged this
+  // profile within serviceWindowHours; otherwise it is "cold" (business-initiated)
+  // and governed by coldDailyLimit (+ the warm-up ramp) via its own counter.
+  serviceWindowHours Int     @default(24)
+  coldDailyLimit    Int?
+  coldMessageCount  Int      @default(0)
   // Per-profile engine selection. whatsapp-web-js (default, production) | baileys (EXPERIMENTAL) | mock (testing).
   engine          String   @default("whatsapp-web-js")
   lastConnectedAt DateTime?

--- a/packages/engine-runtime/src/send-gate.service.ts
+++ b/packages/engine-runtime/src/send-gate.service.ts
@@ -90,6 +90,52 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Default cold-lane daily cap when neither coldDailyLimit nor dailyMessageLimit is set. */
+const COLD_DEFAULT_DAILY_LIMIT = Number(process.env.COLD_DEFAULT_DAILY_LIMIT) || 250;
+
+/**
+ * Classify an outbound send as "cold" (business-initiated) vs "service" (reply).
+ *
+ * A send is a SERVICE reply when the recipient messaged this profile within
+ * serviceWindowHours (WhatsApp's customer-service window) — those are not subject
+ * to the reach-out lock and must flow freely. Everything else to a person is COLD
+ * (first contact / outside the window: OTP, notifications, marketing). Group,
+ * broadcast and newsletter sends are never cold outreach. A missing recipient
+ * defaults to service so we never block a send we cannot classify.
+ */
+export async function classifyColdSend(
+  profileId: string,
+  recipient: string | undefined,
+  serviceWindowHours: number,
+  now: Date = new Date(),
+): Promise<boolean> {
+  if (!recipient) return false;
+  const jid = recipient.replace(/@c\.us$/, '@s.whatsapp.net');
+  if (jid.endsWith('@g.us') || jid.endsWith('@broadcast') || jid.endsWith('@newsletter')) return false;
+  const since = new Date(now.getTime() - Math.max(0, serviceWindowHours) * 60 * 60 * 1000);
+  const lastInbound = await prisma.message.findFirst({
+    where: { profileId, direction: 'incoming', conversation: { is: { jid } } },
+    orderBy: { timestamp: 'desc' },
+    select: { timestamp: true },
+  });
+  return !lastInbound || lastInbound.timestamp < since;
+}
+
+/** Fields the lane cap resolver reads (superset of WarmupCapInput). */
+export type LaneCapInput = WarmupCapInput & { coldDailyLimit?: number | null };
+
+/**
+ * Effective daily cap for a lane. Replies (service) only hit the plain daily
+ * backstop with no warm-up throttling; cold sends hit the cold cap
+ * (coldDailyLimit → dailyMessageLimit → the conservative default), ramped by the
+ * warm-up schedule. Null means uncapped.
+ */
+export function effectiveCapForLane(profile: LaneCapInput, isCold: boolean, now: Date = new Date()): number | null {
+  if (!isCold) return profile.dailyMessageLimit ?? null;
+  const baseColdLimit = profile.coldDailyLimit ?? profile.dailyMessageLimit ?? COLD_DEFAULT_DAILY_LIMIT;
+  return effectiveDailyCap({ ...profile, dailyMessageLimit: baseColdLimit }, now);
+}
+
 @Injectable()
 export class SendGateService {
   private readonly logger = new Logger(SendGateService.name);
@@ -106,12 +152,16 @@ export class SendGateService {
    * counter on success. Returns sendFn's result, or rejects with the send error
    * / a 429 HttpException.
    */
-  async executeWithGate<T>(profileId: string, sendFn: () => Promise<T>): Promise<T> {
+  async executeWithGate<T>(
+    profileId: string,
+    sendFn: () => Promise<T>,
+    recipient?: string,
+  ): Promise<T> {
     const prev = this.profileChains.get(profileId) ?? Promise.resolve();
     // Run after the previous send for this profile, whether it resolved or rejected.
     const runResult = prev.then(
-      () => this.gatedRun(profileId, sendFn),
-      () => this.gatedRun(profileId, sendFn),
+      () => this.gatedRun(profileId, sendFn, recipient),
+      () => this.gatedRun(profileId, sendFn, recipient),
     );
     // The stored tail must never reject (or it poisons the chain).
     this.profileChains.set(
@@ -124,7 +174,11 @@ export class SendGateService {
     return runResult;
   }
 
-  private async gatedRun<T>(profileId: string, sendFn: () => Promise<T>): Promise<T> {
+  private async gatedRun<T>(
+    profileId: string,
+    sendFn: () => Promise<T>,
+    recipient?: string,
+  ): Promise<T> {
     const profile = await prisma.profile.findUnique({
       where: { id: profileId },
       select: {
@@ -137,6 +191,9 @@ export class SendGateService {
         warmupStartPerDay: true,
         warmupRampDays: true,
         warmupStartedAt: true,
+        serviceWindowHours: true,
+        coldDailyLimit: true,
+        coldMessageCount: true,
       },
     });
     if (!profile) throw new NotFoundException('Profile not found');
@@ -153,35 +210,47 @@ export class SendGateService {
     // inter-message spacing.
     this.lastSentAt.set(profileId, Date.now());
 
-    // 2. Lazy daily reset (WIB boundary) + limit check.
+    // 2. Lazy daily reset (WIB boundary) for both the total and cold counters.
     const now = new Date();
     let count = profile.dailyMessageCount ?? 0;
+    let coldCount = profile.coldMessageCount ?? 0;
     if (!profile.dailyResetAt || profile.dailyResetAt <= now) {
       count = 0;
+      coldCount = 0;
       await prisma.profile.update({
         where: { id: profileId },
-        data: { dailyMessageCount: 0, dailyResetAt: nextMidnightWIB(now) },
+        data: { dailyMessageCount: 0, coldMessageCount: 0, dailyResetAt: nextMidnightWIB(now) },
       });
     }
-    // Effective cap accounts for the warm-up ramp; null means unlimited.
-    const limit = effectiveDailyCap(profile, now);
-    if (limit != null && count >= limit) {
+
+    // 3. Lane-aware cap. Replies (in service window) only hit the high overall
+    // backstop; cold sends hit the dedicated cold cap (warm-up ramps toward it).
+    const resetAt = profile.dailyResetAt ?? nextMidnightWIB(now);
+    const isCold = await classifyColdSend(profileId, recipient, profile.serviceWindowHours ?? 24, now);
+    const cap = effectiveCapForLane(profile, isCold, now);
+    const laneCount = isCold ? coldCount : count;
+    if (cap != null && laneCount >= cap) {
       throw new HttpException(
         {
-          error: 'DAILY_LIMIT_REACHED',
-          limit,
-          count,
-          resetAt: profile.dailyResetAt ?? nextMidnightWIB(now),
+          error: isCold ? 'COLD_DAILY_LIMIT_REACHED' : 'DAILY_LIMIT_REACHED',
+          lane: isCold ? 'cold' : 'service',
+          limit: cap,
+          count: laneCount,
+          resetAt,
         },
         HttpStatus.TOO_MANY_REQUESTS,
       );
     }
 
-    // 3. Send, then increment the counter only on a real successful send.
+    // 4. Send, then increment counters only on a real successful send. Cold sends
+    // advance both the total and the cold counter; replies advance only the total.
     const result = await sendFn();
     await prisma.profile.update({
       where: { id: profileId },
-      data: { dailyMessageCount: { increment: 1 } },
+      data: {
+        dailyMessageCount: { increment: 1 },
+        ...(isCold ? { coldMessageCount: { increment: 1 } } : {}),
+      },
     });
     return result;
   }

--- a/packages/engine-runtime/src/send-gate.service.ts
+++ b/packages/engine-runtime/src/send-gate.service.ts
@@ -113,8 +113,28 @@ export async function classifyColdSend(
   const jid = recipient.replace(/@c\.us$/, '@s.whatsapp.net');
   if (jid.endsWith('@g.us') || jid.endsWith('@broadcast') || jid.endsWith('@newsletter')) return false;
   const since = new Date(now.getTime() - Math.max(0, serviceWindowHours) * 60 * 60 * 1000);
+
+  // A contact can be stored under either its phone JID or its hidden @lid form
+  // (multi-device). Gather every linked JID so an in-window reply persisted under
+  // the alternate form still matches. (Truly unresolved @lid inbound with no
+  // stored link can't be connected without the live engine — a known limitation.)
+  const candidates = new Set<string>([jid]);
+  const linked = await prisma.conversation.findMany({
+    where: { profileId, OR: [{ jid }, { metadata: { path: ['lidJid'], equals: jid } }] },
+    select: { jid: true, metadata: true },
+  });
+  for (const c of linked) {
+    candidates.add(c.jid);
+    const lid = (c.metadata as any)?.lidJid;
+    if (typeof lid === 'string' && lid) candidates.add(lid);
+  }
+
   const lastInbound = await prisma.message.findFirst({
-    where: { profileId, direction: 'incoming', conversation: { is: { jid } } },
+    where: {
+      profileId,
+      direction: 'incoming',
+      conversation: { is: { profileId, jid: { in: [...candidates] } } },
+    },
     orderBy: { timestamp: 'desc' },
     select: { timestamp: true },
   });
@@ -214,18 +234,19 @@ export class SendGateService {
     const now = new Date();
     let count = profile.dailyMessageCount ?? 0;
     let coldCount = profile.coldMessageCount ?? 0;
+    let resetAt = profile.dailyResetAt ?? nextMidnightWIB(now);
     if (!profile.dailyResetAt || profile.dailyResetAt <= now) {
       count = 0;
       coldCount = 0;
+      resetAt = nextMidnightWIB(now);
       await prisma.profile.update({
         where: { id: profileId },
-        data: { dailyMessageCount: 0, coldMessageCount: 0, dailyResetAt: nextMidnightWIB(now) },
+        data: { dailyMessageCount: 0, coldMessageCount: 0, dailyResetAt: resetAt },
       });
     }
 
     // 3. Lane-aware cap. Replies (in service window) only hit the high overall
     // backstop; cold sends hit the dedicated cold cap (warm-up ramps toward it).
-    const resetAt = profile.dailyResetAt ?? nextMidnightWIB(now);
     const isCold = await classifyColdSend(profileId, recipient, profile.serviceWindowHours ?? 24, now);
     const cap = effectiveCapForLane(profile, isCold, now);
     const laneCount = isCold ? coldCount : count;


### PR DESCRIPTION
## What & why

Real deployments run **both** customer-service replies **and** cold traffic (OTP,
notifications) on one number — and cold traffic is what trips WhatsApp's reach-out
lock (error 463). A single flat daily limit can't tell them apart, so it either
throttles safe replies or fails to protect against the cold outreach that causes
bans.

This adds WhatsApp's own **24h customer-service window** model to the send gate so
the two are governed independently.

## How it works
- A send is **SERVICE** (reply) when the recipient messaged this profile within
  `serviceWindowHours` (default 24), or it's a group/broadcast → only the high
  overall backstop (`dailyMessageLimit`), **no warm-up throttling**.
- Otherwise it's **COLD** → a dedicated cap (`coldDailyLimit` → `dailyMessageLimit`
  → a conservative **250/day** default, env `COLD_DEFAULT_DAILY_LIMIT`), ramped by
  the warm-up schedule, counted on its own `coldMessageCount`.
- This also **fixes** the prior warm-up behaviour where the ramp throttled *all*
  sends including replies.

## Scope
- **Single source of truth:** `classifyColdSend()` + `effectiveCapForLane()` in the
  send gate; recipient threaded to `executeWithGate` at all 4 send call sites
  (api sync/durable + worker). Pre-enqueue 429 + both automation fast-fails are
  lane-aware.
- schema: `Profile` += `serviceWindowHours`, `coldDailyLimit`, `coldMessageCount`
  (nullable/defaulted → `prisma db push` safe). No route changes.
- admin: guardrails card gains a **Cold-traffic limits** sub-section (cold daily
  limit + service window); warm-up now clearly governs the cold cap; footer shows
  service vs cold counts.
- Design doc: `docs/send-policy-engine.md` (Phases 1-3, vendor-neutral).

## Phase 1 of 3
Phase 2 = delivery-confirmation + health + cold circuit-breaker. Phase 3 =
pluggable multi-channel failover for OTP.

## Testing
- `effectiveCapForLane` + classifier short-circuits verified (incl. "service
  ignores warm-up"). api + worker + admin typecheck clean; API contract in sync (216).
- Ran an adversarial review (5 dimensions → per-finding verify); all 6 confirmed
  findings fixed in the second commit (LID-form classifier match, stale resetAt,
  fast-fail reset guards, index hint, preview day-0).

## Deploy
Deploy **api + worker + admin**; `prisma db push` on api start adds the columns.