### PR TITLE
fix(security): gate org member-management behind owner/admin role

### DIFF
--- a/apps/api/src/modules/auth/decorators/roles.decorator.ts
+++ b/apps/api/src/modules/auth/decorators/roles.decorator.ts
@@ -1,0 +1,15 @@
+// MultiWA Gateway API - Roles Decorator
+// apps/api/src/modules/auth/decorators/roles.decorator.ts
+
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+
+/**
+ * Restrict a route (or controller) to callers whose organization role is one of
+ * `roles`. Enforced by RolesGuard, which reads `req.user.role`. Org roles:
+ * `owner`, `admin`, `member`, `viewer`.
+ *
+ * Example: `@Roles('owner', 'admin')`
+ */
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/modules/auth/guards/roles.guard.spec.ts
+++ b/apps/api/src/modules/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,54 @@
+// RolesGuard Unit Tests
+// Verifies fail-closed role enforcement for @Roles(...)-decorated routes.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import type { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+
+// Build a minimal ExecutionContext whose request carries `user`.
+function makeContext(user: any): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    getHandler: () => () => undefined,
+    getClass: () => class {},
+  } as unknown as ExecutionContext;
+}
+
+function makeGuard(required: string[] | undefined) {
+  const reflector = { getAllAndOverride: vi.fn().mockReturnValue(required) } as unknown as Reflector;
+  return new RolesGuard(reflector);
+}
+
+describe('RolesGuard', () => {
+  it('allows routes with no @Roles metadata', () => {
+    expect(makeGuard(undefined).canActivate(makeContext(undefined))).toBe(true);
+  });
+
+  it('allows routes with an empty required-roles list', () => {
+    expect(makeGuard([]).canActivate(makeContext({ role: 'member' }))).toBe(true);
+  });
+
+  it('allows a caller whose role is in the required set', () => {
+    expect(makeGuard(['owner', 'admin']).canActivate(makeContext({ role: 'admin' }))).toBe(true);
+  });
+
+  it('denies a caller whose role is not in the required set', () => {
+    expect(() =>
+      makeGuard(['owner', 'admin']).canActivate(makeContext({ role: 'member' })),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('denies when the role is missing (fail closed)', () => {
+    expect(() =>
+      makeGuard(['owner', 'admin']).canActivate(makeContext({})),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('denies when there is no authenticated user (fail closed)', () => {
+    expect(() =>
+      makeGuard(['owner', 'admin']).canActivate(makeContext(undefined)),
+    ).toThrow(ForbiddenException);
+  });
+});

--- a/apps/api/src/modules/auth/guards/roles.guard.ts
+++ b/apps/api/src/modules/auth/guards/roles.guard.ts
@@ -1,0 +1,34 @@
+// MultiWA Gateway API - Roles Guard
+// apps/api/src/modules/auth/guards/roles.guard.ts
+
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+/**
+ * Enforces `@Roles(...)` metadata. Routes with no `@Roles` are unrestricted
+ * (so a controller can mix public-to-members reads with role-gated mutations).
+ * Must run after an auth guard that populates `req.user` (e.g. JwtAuthGuard).
+ * Denies when the role is missing or not in the allowed set — fail closed.
+ */
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const required = this.reflector.getAllAndOverride<string[] | undefined>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!required || required.length === 0) {
+      return true;
+    }
+
+    const req = context.switchToHttp().getRequest();
+    const role = req.user?.role;
+    if (!role || !required.includes(role)) {
+      throw new ForbiddenException('Insufficient role for this action');
+    }
+    return true;
+  }
+}

--- a/apps/api/src/modules/organizations/organizations.controller.ts
+++ b/apps/api/src/modules/organizations/organizations.controller.ts
@@ -1,13 +1,15 @@
 // apps/api/src/modules/organizations/organizations.controller.ts
 import { Controller, Get, Post, Put, Delete, Body, Param, UseGuards, Request } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiSecurity, ApiForbiddenResponse } from '@nestjs/swagger';
 import { OrganizationsService } from './organizations.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
 import { ApiAuthErrors, ApiValidationError, ApiNotFound } from '../../common/decorators/api-responses';
 
 @ApiTags('Organizations')
 @Controller('organizations')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 @ApiBearerAuth()
 @ApiSecurity('api-key')
 @ApiAuthErrors()
@@ -21,7 +23,9 @@ export class OrganizationsController {
   }
 
   @Put('current')
+  @Roles('owner', 'admin')
   @ApiOperation({ summary: 'Update current organization' })
+  @ApiForbiddenResponse({ description: 'Requires owner or admin role' })
   @ApiValidationError()
   async update(@Request() req: any, @Body() dto: any) {
     return this.service.update(req.user.organizationId, dto);
@@ -36,14 +40,18 @@ export class OrganizationsController {
   }
 
   @Post('members')
+  @Roles('owner', 'admin')
   @ApiOperation({ summary: 'Invite/create a new member' })
+  @ApiForbiddenResponse({ description: 'Requires owner or admin role' })
   @ApiValidationError()
   async addMember(@Request() req: any, @Body() dto: { email: string; name: string; role?: string }) {
     return this.service.addMember(req.user.organizationId, dto);
   }
 
   @Put('members/:id/role')
+  @Roles('owner', 'admin')
   @ApiOperation({ summary: 'Update member role' })
+  @ApiForbiddenResponse({ description: 'Requires owner or admin role' })
   @ApiValidationError()
   @ApiNotFound('Member')
   async updateMemberRole(
@@ -55,7 +63,9 @@ export class OrganizationsController {
   }
 
   @Delete('members/:id')
+  @Roles('owner', 'admin')
   @ApiOperation({ summary: 'Remove member from organization' })
+  @ApiForbiddenResponse({ description: 'Requires owner or admin role' })
   @ApiNotFound('Member')
   async removeMember(@Request() req: any, @Param('id') memberId: string) {
     return this.service.removeMember(req.user.organizationId, req.user.id, memberId);

--- a/apps/api/src/modules/organizations/organizations.service.ts
+++ b/apps/api/src/modules/organizations/organizations.service.ts
@@ -3,8 +3,22 @@ import { Injectable, NotFoundException, BadRequestException, ForbiddenException 
 import { prisma } from '@multiwa/database';
 import * as bcrypt from 'bcrypt';
 
+// Roles that may be assigned through member-management endpoints. `owner` is
+// deliberately excluded: ownership is set when the org is created and is not
+// mintable here, so an admin can never escalate a member (or themselves) to
+// owner via addMember/updateMemberRole.
+const ASSIGNABLE_ROLES = ['admin', 'member', 'viewer'];
+
 @Injectable()
 export class OrganizationsService {
+  private assertAssignableRole(role: string | undefined) {
+    if (role !== undefined && !ASSIGNABLE_ROLES.includes(role)) {
+      throw new BadRequestException(
+        `Invalid role "${role}". Allowed: ${ASSIGNABLE_ROLES.join(', ')}`,
+      );
+    }
+  }
+
   async findById(id: string) {
     const org = await prisma.organization.findUnique({
       where: { id },
@@ -40,6 +54,8 @@ export class OrganizationsService {
   }
 
   async addMember(organizationId: string, dto: { email: string; name: string; role?: string }) {
+    this.assertAssignableRole(dto.role);
+
     // Check if email already used
     const existing = await prisma.user.findUnique({ where: { email: dto.email } });
     if (existing) {
@@ -72,6 +88,8 @@ export class OrganizationsService {
   }
 
   async updateMemberRole(organizationId: string, memberId: string, role: string) {
+    this.assertAssignableRole(role);
+
     const member = await prisma.user.findFirst({
       where: { id: memberId, organizationId },
     });


### PR DESCRIPTION
## Vulnerability (privilege escalation / broken access control)

`OrganizationsController` was guarded only by `JwtAuthGuard`. Every mutating endpoint was reachable by **any authenticated member**, regardless of role:

- `POST /organizations/members` — create a member (with `role: "owner"` / `"admin"`)
- `PUT /organizations/members/:id/role` — change any member's role, including **promoting yourself to owner**
- `DELETE /organizations/members/:id` — remove other members
- `PUT /organizations/current` — edit org settings

A plain `member` or `viewer` could take over the organization.

## Fix

- **New `@Roles(...)` decorator + `RolesGuard`** (`apps/api/src/modules/auth/`). The guard reads `req.user.role` (populated fresh from the DB in `JwtStrategy.validate`, so role changes take effect immediately) and **fails closed** — missing/unknown role → `403`. Routes without `@Roles` stay open, so reads still work for any member.
- **`@Roles('owner', 'admin')`** on the four mutating endpoints. `getCurrent` / `listMembers` remain readable by any member.
- **Defense-in-depth in the service**: `addMember` / `updateMemberRole` now reject assigning `owner` or any role outside `{admin, member, viewer}`, so an admin cannot mint a second owner even if the guard were bypassed. Existing owner protections (can't demote or remove the owner, can't remove yourself) are preserved.

## Tests / verification

- New `roles.guard.spec.ts` — 6 cases: no metadata → allow; empty list → allow; role in set → allow; role not in set → deny; missing role → deny; no user → deny. **All pass.**
- `tsc --noEmit` on `apps/api` is clean.

Role semantics come from the existing schema (`User.role`: `owner, admin, member, viewer`). No schema change.