### PR TITLE
fix(security): block SSRF in webhook + custom-AI delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,12 @@ PUPPETEER_NO_SANDBOX=false
 WEBHOOK_TIMEOUT_MS=30000
 WEBHOOK_RETRY_ATTEMPTS=3
 WEBHOOK_RETRY_DELAY_MS=5000
+# SSRF guard: by default webhook/custom-AI targets that resolve to loopback,
+# private, or link-local addresses are BLOCKED (cloud metadata is always
+# blocked). Self-hosted deployments that deliver to internal services on the
+# same network (Chatwoot, Typebot, n8n, localhost) set this to true to allow
+# private targets. Leave false for public / multi-tenant deployments.
+WEBHOOK_ALLOW_PRIVATE_TARGETS=false
 
 # ==============================================
 # STORAGE (Media files)

--- a/apps/api/src/modules/autoreply/autoreply.service.ts
+++ b/apps/api/src/modules/autoreply/autoreply.service.ts
@@ -3,6 +3,7 @@
 
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { prisma } from '@multiwa/database';
+import { assertWebhookUrlSafe } from '@multiwa/engine-runtime';
 import { CreateAutoreplyDto, UpdateAutoreplyDto, QuickReplyDto } from './dto';
 
 // In-memory storage for quick replies and configs (would be database in production)
@@ -192,7 +193,8 @@ export class AutoreplyService {
     if (!config.enabled || !config.webhookUrl) return null;
 
     try {
-      const response = await fetch(config.webhookUrl, {
+      const safeUrl = await assertWebhookUrlSafe(config.webhookUrl);
+      const response = await fetch(safeUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -200,6 +202,8 @@ export class AutoreplyService {
           profileId,
           message,
         }),
+        redirect: 'error',
+        signal: AbortSignal.timeout(30000),
       });
 
       if (!response.ok) return null;
@@ -293,13 +297,16 @@ export class AutoreplyService {
   // Custom AI endpoint
   private async callCustomAI(cfg: any, message: string, context?: any): Promise<string | null> {
     try {
-      const response = await fetch(cfg.endpoint, {
+      const safeEndpoint = await assertWebhookUrlSafe(cfg.endpoint);
+      const response = await fetch(safeEndpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           ...(cfg.headers || {}),
         },
         body: JSON.stringify({ message, context, ...cfg.body }),
+        redirect: 'error',
+        signal: AbortSignal.timeout(30000),
       });
 
       const data = await response.json();

--- a/apps/api/src/modules/webhooks/webhook-safety.spec.ts
+++ b/apps/api/src/modules/webhooks/webhook-safety.spec.ts
@@ -1,0 +1,99 @@
+// SSRF guard tests for assertWebhookUrlSafe (shared engine-runtime helper).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock DNS so hostname cases are deterministic (no real network).
+const lookupMock = vi.fn();
+vi.mock('node:dns/promises', () => ({ lookup: (...args: any[]) => lookupMock(...args) }));
+
+import { assertWebhookUrlSafe, WebhookUrlError } from '@multiwa/engine-runtime';
+
+describe('assertWebhookUrlSafe', () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+    delete process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS;
+  });
+  afterEach(() => {
+    delete process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS;
+  });
+
+  it('allows a literal public IP', async () => {
+    await expect(assertWebhookUrlSafe('https://8.8.8.8/hook')).resolves.toContain('8.8.8.8');
+  });
+
+  it.each([
+    ['loopback', 'http://127.0.0.1/x'],
+    ['private 10/8', 'http://10.0.0.5/x'],
+    ['private 192.168', 'http://192.168.1.10/x'],
+    ['link-local metadata', 'http://169.254.169.254/latest/meta-data/'],
+    ['IPv6 loopback', 'http://[::1]/x'],
+  ])('blocks a literal internal IP (%s)', async (_label, url) => {
+    await expect(assertWebhookUrlSafe(url)).rejects.toBeInstanceOf(WebhookUrlError);
+  });
+
+  it.each([
+    ['file', 'file:///etc/passwd'],
+    ['gopher', 'gopher://evil/x'],
+    ['ftp', 'ftp://host/x'],
+  ])('rejects a non-http(s) scheme (%s)', async (_label, url) => {
+    await expect(assertWebhookUrlSafe(url)).rejects.toBeInstanceOf(WebhookUrlError);
+  });
+
+  it('rejects a malformed URL', async () => {
+    await expect(assertWebhookUrlSafe('not a url')).rejects.toBeInstanceOf(WebhookUrlError);
+  });
+
+  it('allows a hostname that resolves to a public address', async () => {
+    lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    await expect(assertWebhookUrlSafe('https://example.com/hook')).resolves.toBe(
+      'https://example.com/hook',
+    );
+  });
+
+  it('blocks a hostname that resolves to a private address (DNS-based SSRF)', async () => {
+    lookupMock.mockResolvedValue([{ address: '10.1.2.3', family: 4 }]);
+    await expect(assertWebhookUrlSafe('https://sneaky.example/hook')).rejects.toBeInstanceOf(
+      WebhookUrlError,
+    );
+  });
+
+  it('blocks if ANY resolved address is internal', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '127.0.0.1', family: 4 },
+    ]);
+    await expect(assertWebhookUrlSafe('https://mixed.example/hook')).rejects.toBeInstanceOf(
+      WebhookUrlError,
+    );
+  });
+
+  it('rejects when the hostname does not resolve', async () => {
+    lookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertWebhookUrlSafe('https://nope.invalid/hook')).rejects.toBeInstanceOf(
+      WebhookUrlError,
+    );
+  });
+
+  describe('WEBHOOK_ALLOW_PRIVATE_TARGETS=true (self-hosted opt-in)', () => {
+    beforeEach(() => {
+      process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS = 'true';
+    });
+
+    it('allows a literal private IP', async () => {
+      await expect(assertWebhookUrlSafe('http://10.0.0.5/x')).resolves.toContain('10.0.0.5');
+    });
+
+    it('rewrites localhost to host.docker.internal', async () => {
+      lookupMock.mockResolvedValue([{ address: '172.17.0.1', family: 4 }]);
+      await expect(assertWebhookUrlSafe('http://localhost:5678/webhook')).resolves.toContain(
+        'host.docker.internal',
+      );
+    });
+
+    it('STILL blocks the cloud metadata endpoint', async () => {
+      await expect(
+        assertWebhookUrlSafe('http://169.254.169.254/latest/meta-data/'),
+      ).rejects.toBeInstanceOf(WebhookUrlError);
+    });
+  });
+});

