### PR TITLE
fix(compose): run worker in production + fix WhatsApp session volume path

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -88,14 +88,58 @@ services:
       S3_REGION: ${S3_REGION:-us-east-1}
       WHATSAPP_ENGINE: ${WHATSAPP_ENGINE:-whatsapp-web.js}
       CHROMIUM_PATH: /usr/bin/chromium
+      # WhatsApp sessions are written under SESSIONS_DIR (see engine-manager +
+      # whatsapp-web.js LocalAuth dataPath). Must match the volume mount below,
+      # or logins are lost on every container recreate.
+      SESSIONS_DIR: /data/sessions
     volumes:
-      - wa_sessions:/app/.wwebjs_auth
+      - wa_sessions:/data/sessions
     healthcheck:
       test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/api/v1/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+    networks:
+      - internal
+
+  # ─── Background Worker (BullMQ) ─────────────────
+  # Drains durable webhook delivery + background jobs. Without this the queues
+  # fill and webhooks are never delivered. Shares the API's sessions volume so a
+  # future ENGINE_HOST=worker cut-over can host the engine here; with the default
+  # ENGINE_HOST=api it only processes queues.
+  worker:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgresql://${DB_USER:-multiwa}:${DB_PASSWORD}@postgres:5432/${DB_NAME:-multiwa}
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+      ENGINE_HOST: ${ENGINE_HOST:-api}
+      WHATSAPP_ENGINE: ${WHATSAPP_ENGINE:-whatsapp-web.js}
+      DEFAULT_ENGINE: ${WHATSAPP_ENGINE:-whatsapp-web.js}
+      PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      SESSIONS_DIR: /data/sessions
+      S3_ENDPOINT: http://minio:9000
+      S3_PORT: 9000
+      S3_USE_SSL: "false"
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY}
+      S3_SECRET_KEY: ${S3_SECRET_KEY}
+      S3_BUCKET: ${S3_BUCKET:-multiwa}
+      S3_REGION: ${S3_REGION:-us-east-1}
+      WEBHOOK_LOG_PAYLOAD_MAX_BYTES: ${WEBHOOK_LOG_PAYLOAD_MAX_BYTES:-512}
+    volumes:
+      - wa_sessions:/data/sessions
     networks:
       - internal
 


### PR DESCRIPTION
## Problems

`docker-compose.production.yml` had two production-breaking gaps:

1. **No `worker` service.** The base `docker-compose.yml` runs a BullMQ worker (durable webhook delivery + background jobs), but the production stack never started one. Result: webhook delivery queues fill and never drain in production.
2. **WhatsApp sessions not persisted.** The `api` mounted `wa_sessions` at `/app/.wwebjs_auth`, but the engine writes sessions under `SESSIONS_DIR` (default `/data/sessions` — see `engine-manager.service.ts` and the whatsapp-web.js `LocalAuth` `dataPath`). So sessions were written to **ephemeral container storage** and lost on every `up --force-recreate` — users had to re-scan the QR after each redeploy.

## Fix

- Add a `worker` service using `docker/Dockerfile.worker`, mirroring the base compose worker (ENGINE_HOST defaults to `api`, so it only drains queues) with the production DB/Redis/S3 wiring, on the `internal` network, sharing the sessions volume.
- Mount `wa_sessions` at `/data/sessions` on **both** `api` and `worker`, and set `SESSIONS_DIR=/data/sessions` explicitly on the `api` so sessions land on the persistent volume and survive recreates.

## Verification

- `docker compose -f docker-compose.production.yml config` → **VALID**.
- Confirmed `SESSIONS_DIR` is the env the code reads (`apps/api/src/modules/profiles/engine-manager.service.ts`; default `/data/sessions`), and that whatsapp-web.js `LocalAuth.dataPath` is derived from it (`packages/engines/src/adapters/whatsapp-webjs.adapter.ts`).
- api and worker now mount the same volume at the same path, so a future `ENGINE_HOST=worker` cut-over sees the same session files.

No application code changed.