### PR TITLE
feat(send-policy): cold-lane circuit breaker + delivery health (Phase 2)

### DIFF
--- a/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
@@ -77,6 +77,8 @@ interface Profile {
   serviceWindowHours?: number;
   coldDailyLimit?: number | null;
   coldMessageCount?: number;
+  coldCircuitState?: string;
+  coldCircuitOpenedAt?: string | null;
   sessionData?: {
     jid?: string;
     name?: string;
@@ -926,7 +928,18 @@ export default function ProfileDetailPage() {
         {/* Cold-traffic (business-initiated) limits */}
         <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-4 space-y-3 max-w-2xl">
           <div>
-            <Label className="text-xs font-medium text-slate-200">Cold-traffic limits</Label>
+            <div className="flex items-center gap-2">
+              <Label className="text-xs font-medium text-slate-200">Cold-traffic limits</Label>
+              {profile.coldCircuitState === 'open' ? (
+                <span className="inline-flex items-center rounded-full bg-red-500/15 text-red-300 border border-red-500/30 px-2 py-0.5 text-[10px] font-medium">
+                  ● Cold circuit paused
+                </span>
+              ) : (
+                <span className="inline-flex items-center rounded-full bg-slate-700/40 text-slate-400 px-2 py-0.5 text-[10px]">
+                  ● Cold circuit OK
+                </span>
+              )}
+            </div>
             <p className="text-[11px] text-slate-500 mt-0.5">
               &ldquo;Cold&rdquo; = messages to people who have not messaged this number within the
               service window (first contact, OTP, notifications). These carry the reach-out-lock

--- a/apps/api/src/modules/messages/messages.service.ts
+++ b/apps/api/src/modules/messages/messages.service.ts
@@ -454,11 +454,16 @@ export class MessagesService {
       throw new Error(`Profile ${profileId} not connected; retrying queued send`);
     }
 
+    // Use the lane classified + persisted at enqueue time so the gate's governance
+    // and the cold-circuit health accounting agree with the message's stored lane.
+    const laneRow = await prisma.message.findUnique({ where: { id: messageDbId }, select: { lane: true } });
+
     try {
       const result = await this.sendGate.executeWithGate(
         profileId,
         () => this.dispatchToEngine(engine, type, to, content, quotedMessageId),
         to,
+        laneRow?.lane === 'cold',
       );
       await prisma.message.update({
         where: { id: messageDbId },

--- a/apps/api/src/modules/messages/messages.service.ts
+++ b/apps/api/src/modules/messages/messages.service.ts
@@ -18,7 +18,13 @@ import {
   SendPollDto,
 } from './dto';
 import { EngineManagerService } from '../profiles/engine-manager.service';
-import { SendGateService, classifyColdSend, effectiveCapForLane } from '@multiwa/engine-runtime';
+import {
+  SendGateService,
+  classifyColdSend,
+  effectiveCapForLane,
+  isColdCircuitBlocking,
+  COLD_CIRCUIT_COOLDOWN_MS,
+} from '@multiwa/engine-runtime';
 import { AppEvents, isWhatsAppRecipient } from '@multiwa/core';
 import {
   OUTBOUND_SEND_QUEUE,
@@ -203,6 +209,10 @@ export class MessagesService {
       });
     }
 
+    // Classify the send lane ONCE (service reply vs cold) and persist it, so the
+    // gate, the pre-enqueue check, and the cold-circuit health eval all agree.
+    const isCold = await classifyColdSend(profileId, jid, (profile as any).serviceWindowHours ?? 24);
+
     // Create message record
     const message = await prisma.message.create({
       data: {
@@ -214,6 +224,7 @@ export class MessagesService {
         type,
         content,
         status: 'pending',
+        lane: isCold ? 'cold' : 'service',
         timestamp: new Date(),
         quotedMessageId,
       },
@@ -238,7 +249,15 @@ export class MessagesService {
       // Lane-aware pre-enqueue check (mirrors the authoritative send-gate): a cold
       // send hits the cold cap on the cold counter; a reply hits the overall
       // backstop. Gives the common case a synchronous 429 instead of an async fail.
-      const isCold = await classifyColdSend(profileId, jid, profile.serviceWindowHours ?? 24, now);
+      // Reuses the lane classified once above.
+      // Cold circuit breaker: reject synchronously while open.
+      if (isCold && isColdCircuitBlocking((profile as any).coldCircuitState, (profile as any).coldCircuitOpenedAt, now)) {
+        await prisma.message.update({ where: { id: message.id }, data: { status: 'failed' } });
+        throw new HttpException(
+          { error: 'COLD_CIRCUIT_OPEN', lane: 'cold', retryAt: new Date(((profile as any).coldCircuitOpenedAt?.getTime() ?? now.getTime()) + COLD_CIRCUIT_COOLDOWN_MS) },
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
       const laneCap = effectiveCapForLane(profile, isCold, now);
       const laneCount = isCold ? (profile.coldMessageCount ?? 0) : (profile.dailyMessageCount ?? 0);
       if (laneCap != null && !resetDue && laneCount >= laneCap) {
@@ -292,6 +311,7 @@ export class MessagesService {
         profileId,
         () => this.dispatchToEngine(engine, type, jid, content, quotedMessageId),
         jid,
+        isCold,
       );
     } catch (error: any) {
       await prisma.message.update({

--- a/apps/api/src/modules/messages/outbound-send.consumer.spec.ts
+++ b/apps/api/src/modules/messages/outbound-send.consumer.spec.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HttpException, HttpStatus } from '@nestjs/common';
 
 vi.mock('@multiwa/database', () => ({
-  prisma: { message: { update: vi.fn() } },
+  prisma: { message: { update: vi.fn(), findUnique: vi.fn() } },
 }));
 
 // Stub the engine-manager module so importing MessagesService does not pull in
@@ -43,6 +43,8 @@ function makeService(over: { engine?: any; gate?: any } = {}) {
 describe('MessagesService.deliverQueued', () => {
   beforeEach(() => {
     vi.mocked(prisma.message.update).mockReset().mockResolvedValue({} as any);
+    // deliverQueued reads the persisted lane to gate cold vs service.
+    vi.mocked(prisma.message.findUnique).mockReset().mockResolvedValue({ lane: null } as any);
   });
 
   it('sends through the gate and marks the message sent + emits message.sent', async () => {

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -1168,6 +1168,13 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           // (pending, sent, delivered, read, played)
           // No need for double-mapping
           
+          // Read prior state before updating so we can fire the cold-circuit eval on
+          // the FIRST terminal transition only (a message emits delivered→read→played).
+          const prior = await prisma.message.findFirst({
+            where: { messageId },
+            select: { status: true, lane: true },
+          });
+
           const updated = await prisma.message.updateMany({
             where: { messageId },
             data: { status },
@@ -1190,28 +1197,24 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
             this.emitEvent(ackEvent, { profileId, messageId, status });
           }
 
-          // Cold-circuit health: when a COLD send reaches a terminal ack, re-evaluate
-          // the breaker (delivered = success; unknown/failed = failure) and alert on a
-          // state transition. Replies never affect the circuit.
-          const terminal =
-            status === 'delivered' || status === 'read' || status === 'played' ||
-            status === 'unknown' || status === 'failed';
-          if (terminal) {
-            const msg = await prisma.message.findFirst({ where: { messageId }, select: { lane: true } });
-            if (msg?.lane === 'cold') {
-              const success = status === 'delivered' || status === 'read' || status === 'played';
-              const transition = await evaluateColdCircuit(profileId, success);
-              if (transition === 'opened') {
-                this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '🧊 Cold circuit opened',
-                  'Cold (business-initiated) sends are paused after repeated delivery failures — the number is likely rate-locked. Replies still work; it will auto-retry after a cooldown.',
-                  { profileId, reason: 'cold-circuit-open' },
-                ).catch((err) => this.logger.warn(`Notification error (cold-circuit-open): ${err.message}`));
-              } else if (transition === 'closed') {
-                this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '✅ Cold circuit recovered',
-                  'Cold sending recovered and has resumed.',
-                  { profileId, reason: 'cold-circuit-closed' },
-                ).catch((err) => this.logger.warn(`Notification error (cold-circuit-closed): ${err.message}`));
-              }
+          // Cold-circuit health: evaluate the breaker ONCE, on the first terminal
+          // transition of a COLD message (delivered/read/played = success, unknown =
+          // failure). Later acks on the same message don't re-run the state machine.
+          const TERMINAL_ACKS = ['delivered', 'read', 'played', 'unknown'];
+          const wasTerminal = prior ? TERMINAL_ACKS.includes(prior.status) : false;
+          if (prior?.lane === 'cold' && !wasTerminal && TERMINAL_ACKS.includes(status)) {
+            const success = status === 'delivered' || status === 'read' || status === 'played';
+            const transition = await evaluateColdCircuit(profileId, success);
+            if (transition === 'opened') {
+              this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '🧊 Cold circuit opened',
+                'Cold (business-initiated) sends are paused after repeated delivery failures — the number is likely rate-locked. Replies still work; it will auto-retry after a cooldown.',
+                { profileId, reason: 'cold-circuit-open' },
+              ).catch((err) => this.logger.warn(`Notification error (cold-circuit-open): ${err.message}`));
+            } else if (transition === 'closed') {
+              this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '✅ Cold circuit recovered',
+                'Cold sending recovered and has resumed.',
+                { profileId, reason: 'cold-circuit-closed' },
+              ).catch((err) => this.logger.warn(`Notification error (cold-circuit-closed): ${err.message}`));
             }
           }
         } catch (error) {

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,6 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
+import { evaluateColdCircuit } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -1187,6 +1188,31 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
                 : null;
           if (ackEvent) {
             this.emitEvent(ackEvent, { profileId, messageId, status });
+          }
+
+          // Cold-circuit health: when a COLD send reaches a terminal ack, re-evaluate
+          // the breaker (delivered = success; unknown/failed = failure) and alert on a
+          // state transition. Replies never affect the circuit.
+          const terminal =
+            status === 'delivered' || status === 'read' || status === 'played' ||
+            status === 'unknown' || status === 'failed';
+          if (terminal) {
+            const msg = await prisma.message.findFirst({ where: { messageId }, select: { lane: true } });
+            if (msg?.lane === 'cold') {
+              const success = status === 'delivered' || status === 'read' || status === 'played';
+              const transition = await evaluateColdCircuit(profileId, success);
+              if (transition === 'opened') {
+                this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '🧊 Cold circuit opened',
+                  'Cold (business-initiated) sends are paused after repeated delivery failures — the number is likely rate-locked. Replies still work; it will auto-retry after a cooldown.',
+                  { profileId, reason: 'cold-circuit-open' },
+                ).catch((err) => this.logger.warn(`Notification error (cold-circuit-open): ${err.message}`));
+              } else if (transition === 'closed') {
+                this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '✅ Cold circuit recovered',
+                  'Cold sending recovered and has resumed.',
+                  { profileId, reason: 'cold-circuit-closed' },
+                ).catch((err) => this.logger.warn(`Notification error (cold-circuit-closed): ${err.message}`));
+              }
+            }
           }
         } catch (error) {
           this.logger.warn(`Failed to update message ack: ${(error as Error).message}`);

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -955,6 +955,13 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           // (pending, sent, delivered, read, played)
           // No need for double-mapping
           
+          // Read prior state before updating so the cold-circuit eval fires only on
+          // the FIRST terminal transition (a message emits delivered→read→played).
+          const prior = await prisma.message.findFirst({
+            where: { messageId },
+            select: { status: true, lane: true },
+          });
+
           const updated = await prisma.message.updateMany({
             where: { messageId },
             data: { status },
@@ -977,27 +984,23 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
             this.emitEvent(ackEvent, { profileId, messageId, status });
           }
 
-          // Cold-circuit health: re-evaluate the breaker on a COLD send's terminal
-          // ack (delivered = success; unknown/failed = failure) and alert on change.
-          const terminal =
-            status === 'delivered' || status === 'read' || status === 'played' ||
-            status === 'unknown' || status === 'failed';
-          if (terminal) {
-            const msg = await prisma.message.findFirst({ where: { messageId }, select: { lane: true } });
-            if (msg?.lane === 'cold') {
-              const success = status === 'delivered' || status === 'read' || status === 'played';
-              const transition = await evaluateColdCircuit(profileId, success);
-              if (transition === 'opened') {
-                this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '🧊 Cold circuit opened',
-                  'Cold (business-initiated) sends are paused after repeated delivery failures — the number is likely rate-locked. Replies still work; it will auto-retry after a cooldown.',
-                  { profileId, reason: 'cold-circuit-open' },
-                ).catch((err) => this.logger.warn(`Notification error (cold-circuit-open): ${err.message}`));
-              } else if (transition === 'closed') {
-                this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '✅ Cold circuit recovered',
-                  'Cold sending recovered and has resumed.',
-                  { profileId, reason: 'cold-circuit-closed' },
-                ).catch((err) => this.logger.warn(`Notification error (cold-circuit-closed): ${err.message}`));
-              }
+          // Cold-circuit health: evaluate ONCE, on the first terminal transition of a
+          // COLD message (delivered/read/played = success, unknown = failure).
+          const TERMINAL_ACKS = ['delivered', 'read', 'played', 'unknown'];
+          const wasTerminal = prior ? TERMINAL_ACKS.includes(prior.status) : false;
+          if (prior?.lane === 'cold' && !wasTerminal && TERMINAL_ACKS.includes(status)) {
+            const success = status === 'delivered' || status === 'read' || status === 'played';
+            const transition = await evaluateColdCircuit(profileId, success);
+            if (transition === 'opened') {
+              this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '🧊 Cold circuit opened',
+                'Cold (business-initiated) sends are paused after repeated delivery failures — the number is likely rate-locked. Replies still work; it will auto-retry after a cooldown.',
+                { profileId, reason: 'cold-circuit-open' },
+              ).catch((err) => this.logger.warn(`Notification error (cold-circuit-open): ${err.message}`));
+            } else if (transition === 'closed') {
+              this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '✅ Cold circuit recovered',
+                'Cold sending recovered and has resumed.',
+                { profileId, reason: 'cold-circuit-closed' },
+              ).catch((err) => this.logger.warn(`Notification error (cold-circuit-closed): ${err.message}`));
             }
           }
         } catch (error) {

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,6 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
+import { evaluateColdCircuit } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -974,6 +975,30 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
                 : null;
           if (ackEvent) {
             this.emitEvent(ackEvent, { profileId, messageId, status });
+          }
+
+          // Cold-circuit health: re-evaluate the breaker on a COLD send's terminal
+          // ack (delivered = success; unknown/failed = failure) and alert on change.
+          const terminal =
+            status === 'delivered' || status === 'read' || status === 'played' ||
+            status === 'unknown' || status === 'failed';
+          if (terminal) {
+            const msg = await prisma.message.findFirst({ where: { messageId }, select: { lane: true } });
+            if (msg?.lane === 'cold') {
+              const success = status === 'delivered' || status === 'read' || status === 'played';
+              const transition = await evaluateColdCircuit(profileId, success);
+              if (transition === 'opened') {
+                this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '🧊 Cold circuit opened',
+                  'Cold (business-initiated) sends are paused after repeated delivery failures — the number is likely rate-locked. Replies still work; it will auto-retry after a cooldown.',
+                  { profileId, reason: 'cold-circuit-open' },
+                ).catch((err) => this.logger.warn(`Notification error (cold-circuit-open): ${err.message}`));
+              } else if (transition === 'closed') {
+                this.notifyOrgUsers(profileId, NotificationType.SYSTEM, '✅ Cold circuit recovered',
+                  'Cold sending recovered and has resumed.',
+                  { profileId, reason: 'cold-circuit-closed' },
+                ).catch((err) => this.logger.warn(`Notification error (cold-circuit-closed): ${err.message}`));
+              }
+            }
           }
         } catch (error) {
           this.logger.warn(`Failed to update message ack: ${(error as Error).message}`);

--- a/apps/worker/src/engine/messages.service.ts
+++ b/apps/worker/src/engine/messages.service.ts
@@ -125,11 +125,14 @@ export class WorkerMessagesService {
       }
       throw new Error(`Profile ${profileId} not connected; retrying queued send`);
     }
+    // Reuse the lane persisted at enqueue so gate governance matches the stored lane.
+    const laneRow = await prisma.message.findUnique({ where: { id: messageDbId }, select: { lane: true } });
     try {
       const result = await this.sendGate.executeWithGate(
         profileId,
         () => this.dispatchToEngine(engine, type, to, content, quotedMessageId),
         to,
+        laneRow?.lane === 'cold',
       );
       await prisma.message.update({
         where: { id: messageDbId },

--- a/apps/worker/src/engine/messages.service.ts
+++ b/apps/worker/src/engine/messages.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, HttpException, HttpStatus, Inject, forwardRef } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { prisma } from '@multiwa/database';
-import { SendGateService } from '@multiwa/engine-runtime';
+import { SendGateService, classifyColdSend } from '@multiwa/engine-runtime';
 import { AppEvents, isWhatsAppRecipient } from '@multiwa/core';
 import { EngineManagerService } from './engine-manager.service';
 
@@ -70,6 +70,9 @@ export class WorkerMessagesService {
       });
     }
 
+    // Classify the send lane once (service reply vs cold) and persist it.
+    const isCold = await classifyColdSend(profileId, jid, (profile as any).serviceWindowHours ?? 24);
+
     const message = await prisma.message.create({
       data: {
         profileId,
@@ -80,6 +83,7 @@ export class WorkerMessagesService {
         type,
         content,
         status: 'pending',
+        lane: isCold ? 'cold' : 'service',
         timestamp: new Date(),
         quotedMessageId,
       },
@@ -96,6 +100,7 @@ export class WorkerMessagesService {
         profileId,
         () => this.dispatchToEngine(engine, type, jid, content, quotedMessageId),
         jid,
+        isCold,
       );
       if (result?.messageId) {
         await prisma.message.update({ where: { id: message.id }, data: { messageId: result.messageId, status: 'sent' } });

--- a/docs/send-policy-engine.md
+++ b/docs/send-policy-engine.md
@@ -173,6 +173,15 @@ success, `unknown`/`failed` = failure.
 - **Half-open + recover:** after `COLD_CIRCUIT_COOLDOWN_MS` (30 min) the next cold
   send is allowed as a probe; a delivered ack closes the breaker (recovered
   alert), a failed one re-arms the cooldown.
+- The health signal counts only **transmitted** cold sends (real WhatsApp id) with
+  an ack-derived terminal state — policy 429s / send errors keep a placeholder id
+  and are excluded, so the breaker never counts its own blocks. State transitions
+  are atomic (compare-and-set) and evaluated once per message (first terminal ack).
+- **Known limitation:** the breaker relies on undelivered cold sends producing a
+  terminal `unknown` ack (whatsapp-web.js does; a reach-out-locked send yields
+  ack=-1). An engine that leaves silently-dropped sends at non-terminal `sent`
+  (e.g. Baileys) would need a stuck-`sent` reconciliation sweep to feed the signal
+  — a small follow-up, not required for the whatsapp-web.js path.
 - All thresholds are env-overridable. Per-send OTP confirmation + failover is
   Phase 3.
 

--- a/docs/send-policy-engine.md
+++ b/docs/send-policy-engine.md
@@ -159,13 +159,22 @@ today's `service` vs `cold` counts.
 
 ---
 
-## 6. Phase 2 — Delivery confirmation, health, circuit breaker (outline)
-- Track per-lane ack outcomes (`delivered`/`read` vs `unknown`/`failed`) over a
-  rolling window → per-profile **cold delivery-success rate**.
-- **Circuit breaker:** on sustained cold failures (the number is locked), auto-pause
-  the cold lanes and raise an alert, while SERVICE keeps flowing.
-- Per-send confirmation for `authentication`: await ack up to `otpAckTimeoutMs`
-  (e.g. 8 s); `unknown`/timeout → trigger failover (Phase 3).
+## 6. Phase 2 — Delivery confirmation, health, cold circuit breaker (implemented)
+Each outbound send persists its `lane` (service|cold) on the message. When a COLD
+message reaches a terminal ack, the breaker is re-evaluated from the last
+`COLD_CIRCUIT_WINDOW` (10) terminal cold outcomes: `delivered`/`read`/`played` =
+success, `unknown`/`failed` = failure.
+
+- **Open:** when the cold delivery-success rate drops below
+  `COLD_CIRCUIT_MIN_SUCCESS` (0.4) over at least `COLD_CIRCUIT_MIN_SAMPLES` (5)
+  samples, `Profile.coldCircuitState` → `open`. While open, cold sends are
+  rejected `429 COLD_CIRCUIT_OPEN`; **replies (service) keep flowing**. An org
+  `SYSTEM` alert fires on the transition.
+- **Half-open + recover:** after `COLD_CIRCUIT_COOLDOWN_MS` (30 min) the next cold
+  send is allowed as a probe; a delivered ack closes the breaker (recovered
+  alert), a failed one re-arms the cooldown.
+- All thresholds are env-overridable. Per-send OTP confirmation + failover is
+  Phase 3.
 
 ## 7. Phase 3 — Pluggable multi-channel failover (outline)
 - `SendChannel` interface: `whatsapp-web-js` (unofficial, primary), an optional

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -155,6 +155,11 @@ model Profile {
   serviceWindowHours Int     @default(24)
   coldDailyLimit    Int?
   coldMessageCount  Int      @default(0)
+  // Cold-lane circuit breaker: "closed" (normal) | "open" (cold sends paused after
+  // repeated delivery failures — the number is likely reach-out-locked). Replies
+  // keep flowing regardless. Auto half-opens for a probe after a cooldown.
+  coldCircuitState   String    @default("closed")
+  coldCircuitOpenedAt DateTime?
   // Per-profile engine selection. whatsapp-web-js (default, production) | baileys (EXPERIMENTAL) | mock (testing).
   engine          String   @default("whatsapp-web-js")
   lastConnectedAt DateTime?
@@ -250,7 +255,11 @@ model Message {
   type           String   // text, image, video, audio, document, location, contact
   content        Json
   quotedMessageId String?
-  status         String   @default("pending") // pending, sent, delivered, read, failed
+  status         String   @default("pending") // pending, sent, delivered, read, failed, unknown
+  // Send Policy Engine lane at send time: "service" (in-window reply) | "cold"
+  // (business-initiated). Null for inbound/history rows. Feeds the cold-circuit
+  // delivery-health evaluation.
+  lane           String?
   timestamp      DateTime
   metadata       Json?
   createdAt      DateTime @default(now())
@@ -262,6 +271,7 @@ model Message {
   @@index([conversationId, timestamp])
   @@index([messageId])
   @@index([profileId, status])
+  @@index([profileId, lane, createdAt])
   @@map("messages")
 }
 

--- a/packages/engine-runtime/src/send-gate.service.ts
+++ b/packages/engine-runtime/src/send-gate.service.ts
@@ -156,6 +156,87 @@ export function effectiveCapForLane(profile: LaneCapInput, isCold: boolean, now:
   return effectiveDailyCap({ ...profile, dailyMessageLimit: baseColdLimit }, now);
 }
 
+// ---- Cold-lane circuit breaker (delivery-health protection) ------------------
+// When cold (business-initiated) sends stop being delivered — the classic sign a
+// number is reach-out-locked — pause the COLD lane so we stop digging the hole and
+// stop wasting OTP attempts. Replies (service lane) are never affected. After a
+// cooldown the breaker half-opens: one probe cold send is allowed, and its ack
+// closes (recovered) or re-arms (still failing) the breaker.
+const COLD_CIRCUIT_WINDOW = Number(process.env.COLD_CIRCUIT_WINDOW) || 10;
+const COLD_CIRCUIT_MIN_SUCCESS = Number(process.env.COLD_CIRCUIT_MIN_SUCCESS) || 0.4;
+const COLD_CIRCUIT_MIN_SAMPLES = Number(process.env.COLD_CIRCUIT_MIN_SAMPLES) || 5;
+export const COLD_CIRCUIT_COOLDOWN_MS = Number(process.env.COLD_CIRCUIT_COOLDOWN_MS) || 30 * 60 * 1000;
+
+const DELIVERED_STATUSES = ['delivered', 'read', 'played'];
+const TERMINAL_STATUSES = [...DELIVERED_STATUSES, 'unknown', 'failed'];
+
+/**
+ * Is the cold circuit currently blocking sends? Returns true when the breaker is
+ * open AND still within its cooldown. Once the cooldown elapses it returns false
+ * so the next cold send acts as a half-open probe.
+ */
+export function isColdCircuitBlocking(
+  state: string | null | undefined,
+  openedAt: Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (state !== 'open') return false;
+  const opened = openedAt?.getTime() ?? 0;
+  return now.getTime() - opened < COLD_CIRCUIT_COOLDOWN_MS;
+}
+
+/**
+ * Re-evaluate the cold circuit after a cold message reaches a terminal ack.
+ * Returns the state transition ('opened' | 'closed') so the caller can alert, or
+ * null when nothing changed. `ackWasSuccess` = the just-resolved cold ack was a
+ * delivery (delivered/read/played) rather than a failure (unknown/failed).
+ */
+export async function evaluateColdCircuit(
+  profileId: string,
+  ackWasSuccess: boolean,
+): Promise<'opened' | 'closed' | null> {
+  const profile = await prisma.profile.findUnique({
+    where: { id: profileId },
+    select: { coldCircuitState: true },
+  });
+  if (!profile) return null;
+
+  if (profile.coldCircuitState === 'open') {
+    if (ackWasSuccess) {
+      // A cold send got through (the half-open probe worked) → recovered.
+      await prisma.profile.update({
+        where: { id: profileId },
+        data: { coldCircuitState: 'closed', coldCircuitOpenedAt: null },
+      });
+      return 'closed';
+    }
+    // Still failing → re-arm the cooldown so it doesn't half-open immediately.
+    await prisma.profile.update({
+      where: { id: profileId },
+      data: { coldCircuitOpenedAt: new Date() },
+    });
+    return null;
+  }
+
+  // Closed: open only when the recent terminal cold outcomes are mostly failures.
+  const recent = await prisma.message.findMany({
+    where: { profileId, lane: 'cold', direction: 'outgoing', status: { in: TERMINAL_STATUSES } },
+    orderBy: { createdAt: 'desc' },
+    take: COLD_CIRCUIT_WINDOW,
+    select: { status: true },
+  });
+  if (recent.length < COLD_CIRCUIT_MIN_SAMPLES) return null;
+  const delivered = recent.filter((m) => DELIVERED_STATUSES.includes(m.status)).length;
+  if (delivered / recent.length < COLD_CIRCUIT_MIN_SUCCESS) {
+    await prisma.profile.update({
+      where: { id: profileId },
+      data: { coldCircuitState: 'open', coldCircuitOpenedAt: new Date() },
+    });
+    return 'opened';
+  }
+  return null;
+}
+
 @Injectable()
 export class SendGateService {
   private readonly logger = new Logger(SendGateService.name);
@@ -176,12 +257,13 @@ export class SendGateService {
     profileId: string,
     sendFn: () => Promise<T>,
     recipient?: string,
+    isCold?: boolean,
   ): Promise<T> {
     const prev = this.profileChains.get(profileId) ?? Promise.resolve();
     // Run after the previous send for this profile, whether it resolved or rejected.
     const runResult = prev.then(
-      () => this.gatedRun(profileId, sendFn, recipient),
-      () => this.gatedRun(profileId, sendFn, recipient),
+      () => this.gatedRun(profileId, sendFn, recipient, isCold),
+      () => this.gatedRun(profileId, sendFn, recipient, isCold),
     );
     // The stored tail must never reject (or it poisons the chain).
     this.profileChains.set(
@@ -198,6 +280,7 @@ export class SendGateService {
     profileId: string,
     sendFn: () => Promise<T>,
     recipient?: string,
+    isColdArg?: boolean,
   ): Promise<T> {
     const profile = await prisma.profile.findUnique({
       where: { id: profileId },
@@ -214,6 +297,8 @@ export class SendGateService {
         serviceWindowHours: true,
         coldDailyLimit: true,
         coldMessageCount: true,
+        coldCircuitState: true,
+        coldCircuitOpenedAt: true,
       },
     });
     if (!profile) throw new NotFoundException('Profile not found');
@@ -245,9 +330,21 @@ export class SendGateService {
       });
     }
 
-    // 3. Lane-aware cap. Replies (in service window) only hit the high overall
-    // backstop; cold sends hit the dedicated cold cap (warm-up ramps toward it).
-    const isCold = await classifyColdSend(profileId, recipient, profile.serviceWindowHours ?? 24, now);
+    // 3. Lane-aware governance. Replies (in service window) only hit the high
+    // overall backstop; cold sends hit the circuit breaker + the dedicated cold cap.
+    const isCold =
+      isColdArg ?? (await classifyColdSend(profileId, recipient, profile.serviceWindowHours ?? 24, now));
+
+    // 3a. Cold circuit breaker: pause cold sends while open (delivery is failing /
+    // the number is reach-out-locked). Replies are never blocked here.
+    if (isCold && isColdCircuitBlocking(profile.coldCircuitState, profile.coldCircuitOpenedAt, now)) {
+      const retryAt = new Date((profile.coldCircuitOpenedAt?.getTime() ?? now.getTime()) + COLD_CIRCUIT_COOLDOWN_MS);
+      throw new HttpException(
+        { error: 'COLD_CIRCUIT_OPEN', lane: 'cold', retryAt },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
     const cap = effectiveCapForLane(profile, isCold, now);
     const laneCount = isCold ? coldCount : count;
     if (cap != null && laneCount >= cap) {

--- a/packages/engine-runtime/src/send-gate.service.ts
+++ b/packages/engine-runtime/src/send-gate.service.ts
@@ -168,7 +168,10 @@ const COLD_CIRCUIT_MIN_SAMPLES = Number(process.env.COLD_CIRCUIT_MIN_SAMPLES) ||
 export const COLD_CIRCUIT_COOLDOWN_MS = Number(process.env.COLD_CIRCUIT_COOLDOWN_MS) || 30 * 60 * 1000;
 
 const DELIVERED_STATUSES = ['delivered', 'read', 'played'];
-const TERMINAL_STATUSES = [...DELIVERED_STATUSES, 'unknown', 'failed'];
+// Ack-derived terminal states only. 'failed' is deliberately excluded: it is set
+// by the SEND path (policy 429s / engine throws), never by an ack, and always on
+// a never-transmitted row — counting it would let the breaker poison itself.
+const TERMINAL_STATUSES = [...DELIVERED_STATUSES, 'unknown'];
 
 /**
  * Is the cold circuit currently blocking sends? Returns true when the breaker is
@@ -203,24 +206,33 @@ export async function evaluateColdCircuit(
 
   if (profile.coldCircuitState === 'open') {
     if (ackWasSuccess) {
-      // A cold send got through (the half-open probe worked) → recovered.
-      await prisma.profile.update({
-        where: { id: profileId },
+      // Half-open probe delivered → recovered. CAS guarded to 'open' so only the
+      // ack that actually performs the transition returns 'closed' (no double-alert).
+      const r = await prisma.profile.updateMany({
+        where: { id: profileId, coldCircuitState: 'open' },
         data: { coldCircuitState: 'closed', coldCircuitOpenedAt: null },
       });
-      return 'closed';
+      return r.count === 1 ? 'closed' : null;
     }
-    // Still failing → re-arm the cooldown so it doesn't half-open immediately.
-    await prisma.profile.update({
-      where: { id: profileId },
+    // Still failing → re-arm the cooldown so it doesn't immediately half-open again.
+    await prisma.profile.updateMany({
+      where: { id: profileId, coldCircuitState: 'open' },
       data: { coldCircuitOpenedAt: new Date() },
     });
     return null;
   }
 
-  // Closed: open only when the recent terminal cold outcomes are mostly failures.
+  // Closed: open only when the recent REAL (transmitted) cold outcomes are mostly
+  // failures. Exclude never-transmitted rows — policy 429s and engine-throw failures
+  // keep the `pending_` placeholder id — so the breaker never counts its own blocks.
   const recent = await prisma.message.findMany({
-    where: { profileId, lane: 'cold', direction: 'outgoing', status: { in: TERMINAL_STATUSES } },
+    where: {
+      profileId,
+      lane: 'cold',
+      direction: 'outgoing',
+      status: { in: TERMINAL_STATUSES },
+      NOT: { messageId: { startsWith: 'pending_' } },
+    },
     orderBy: { createdAt: 'desc' },
     take: COLD_CIRCUIT_WINDOW,
     select: { status: true },
@@ -228,11 +240,11 @@ export async function evaluateColdCircuit(
   if (recent.length < COLD_CIRCUIT_MIN_SAMPLES) return null;
   const delivered = recent.filter((m) => DELIVERED_STATUSES.includes(m.status)).length;
   if (delivered / recent.length < COLD_CIRCUIT_MIN_SUCCESS) {
-    await prisma.profile.update({
-      where: { id: profileId },
+    const r = await prisma.profile.updateMany({
+      where: { id: profileId, coldCircuitState: 'closed' },
       data: { coldCircuitState: 'open', coldCircuitOpenedAt: new Date() },
     });
-    return 'opened';
+    return r.count === 1 ? 'opened' : null;
   }
   return null;
 }
@@ -337,12 +349,22 @@ export class SendGateService {
 
     // 3a. Cold circuit breaker: pause cold sends while open (delivery is failing /
     // the number is reach-out-locked). Replies are never blocked here.
-    if (isCold && isColdCircuitBlocking(profile.coldCircuitState, profile.coldCircuitOpenedAt, now)) {
-      const retryAt = new Date((profile.coldCircuitOpenedAt?.getTime() ?? now.getTime()) + COLD_CIRCUIT_COOLDOWN_MS);
-      throw new HttpException(
-        { error: 'COLD_CIRCUIT_OPEN', lane: 'cold', retryAt },
-        HttpStatus.TOO_MANY_REQUESTS,
-      );
+    if (isCold && profile.coldCircuitState === 'open') {
+      if (isColdCircuitBlocking(profile.coldCircuitState, profile.coldCircuitOpenedAt, now)) {
+        const retryAt = new Date((profile.coldCircuitOpenedAt?.getTime() ?? now.getTime()) + COLD_CIRCUIT_COOLDOWN_MS);
+        throw new HttpException({ error: 'COLD_CIRCUIT_OPEN', lane: 'cold', retryAt }, HttpStatus.TOO_MANY_REQUESTS);
+      }
+      // Cooldown elapsed → admit exactly ONE half-open probe. CAS on openedAt so a
+      // concurrent burst can't all probe; the winner re-arms the cooldown, and its
+      // ack will close (recovered) or re-arm the breaker.
+      const claim = await prisma.profile.updateMany({
+        where: { id: profileId, coldCircuitState: 'open', coldCircuitOpenedAt: profile.coldCircuitOpenedAt },
+        data: { coldCircuitOpenedAt: now },
+      });
+      if (claim.count !== 1) {
+        const retryAt = new Date(now.getTime() + COLD_CIRCUIT_COOLDOWN_MS);
+        throw new HttpException({ error: 'COLD_CIRCUIT_OPEN', lane: 'cold', retryAt }, HttpStatus.TOO_MANY_REQUESTS);
+      }
     }
 
     const cap = effectiveCapForLane(profile, isCold, now);


### PR DESCRIPTION
## What & why

Phase 2 of the Send Policy Engine turns the manual "is this number locked?"
diagnosis into **automatic protection**. When cold (business-initiated) sends
stop being delivered — the classic sign of a WhatsApp reach-out lock — MultiWA
auto-pauses the **cold lane** while **replies keep flowing**, and alerts the org.

## How it works
- Each outbound send persists its `lane` (service|cold), classified once in
  `queueMessage` and threaded to the gate (`executeWithGate` gains `isCold`).
- On a COLD message's **first terminal ack**, `evaluateColdCircuit` re-scores the
  breaker from the last `COLD_CIRCUIT_WINDOW` (10) **transmitted** terminal cold
  outcomes (`delivered`/`read`/`played` = success, `unknown` = failure). It opens
  when the success rate < `COLD_CIRCUIT_MIN_SUCCESS` (0.4) over ≥
  `COLD_CIRCUIT_MIN_SAMPLES` (5).
- **While open:** cold sends → `429 COLD_CIRCUIT_OPEN`; replies unaffected. A
  `SYSTEM` org alert fires on open ("paused") and close ("recovered").
- **Half-open:** after `COLD_CIRCUIT_COOLDOWN_MS` (30 min) the gate admits exactly
  one probe (CAS on `openedAt`); its ack closes or re-arms the breaker.
- All thresholds env-overridable.

## Correctness (from adversarial review — 5 confirmed fixes in commit 2)
- Health signal **excludes never-transmitted rows** (policy 429s keep a
  `pending_` id) so the breaker never counts its own blocks.
- **Evaluated once per message** (first terminal transition) — no flap / alert spam.
- **Atomic** open/close/re-arm (compare-and-set); alert only on the real transition.
- **Single** half-open probe per cooldown (CAS).
- Durable `deliverQueued` passes the persisted lane into the gate.

## Deploy note
Deploy **api + worker + admin**. `prisma db push` adds `Message.lane`,
`Profile.coldCircuitState/coldCircuitOpenedAt` + an index. On a large populated
`messages` table, **pre-seed the index CONCURRENTLY** before recreating api:
`CREATE INDEX CONCURRENTLY IF NOT EXISTS "messages_profileId_lane_createdAt_idx" ON "messages" ("profileId","lane","createdAt");`

## Testing
- Pure breaker logic verified; api + worker + admin typecheck clean; contract in
  sync (216). Live breaker test on deploy.