--- a/apps/api/src/modules/webhooks/webhooks.service.ts
+++ b/apps/api/src/modules/webhooks/webhooks.service.ts
@@ -4,6 +4,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { prisma } from '@multiwa/database';
 import { createHmac, randomBytes } from 'crypto';
+import { assertWebhookUrlSafe } from '@multiwa/engine-runtime';
 import { CreateWebhookDto, UpdateWebhookDto } from './dto';
 
 @Injectable()
@@ -96,19 +97,18 @@ export class WebhooksService {
       ...((webhook.headers as Record<string, string>) || {}),
     };
 
-    // Rewrite localhost URLs to host.docker.internal for Docker compatibility
-    // Always rewrite since the API runs inside Docker where localhost != host machine
-    let targetUrl = webhook.url;
-    targetUrl = targetUrl
-      .replace('://localhost:', '://host.docker.internal:')
-      .replace('://localhost/', '://host.docker.internal/')
-      .replace('://127.0.0.1:', '://host.docker.internal:')
-      .replace('://127.0.0.1/', '://host.docker.internal/');
+    // SSRF guard: reject targets that resolve to internal/metadata addresses
+    // (see assertWebhookUrlSafe). Set WEBHOOK_ALLOW_PRIVATE_TARGETS=true for
+    // self-hosted delivery to internal services. `redirect: 'error'` prevents a
+    // 3xx from bouncing us to an internal host.
+    const targetUrl = await assertWebhookUrlSafe(webhook.url);
 
     const response = await fetch(targetUrl, {
       method: 'POST',
       headers,
       body,
+      redirect: 'error',
+      signal: AbortSignal.timeout(30000),
     });
 
     // Log delivery attempt

