### PR TITLE
feat(send-policy): OTP delivery-confirmed failover (Phase 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,33 @@ S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minio
 S3_SECRET_KEY=minio123
 S3_BUCKET=multiwa-media
+
+# ==============================================
+# SEND POLICY ENGINE (anti-ban pacing + cold circuit) — all optional
+# ==============================================
+# Cold-lane default daily cap when a profile sets neither coldDailyLimit nor dailyMessageLimit.
+COLD_DEFAULT_DAILY_LIMIT=250
+# Cold circuit breaker: opens when <MIN_SUCCESS of the last WINDOW terminal cold acks
+# were delivered (min SAMPLES), and half-opens after COOLDOWN_MS.
+COLD_CIRCUIT_WINDOW=10
+COLD_CIRCUIT_MIN_SUCCESS=0.4
+COLD_CIRCUIT_MIN_SAMPLES=5
+COLD_CIRCUIT_COOLDOWN_MS=1800000
+
+# ==============================================
+# OTP FAILOVER (Phase 3) — secondary template channel, all optional
+# ==============================================
+# How long to wait for a delivered/read ack on the primary WhatsApp number before
+# failing over to the secondary channel.
+OTP_ACK_TIMEOUT_MS=8000
+# Secondary channel = a generic template-send HTTP endpoint (any provider). Leave
+# OTP_FALLBACK_URL empty to disable failover. Values are deployment-specific.
+OTP_FALLBACK_URL=
+OTP_FALLBACK_COMPANY_UUID=
+OTP_FALLBACK_TEMPLATE_UUID=
+OTP_FALLBACK_CHATBOT_UUID=
+OTP_FALLBACK_VAR_KEY={{1}}
+# Optional auth header — set both only if the provider authenticates via a header
+# (e.g. OTP_FALLBACK_AUTH_HEADER=Authorization, OTP_FALLBACK_TOKEN="Bearer <token>").
+OTP_FALLBACK_AUTH_HEADER=
+OTP_FALLBACK_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -107,3 +107,5 @@ OTP_FALLBACK_VAR_KEY={{1}}
 # (e.g. OTP_FALLBACK_AUTH_HEADER=Authorization, OTP_FALLBACK_TOKEN="Bearer <token>").
 OTP_FALLBACK_AUTH_HEADER=
 OTP_FALLBACK_TOKEN=
+# Abort the fallback HTTP request if the provider doesn't respond in time.
+OTP_FALLBACK_TIMEOUT_MS=10000

--- a/apps/api/src/modules/messages/dto/index.ts
+++ b/apps/api/src/modules/messages/dto/index.ts
@@ -58,6 +58,25 @@ export class SendMessageResponse {
   status: string;
 }
 
+// OTP with delivery-confirmed failover to a secondary channel (Send Policy Phase 3).
+export class SendOtpDto extends BaseMessageDto {
+  @ApiProperty({
+    example: 'Kode OTP Anda: 563842. Jangan bagikan kode ini kepada siapa pun.',
+    description: 'The OTP message text sent over the primary (unofficial) WhatsApp number.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  text: string;
+
+  @ApiProperty({
+    example: '563842',
+    description: 'The OTP code substituted into the fallback template variable when failing over.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  code: string;
+}
+
 // Text message
 export class SendTextDto extends BaseMessageDto {
   @ApiProperty({ example: 'Hello, World!' })

--- a/apps/api/src/modules/messages/messages.controller.ts
+++ b/apps/api/src/modules/messages/messages.controller.ts
@@ -1,7 +1,7 @@
 // MultiWA Gateway - Enhanced Messages Controller
 // apps/api/src/modules/messages/messages.controller.ts
 
-import { Controller, Get, Post, Delete, Put, Body, Param, Query, UseGuards, Req, applyDecorators } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Put, Body, Param, Query, UseGuards, Req, applyDecorators, HttpException, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiSecurity, ApiQuery, ApiCreatedResponse } from '@nestjs/swagger';
 import { ApiAuthErrors, ApiValidationError, ApiRateLimited, ApiNotFound } from '../../common/decorators/api-responses';
 import { MessagesService } from './messages.service';
@@ -81,9 +81,17 @@ export class MessagesController {
       action: AuditAction.MESSAGE_SEND,
       userId: req.user?.id,
       resourceType: 'message',
-      metadata: { type: 'otp', profileId: dto.profileId, to: dto.to, channel: result.channel },
+      metadata: { type: 'otp', profileId: dto.profileId, to: dto.to, channel: result.channel, success: result.success },
       ...AuditService.fromRequest(req),
     }).catch(() => {});
+    // Total delivery failure (no channel delivered) must surface as a non-2xx so
+    // callers that gate on HTTP status don't treat an undelivered OTP as sent.
+    if (!result.success) {
+      throw new HttpException(
+        { error: 'OTP_DELIVERY_FAILED', channel: result.channel, reason: result.reason },
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
     return result;
   }
 

--- a/apps/api/src/modules/messages/messages.controller.ts
+++ b/apps/api/src/modules/messages/messages.controller.ts
@@ -24,7 +24,9 @@ import {
   DeleteForEveryoneDto,
   ScheduleMessageDto,
   SendMessageResponse,
+  SendOtpDto,
 } from './dto';
+import { OtpService } from './otp.service';
 import { AuditService, AuditAction } from '../audit/audit.service';
 
 // Composite for the send endpoints: operation summary + the queued 201 response +
@@ -46,6 +48,7 @@ const ApiSend = (summary: string, description?: string) =>
 export class MessagesController {
   constructor(
     private readonly service: MessagesService,
+    private readonly otp: OtpService,
     private readonly auditService: AuditService,
   ) {}
 
@@ -60,6 +63,25 @@ export class MessagesController {
       userId: req.user?.id,
       resourceType: 'message',
       metadata: { type: 'text', profileId: dto.profileId, to: dto.to },
+      ...AuditService.fromRequest(req),
+    }).catch(() => {});
+    return result;
+  }
+
+  // Send OTP with delivery-confirmed failover to a secondary channel.
+  @Post('otp')
+  @RequireTenant({ from: 'body', key: 'profileId', resource: 'profile' })
+  @ApiSend(
+    'Send an OTP with failover',
+    'Sends the OTP over the primary WhatsApp number; if the cold circuit is open or delivery is not confirmed within the ack timeout, it fails over to the configured secondary template channel. Returns which channel delivered it.',
+  )
+  async sendOtp(@Body() dto: SendOtpDto, @Req() req: any) {
+    const result = await this.otp.sendOtp(dto.profileId, dto.to, dto.text, dto.code);
+    this.auditService.log({
+      action: AuditAction.MESSAGE_SEND,
+      userId: req.user?.id,
+      resourceType: 'message',
+      metadata: { type: 'otp', profileId: dto.profileId, to: dto.to, channel: result.channel },
       ...AuditService.fromRequest(req),
     }).catch(() => {});
     return result;

--- a/apps/api/src/modules/messages/messages.module.ts
+++ b/apps/api/src/modules/messages/messages.module.ts
@@ -5,6 +5,7 @@ import { Queue } from 'bullmq';
 import IORedis from 'ioredis';
 import { MessagesController } from './messages.controller';
 import { MessagesService } from './messages.service';
+import { OtpService } from './otp.service';
 import { ScheduledMessageCron } from './scheduled-message.cron';
 import { SendGateService } from '@multiwa/engine-runtime';
 import { DailyResetCron } from './daily-reset.cron';
@@ -17,6 +18,7 @@ import { ProfilesModule } from '../profiles/profiles.module';
   controllers: [MessagesController],
   providers: [
     MessagesService,
+    OtpService,
     ScheduledMessageCron,
     SendGateService,
     DailyResetCron,

--- a/apps/api/src/modules/messages/otp.service.ts
+++ b/apps/api/src/modules/messages/otp.service.ts
@@ -65,16 +65,33 @@ export class OtpService {
       send = await this.messages.sendText({ profileId, to, text } as any);
     } catch (err: any) {
       this.logger.warn(`OTP for ${profileId}: unofficial send rejected (${err?.message}) → fallback`);
-      return this.viaFallback(to, code, `whatsapp-rejected:${err?.message ?? 'error'}`);
+      return this.viaFallback(to, code, 'whatsapp-rejected');
     }
-    if (!send?.messageId) {
-      return this.viaFallback(to, code, 'whatsapp-no-message-id');
+    // Fail over IMMEDIATELY on a synchronously-known non-delivery (soft-fail, or the
+    // message was only enqueued / the profile is offline) — don't burn the ack timeout.
+    // NB: reliable per-OTP confirmation assumes synchronous send mode
+    // (ENGINE_HOST=api, DURABLE_SEND off); in durable mode the primary is only queued.
+    if (!send?.messageId || send?.success === false || send?.status === 'failed' || send?.status === 'pending') {
+      return this.viaFallback(to, code, 'whatsapp-not-sent');
     }
 
     // Wait for a delivered/read ack; failover if it doesn't confirm in time.
-    const delivered = await this.waitForDelivery(send.messageId, this.ackTimeoutMs);
-    if (delivered) {
+    if (await this.waitForDelivery(send.messageId, this.ackTimeoutMs)) {
       return { success: true, channel: 'whatsapp', messageId: send.messageId, waMessageId: send.waMessageId };
+    }
+    // Final status recheck closes the poll gap so a just-delivered OTP doesn't double-send.
+    const late = await prisma.message.findUnique({ where: { id: send.messageId }, select: { status: true } });
+    if (late && (late.status === 'delivered' || late.status === 'read' || late.status === 'played')) {
+      return { success: true, channel: 'whatsapp', messageId: send.messageId, waMessageId: send.waMessageId };
+    }
+    // Best-effort recall of the primary before failover: both messages carry the same
+    // code, so deleting a late-delivered copy is harmless. Non-fatal.
+    if (send.waMessageId) {
+      try {
+        await this.messages.deleteForEveryone(profileId, to, send.waMessageId);
+      } catch (e: any) {
+        this.logger.warn(`OTP primary recall failed: ${e?.message}`);
+      }
     }
     this.logger.warn(`OTP for ${profileId}: not confirmed within ${this.ackTimeoutMs}ms → fallback`);
     return this.viaFallback(to, code, 'whatsapp-not-delivered');
@@ -93,6 +110,24 @@ export class OtpService {
   }
 
   /**
+   * Extract a plain phone number (digits) for the template channel, or null when
+   * the recipient is a non-phone JID (@lid / @g.us / …) that has no phone form —
+   * `to.replace(/\D/g,'')` would otherwise mangle those into a bogus number.
+   */
+  private fallbackNumber(to: string): string | null {
+    const t = to.trim();
+    if (t.includes('@')) {
+      if (t.endsWith('@s.whatsapp.net') || t.endsWith('@c.us')) {
+        const digits = t.split('@')[0].split(':')[0].replace(/\D/g, '');
+        return digits.length >= 7 ? digits : null;
+      }
+      return null; // @lid, @g.us, @broadcast, @newsletter — no phone number
+    }
+    const digits = t.replace(/\D/g, '');
+    return digits.length >= 7 ? digits : null;
+  }
+
+  /**
    * Deliver the OTP via the generic template fallback channel. Endpoint,
    * credentials and template identifiers are all read from environment variables;
    * the request body mirrors a standard template-send API. An optional auth header
@@ -105,7 +140,11 @@ export class OtpService {
       this.logger.error(`OTP fallback requested (${reason}) but OTP_FALLBACK_URL is not configured`);
       return { success: false, channel: 'fallback', reason, error: 'fallback-not-configured' };
     }
-    const number = to.replace(/\D/g, '');
+    const number = this.fallbackNumber(to);
+    if (!number) {
+      this.logger.error(`OTP fallback (${reason}): recipient has no usable phone number`);
+      return { success: false, channel: 'fallback', reason, error: 'no-phone-number' };
+    }
     const varKey = this.config.get<string>('OTP_FALLBACK_VAR_KEY') || '{{1}}';
     const body = {
       company_uuid: this.config.get<string>('OTP_FALLBACK_COMPANY_UUID'),
@@ -119,7 +158,13 @@ export class OtpService {
     if (authHeader && token) headers[authHeader] = token;
 
     try {
-      const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+      const timeoutMs = Number(this.config.get('OTP_FALLBACK_TIMEOUT_MS')) || 10000;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
       const ok = res.ok;
       if (!ok) {
         const detail = (await res.text().catch(() => '')).slice(0, 200);

--- a/apps/api/src/modules/messages/otp.service.ts
+++ b/apps/api/src/modules/messages/otp.service.ts
@@ -1,0 +1,134 @@
+// MultiWA Gateway - OTP send with delivery-confirmed failover (Send Policy Phase 3)
+// apps/api/src/modules/messages/otp.service.ts
+//
+// Sends an OTP over the primary (unofficial) WhatsApp number and, when that path
+// is unreliable, fails over to a secondary template channel (an official
+// authentication-template provider). The secondary channel is fully generic and
+// configured ONLY through environment variables — no provider name or credential
+// lives in this repository.
+//
+// Failover policy (operator-approved):
+//   - cold circuit OPEN (the number is known to be reach-out-locked) → go straight
+//     to the fallback channel (don't waste an attempt).
+//   - otherwise → send via the unofficial number, wait up to OTP_ACK_TIMEOUT_MS for
+//     a delivered/read ack; if it isn't confirmed (or the send is rejected) → fail
+//     over to the fallback channel.
+
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { prisma } from '@multiwa/database';
+import { MessagesService } from './messages.service';
+
+export interface OtpResult {
+  success: boolean;
+  channel: 'whatsapp' | 'fallback';
+  reason?: string;
+  messageId?: string;
+  waMessageId?: string;
+  fallbackStatus?: number;
+  error?: string;
+}
+
+@Injectable()
+export class OtpService {
+  private readonly logger = new Logger(OtpService.name);
+
+  constructor(
+    private readonly messages: MessagesService,
+    private readonly config: ConfigService,
+  ) {}
+
+  private get ackTimeoutMs(): number {
+    return Number(this.config.get('OTP_ACK_TIMEOUT_MS')) || 8000;
+  }
+
+  /**
+   * Send an OTP. `text` is the plain WhatsApp message for the unofficial path;
+   * `code` is the value substituted into the fallback template variable.
+   */
+  async sendOtp(profileId: string, to: string, text: string, code: string): Promise<OtpResult> {
+    const profile = await prisma.profile.findUnique({
+      where: { id: profileId },
+      select: { coldCircuitState: true },
+    });
+    if (!profile) throw new NotFoundException('Profile not found');
+
+    // Circuit open → the number is reach-out-locked; skip straight to the fallback.
+    if (profile.coldCircuitState === 'open') {
+      this.logger.warn(`OTP for ${profileId}: cold circuit open → fallback channel`);
+      return this.viaFallback(to, code, 'cold-circuit-open');
+    }
+
+    // Try the unofficial number first.
+    let send: any;
+    try {
+      send = await this.messages.sendText({ profileId, to, text } as any);
+    } catch (err: any) {
+      this.logger.warn(`OTP for ${profileId}: unofficial send rejected (${err?.message}) → fallback`);
+      return this.viaFallback(to, code, `whatsapp-rejected:${err?.message ?? 'error'}`);
+    }
+    if (!send?.messageId) {
+      return this.viaFallback(to, code, 'whatsapp-no-message-id');
+    }
+
+    // Wait for a delivered/read ack; failover if it doesn't confirm in time.
+    const delivered = await this.waitForDelivery(send.messageId, this.ackTimeoutMs);
+    if (delivered) {
+      return { success: true, channel: 'whatsapp', messageId: send.messageId, waMessageId: send.waMessageId };
+    }
+    this.logger.warn(`OTP for ${profileId}: not confirmed within ${this.ackTimeoutMs}ms → fallback`);
+    return this.viaFallback(to, code, 'whatsapp-not-delivered');
+  }
+
+  /** Poll the message row until it is delivered/read, or the timeout elapses. */
+  private async waitForDelivery(messageDbId: string, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    const step = 800;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, step));
+      const row = await prisma.message.findUnique({ where: { id: messageDbId }, select: { status: true } });
+      if (row && (row.status === 'delivered' || row.status === 'read' || row.status === 'played')) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Deliver the OTP via the generic template fallback channel. Endpoint,
+   * credentials and template identifiers are all read from environment variables;
+   * the request body mirrors a standard template-send API. An optional auth header
+   * is added only when configured, so channels that authenticate via body
+   * identifiers work without one.
+   */
+  private async viaFallback(to: string, code: string, reason: string): Promise<OtpResult> {
+    const url = this.config.get<string>('OTP_FALLBACK_URL');
+    if (!url) {
+      this.logger.error(`OTP fallback requested (${reason}) but OTP_FALLBACK_URL is not configured`);
+      return { success: false, channel: 'fallback', reason, error: 'fallback-not-configured' };
+    }
+    const number = to.replace(/\D/g, '');
+    const varKey = this.config.get<string>('OTP_FALLBACK_VAR_KEY') || '{{1}}';
+    const body = {
+      company_uuid: this.config.get<string>('OTP_FALLBACK_COMPANY_UUID'),
+      template_uuid: this.config.get<string>('OTP_FALLBACK_TEMPLATE_UUID'),
+      chat_bot_uuid: this.config.get<string>('OTP_FALLBACK_CHATBOT_UUID'),
+      contacts: [{ number, variabel: { [varKey]: code } }],
+    };
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const authHeader = this.config.get<string>('OTP_FALLBACK_AUTH_HEADER');
+    const token = this.config.get<string>('OTP_FALLBACK_TOKEN');
+    if (authHeader && token) headers[authHeader] = token;
+
+    try {
+      const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+      const ok = res.ok;
+      if (!ok) {
+        const detail = (await res.text().catch(() => '')).slice(0, 200);
+        this.logger.error(`OTP fallback POST failed http=${res.status} ${detail}`);
+      }
+      return { success: ok, channel: 'fallback', reason, fallbackStatus: res.status };
+    } catch (err: any) {
+      this.logger.error(`OTP fallback POST threw: ${err?.message}`);
+      return { success: false, channel: 'fallback', reason, error: err?.message ?? 'fallback-request-failed' };
+    }
+  }
+}

--- a/docs/07-api-specification.md
+++ b/docs/07-api-specification.md
@@ -133,6 +133,7 @@ The tables below mirror the `@Controller(...)` decorators in `apps/api/src/`. Us
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/messages/text` | Send text message |
+| `POST` | `/messages/otp` | Send an OTP with delivery-confirmed failover to a secondary channel |
 | `POST` | `/messages/image` | Send image |
 | `POST` | `/messages/video` | Send video |
 | `POST` | `/messages/audio` | Send audio/voice |

--- a/docs/send-policy-engine.md
+++ b/docs/send-policy-engine.md
@@ -185,16 +185,24 @@ success, `unknown`/`failed` = failure.
 - All thresholds are env-overridable. Per-send OTP confirmation + failover is
   Phase 3.
 
-## 7. Phase 3 — Pluggable multi-channel failover (outline)
-- `SendChannel` interface: `whatsapp-web-js` (unofficial, primary), an optional
-  secondary channel, and optional SMS. The interface is generic; any concrete
-  channel is provided by the operator.
-- Per-category routing + failover: OTP primary = unofficial number; on
-  non-confirmation, fail over to a secondary channel (e.g. an official
-  authentication-template channel, reliable for OTP with no reach-out-lock).
-- All channel endpoints and credentials are read from environment variables
-  only, never committed. Concrete provider wiring (endpoints, account IDs,
-  tokens) is deployment-specific and lives outside this repository.
+## 7. Phase 3 — OTP delivery-confirmed failover (implemented)
+`POST /messages/otp` sends an OTP with automatic failover to a generic secondary
+template channel:
+
+- **Cold circuit open** → straight to the secondary channel (the number is
+  reach-out-locked; don't waste an attempt).
+- **Otherwise** → send over the primary (unofficial) number, wait up to
+  `OTP_ACK_TIMEOUT_MS` (8 s) for a delivered/read ack; if it isn't confirmed, or
+  the send is rejected (cold cap / circuit), fail over to the secondary channel.
+- The response reports which channel delivered it (`whatsapp` | `fallback`).
+
+The secondary channel is a **generic** template-send HTTP adapter configured
+entirely through env: `OTP_FALLBACK_URL`, `OTP_FALLBACK_COMPANY_UUID`,
+`OTP_FALLBACK_TEMPLATE_UUID`, `OTP_FALLBACK_CHATBOT_UUID`, `OTP_FALLBACK_VAR_KEY`,
+and an **optional** auth header (`OTP_FALLBACK_AUTH_HEADER` + `OTP_FALLBACK_TOKEN`)
+for providers that require one. Leaving `OTP_FALLBACK_URL` empty disables failover.
+No provider name, endpoint, or credential lives in this repository — concrete
+wiring is deployment-specific (server `.env` only).
 
 ---
 

--- a/docs/send-policy-engine.md
+++ b/docs/send-policy-engine.md
@@ -199,10 +199,26 @@ template channel:
 The secondary channel is a **generic** template-send HTTP adapter configured
 entirely through env: `OTP_FALLBACK_URL`, `OTP_FALLBACK_COMPANY_UUID`,
 `OTP_FALLBACK_TEMPLATE_UUID`, `OTP_FALLBACK_CHATBOT_UUID`, `OTP_FALLBACK_VAR_KEY`,
-and an **optional** auth header (`OTP_FALLBACK_AUTH_HEADER` + `OTP_FALLBACK_TOKEN`)
-for providers that require one. Leaving `OTP_FALLBACK_URL` empty disables failover.
-No provider name, endpoint, or credential lives in this repository — concrete
-wiring is deployment-specific (server `.env` only).
+`OTP_FALLBACK_TIMEOUT_MS`, and an **optional** auth header
+(`OTP_FALLBACK_AUTH_HEADER` + `OTP_FALLBACK_TOKEN`) for providers that require one.
+Leaving `OTP_FALLBACK_URL` empty disables failover. No provider name, endpoint, or
+credential lives in this repository — concrete wiring is deployment-specific
+(server `.env` only).
+
+Hardening applied: immediate failover on a synchronously-known non-delivery (no
+wasted ack wait); a final status recheck + best-effort `deleteForEveryone` recall
+before failover to reduce duplicate OTPs; an abort timeout on the fallback HTTP
+call; recipient JIDs without a phone form (`@lid`/`@g.us`) are rejected for the
+template channel; and total delivery failure returns HTTP 502 (not a 200 with
+`success:false`).
+
+**Known limitations / follow-ups:** (1) reliable per-OTP confirmation assumes
+**synchronous send mode** (`ENGINE_HOST=api`, `DURABLE_SEND` off) — in durable
+mode the primary is only enqueued, so it fails over immediately. (2) The fallback
+channel does **not** count against the per-profile cold cap / circuit, so OTP
+volume is bounded only by the endpoint's auth + the provider's own limits; a
+dedicated per-profile fallback quota is a possible follow-up. (3) A late-delivered
+primary can still race the recall (at-least-once OTP delivery).
 
 ---
 

--- a/scripts/api-routes.snapshot.json
+++ b/scripts/api-routes.snapshot.json
@@ -7,7 +7,7 @@
     "@ApiExcludeController()",
     "@ApiExcludeEndpoint()"
   ],
-  "routeCount": 216,
+  "routeCount": 217,
   "routes": [
     {
       "method": "DELETE",
@@ -560,6 +560,10 @@
     {
       "method": "POST",
       "path": "/api/v1/messages/mark-read"
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/messages/otp"
     },
     {
       "method": "POST",


### PR DESCRIPTION
## What & why
Phase 3 completes the Send Policy Engine: **OTP reliability**. `POST /messages/otp`
sends an OTP over the primary (unofficial) WhatsApp number and **fails over** to a
generic secondary template channel when the primary can't deliver — so login OTP
still arrives even when the number is reach-out-locked.

## Failover policy (operator-approved)
- **Cold circuit OPEN** → straight to the secondary channel (don't waste an attempt).
- **Otherwise** → send via the unofficial number, wait up to `OTP_ACK_TIMEOUT_MS`
  (8 s) for a delivered/read ack; if unconfirmed or the send is rejected (cold cap /
  circuit) → fail over. Response reports the delivering channel (`whatsapp` | `fallback`).

## Generic + private-safe
The secondary channel is a **generic** template-send HTTP adapter, configured
entirely via env (`OTP_FALLBACK_URL`, `_COMPANY_UUID`, `_TEMPLATE_UUID`,
`_CHATBOT_UUID`, `_VAR_KEY`) with an **optional** auth header
(`OTP_FALLBACK_AUTH_HEADER` + `_TOKEN`). **No provider name, endpoint, or
credential is in this repo** — concrete wiring is server `.env` only. Empty
`OTP_FALLBACK_URL` disables failover.

## Scope
- api-only (wagw `ENGINE_HOST=api`): engine send + ack wait + HTTP failover all in api.
- New: `otp.service.ts`, `SendOtpDto`, `POST /messages/otp`, module provider.
- API contract in sync (217 routes + docs row); `.env.example` documents the knobs.

## Testing
- api typecheck clean; contract green. Live OTP test on deploy (with server `.env`
  fallback config).