--- a/apps/worker/src/processors/webhook.processor.ts
+++ b/apps/worker/src/processors/webhook.processor.ts
@@ -2,6 +2,7 @@
 import { Job } from 'bullmq';
 import { PrismaClient } from '@prisma/client';
 import * as crypto from 'crypto';
+import { assertWebhookUrlSafe } from '@multiwa/engine-runtime';
 
 const prisma = new PrismaClient();
 
@@ -16,18 +17,6 @@ export interface WebhookJob {
  */
 function generateHmacSignature(body: string, secret: string): string {
   return crypto.createHmac('sha256', secret).update(body).digest('hex');
-}
-
-/**
- * Rewrite localhost URLs to host.docker.internal so the dockerized worker can
- * reach an endpoint running on the host (matches webhooks.service.ts).
- */
-function rewriteLocalhost(url: string): string {
-  return url
-    .replace('://localhost:', '://host.docker.internal:')
-    .replace('://localhost/', '://host.docker.internal/')
-    .replace('://127.0.0.1:', '://host.docker.internal:')
-    .replace('://127.0.0.1/', '://host.docker.internal/');
 }
 
 /**
@@ -82,7 +71,12 @@ export class WebhookProcessor {
       const signature = generateHmacSignature(body, webhook.secret);
       const customHeaders = (webhook.headers as Record<string, string>) || {};
 
-      const response = await fetch(rewriteLocalhost(webhook.url), {
+      // SSRF guard: block internal/metadata targets (opt out per-deploy with
+      // WEBHOOK_ALLOW_PRIVATE_TARGETS=true). `redirect: 'error'` stops a 3xx
+      // from bouncing the request to an internal host.
+      const safeUrl = await assertWebhookUrlSafe(webhook.url);
+
+      const response = await fetch(safeUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -91,6 +85,7 @@ export class WebhookProcessor {
           ...customHeaders,
         },
         body,
+        redirect: 'error',
         signal: AbortSignal.timeout(30000), // 30s timeout
       });
 

--- a/packages/engine-runtime/src/index.ts
+++ b/packages/engine-runtime/src/index.ts
@@ -7,3 +7,4 @@
 // architecture/engine-worker-migration-sop.md.
 
 export * from './send-gate.service';
+export * from './webhook-safety';

--- a/packages/engine-runtime/src/webhook-safety.ts
+++ b/packages/engine-runtime/src/webhook-safety.ts
@@ -1,0 +1,147 @@
+// MultiWA Gateway - Webhook / outbound-URL SSRF guard (shared engine runtime)
+// packages/engine-runtime/src/webhook-safety.ts
+//
+// Tenant-controlled URLs (webhook targets, custom-AI endpoints) are fetched
+// server-side, so without validation a tenant can point them at internal
+// services — cloud metadata (169.254.169.254), other containers, admin panels
+// on the Docker network, etc. This is a classic SSRF.
+//
+// Policy:
+//   • Only http/https.
+//   • Cloud metadata endpoints are ALWAYS blocked.
+//   • By default (WEBHOOK_ALLOW_PRIVATE_TARGETS != "true") loopback, private,
+//     link-local and other reserved ranges are blocked — safe for public /
+//     multi-tenant deployments. Every resolved A/AAAA address is checked, so a
+//     hostname that maps to an internal IP is rejected too.
+//   • Self-hosted operators who deliver to internal services (Chatwoot, Typebot,
+//     n8n on the same network) set WEBHOOK_ALLOW_PRIVATE_TARGETS=true to allow
+//     private/loopback targets. Metadata endpoints stay blocked even then.
+//   • The legacy localhost -> host.docker.internal rewrite is applied ONLY when
+//     private targets are allowed (it was the SSRF amplifier otherwise).
+//
+// Residual: a hostname could rebind DNS between validation and connect
+// (TOCTOU). Callers additionally pass `redirect: 'error'` so a 3xx to an
+// internal host is never followed. Fully closing rebinding needs connect-time
+// pinning (undici custom connector), tracked as a follow-up.
+
+import { lookup } from 'node:dns/promises';
+import { BlockList, isIPv4, isIPv6 } from 'node:net';
+
+export class WebhookUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WebhookUrlError';
+  }
+}
+
+// Always blocked, regardless of the private-targets flag.
+const metadataBlock = (() => {
+  const bl = new BlockList();
+  bl.addAddress('169.254.169.254', 'ipv4'); // AWS/GCP/Azure IMDS
+  bl.addAddress('fd00:ec2::254', 'ipv6'); // AWS IMDS over IPv6
+  return bl;
+})();
+
+// Blocked unless WEBHOOK_ALLOW_PRIVATE_TARGETS=true.
+const privateBlock = (() => {
+  const bl = new BlockList();
+  // IPv4 loopback / private / link-local / reserved / test / multicast
+  bl.addSubnet('0.0.0.0', 8, 'ipv4');
+  bl.addSubnet('10.0.0.0', 8, 'ipv4');
+  bl.addSubnet('100.64.0.0', 10, 'ipv4');
+  bl.addSubnet('127.0.0.0', 8, 'ipv4');
+  bl.addSubnet('169.254.0.0', 16, 'ipv4');
+  bl.addSubnet('172.16.0.0', 12, 'ipv4');
+  bl.addSubnet('192.0.0.0', 24, 'ipv4');
+  bl.addSubnet('192.0.2.0', 24, 'ipv4');
+  bl.addSubnet('192.168.0.0', 16, 'ipv4');
+  bl.addSubnet('198.18.0.0', 15, 'ipv4');
+  bl.addSubnet('198.51.100.0', 24, 'ipv4');
+  bl.addSubnet('203.0.113.0', 24, 'ipv4');
+  bl.addSubnet('224.0.0.0', 4, 'ipv4');
+  bl.addSubnet('240.0.0.0', 4, 'ipv4');
+  // IPv6 loopback / unspecified / ULA / link-local / multicast / doc
+  bl.addAddress('::1', 'ipv6');
+  bl.addAddress('::', 'ipv6');
+  bl.addSubnet('fc00::', 7, 'ipv6');
+  bl.addSubnet('fe80::', 10, 'ipv6');
+  bl.addSubnet('ff00::', 8, 'ipv6');
+  bl.addSubnet('2001:db8::', 32, 'ipv6');
+  return bl;
+})();
+
+function allowPrivateTargets(): boolean {
+  return process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS === 'true';
+}
+
+// dns.lookup can return IPv4-mapped IPv6 (::ffff:a.b.c.d); check the real v4.
+function normalize(ip: string): { addr: string; family: 'ipv4' | 'ipv6' } {
+  const mapped = ip.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  if (mapped) return { addr: mapped[1], family: 'ipv4' };
+  return { addr: ip, family: isIPv4(ip) ? 'ipv4' : 'ipv6' };
+}
+
+function addressIsBlocked(ip: string, allowPrivate: boolean): boolean {
+  const { addr, family } = normalize(ip);
+  if (metadataBlock.check(addr, family)) return true;
+  if (allowPrivate) return false;
+  return privateBlock.check(addr, family);
+}
+
+// Docker convenience, only when private targets are explicitly allowed.
+function rewriteLocalhostForDocker(url: URL): void {
+  if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') {
+    url.hostname = 'host.docker.internal';
+  }
+}
+
+/**
+ * Validate a tenant-controlled URL and return the URL string to fetch. Throws
+ * {@link WebhookUrlError} if the scheme is unsupported or the target resolves to
+ * a blocked address. Callers should fetch with `redirect: 'error'`.
+ */
+export async function assertWebhookUrlSafe(rawUrl: string): Promise<string> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new WebhookUrlError('Invalid webhook URL');
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new WebhookUrlError(`Unsupported webhook URL scheme "${url.protocol}"`);
+  }
+
+  const allowPrivate = allowPrivateTargets();
+  if (allowPrivate) {
+    rewriteLocalhostForDocker(url);
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+
+  // Literal IP: validate directly, no DNS.
+  if (isIPv4(hostname) || isIPv6(hostname)) {
+    if (addressIsBlocked(hostname, allowPrivate)) {
+      throw new WebhookUrlError('Webhook target address is not allowed');
+    }
+    return url.toString();
+  }
+
+  // Hostname: resolve every address and validate each.
+  let results: Array<{ address: string; family: number }>;
+  try {
+    results = await lookup(hostname, { all: true });
+  } catch {
+    throw new WebhookUrlError(`Webhook host "${hostname}" could not be resolved`);
+  }
+  if (results.length === 0) {
+    throw new WebhookUrlError(`Webhook host "${hostname}" did not resolve`);
+  }
+  for (const { address } of results) {
+    if (addressIsBlocked(address, allowPrivate)) {
+      throw new WebhookUrlError('Webhook target resolves to a blocked address');
+    }
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
## Vulnerability (SSRF)

Tenant-controlled URLs are fetched server-side with no validation:

- `webhooks.service.ts` (`sendWebhook`) and the durable worker path (`webhook.processor.ts`) fetch `webhook.url`
- `autoreply.service.ts` fetches the per-profile `webhookUrl` and a custom-AI `endpoint`

Worse, the code **rewrote `localhost`/`127.0.0.1` → `host.docker.internal`**, actively amplifying SSRF. A tenant could set a webhook to `http://169.254.169.254/latest/meta-data/` (cloud credentials), `http://10.x/admin`, or another container on the Docker network and have the server fetch it.

## Fix

New shared guard **`assertWebhookUrlSafe`** in `@multiwa/engine-runtime` (used by both api and worker):

- **http/https only.**
- **Cloud metadata endpoints always blocked** (`169.254.169.254`, `fd00:ec2::254`).
- **Default (safe for public / multi-tenant):** blocks loopback, private (RFC1918/CGNAT/ULA), link-local, and reserved ranges. Resolves the hostname and checks **every** A/AAAA address, so a name that maps to an internal IP is rejected. IPv4-mapped IPv6 is normalized.
- **Self-hosted opt-in `WEBHOOK_ALLOW_PRIVATE_TARGETS=true`:** re-allows private/loopback delivery (Chatwoot/Typebot/n8n/localhost on the same network — the reason the rewrite existed). The `localhost → host.docker.internal` rewrite now happens **only** in this mode; metadata stays blocked either way.
- All four call sites now also use **`redirect: 'error'`** (a 3xx can't bounce us to an internal host) and a fetch timeout.

## Why an opt-in rather than a hard block

MultiWA is self-hosted; many single-tenant operators legitimately deliver webhooks to internal services on the Docker network. A blanket block would break them. Default-deny protects public/multi-tenant installs; one env var restores internal delivery for trusted setups.

## Tests / verification

- New `webhook-safety.spec.ts` — **17 cases**: literal public IP allowed; loopback/private/link-local/IPv6-loopback blocked; non-http(s) schemes and malformed URLs rejected; DNS-resolved hostname allowed/blocked (incl. "any resolved address internal"); NXDOMAIN rejected; opt-in mode allows private + rewrites localhost but still blocks metadata. All pass.
- `tsc --noEmit` clean on `apps/api`, `apps/worker`, and `packages/engine-runtime`.

## Known residual

DNS rebinding (TOCTOU between validation and connect) is documented in the code. `redirect: 'error'` closes the redirect vector; fully closing rebinding needs connect-time IP pinning (undici custom connector), which isn't importable here yet — tracked as a follow-up.