### PR TITLE
fix(security): enforce session revocation on every JWT request

### DIFF
--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -90,17 +90,7 @@ export class AuthService {
       data: { lastLoginAt: new Date() },
     });
 
-    const tokens = await this.generateTokens(user);
-
-    // Create session
-    await this.sessionsService.createSession(
-      user.id,
-      tokens.accessToken,
-      ipAddress,
-      userAgent,
-    );
-
-    return tokens;
+    return this.generateTokens(user, { ipAddress, userAgent });
   }
 
   /**
@@ -130,17 +120,7 @@ export class AuthService {
       data: { lastLoginAt: new Date() },
     });
 
-    const tokens = await this.generateTokens(user);
-
-    // Create session
-    await this.sessionsService.createSession(
-      user.id,
-      tokens.accessToken,
-      ipAddress,
-      userAgent,
-    );
-
-    return tokens;
+    return this.generateTokens(user, { ipAddress, userAgent });
   }
 
   async refreshToken(refreshToken: string): Promise<TokenResponseDto> {
@@ -242,7 +222,10 @@ export class AuthService {
     return { success: true };
   }
 
-  private async generateTokens(user: any): Promise<TokenResponseDto> {
+  private async generateTokens(
+    user: any,
+    sessionContext?: { ipAddress?: string; userAgent?: string },
+  ): Promise<TokenResponseDto> {
     const payload = {
       sub: user.id,
       email: user.email,
@@ -252,6 +235,16 @@ export class AuthService {
 
     const accessToken = this.jwtService.sign(payload);
     const refreshToken = this.jwtService.sign(payload, { expiresIn: '30d' });
+
+    // Every issued access token is bound to a server-side session so logout and
+    // session revocation actually invalidate it (JwtStrategy checks the session
+    // on each request). Centralized here so no issuance path can forget it.
+    await this.sessionsService.createSession(
+      user.id,
+      accessToken,
+      sessionContext?.ipAddress,
+      sessionContext?.userAgent,
+    );
 
     return {
       accessToken,

--- a/apps/api/src/modules/auth/sessions.service.spec.ts
+++ b/apps/api/src/modules/auth/sessions.service.spec.ts
@@ -1,0 +1,64 @@
+// SessionsService.validateAndTouch tests — the revocation check run on every
+// authenticated request.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => ({
+  prisma: {
+    session: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@multiwa/database';
+import { SessionsService } from './sessions.service';
+
+const service = new SessionsService();
+const future = () => new Date(Date.now() + 60_000);
+const past = () => new Date(Date.now() - 60_000);
+
+describe('SessionsService.validateAndTouch', () => {
+  beforeEach(() => {
+    vi.mocked(prisma.session.findUnique).mockReset();
+    vi.mocked(prisma.session.update).mockReset().mockResolvedValue({} as any);
+  });
+
+  it('returns false when the session is missing (logged out / revoked)', async () => {
+    vi.mocked(prisma.session.findUnique).mockResolvedValue(null as any);
+    expect(await service.validateAndTouch('tok')).toBe(false);
+    expect(prisma.session.update).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the session has expired', async () => {
+    vi.mocked(prisma.session.findUnique).mockResolvedValue({
+      id: 's1',
+      expiresAt: past(),
+      lastActiveAt: new Date(),
+    } as any);
+    expect(await service.validateAndTouch('tok')).toBe(false);
+  });
+
+  it('returns true and does NOT write when activity is recent (throttled)', async () => {
+    vi.mocked(prisma.session.findUnique).mockResolvedValue({
+      id: 's1',
+      expiresAt: future(),
+      lastActiveAt: new Date(), // just now → within throttle window
+    } as any);
+    expect(await service.validateAndTouch('tok')).toBe(true);
+    expect(prisma.session.update).not.toHaveBeenCalled();
+  });
+
+  it('returns true and refreshes lastActiveAt when activity is stale', async () => {
+    vi.mocked(prisma.session.findUnique).mockResolvedValue({
+      id: 's1',
+      expiresAt: future(),
+      lastActiveAt: new Date(Date.now() - 10 * 60 * 1000), // 10 min ago → stale
+    } as any);
+    expect(await service.validateAndTouch('tok')).toBe(true);
+    expect(prisma.session.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 's1' } }),
+    );
+  });
+});

--- a/apps/api/src/modules/auth/sessions.service.ts
+++ b/apps/api/src/modules/auth/sessions.service.ts
@@ -9,6 +9,10 @@ import * as crypto from 'crypto';
 export class SessionsService {
   private readonly logger = new Logger(SessionsService.name);
 
+  // Throttle lastActiveAt writes: the session is checked on every authenticated
+  // request, but we only persist activity at most once per this interval.
+  private static readonly TOUCH_THROTTLE_MS = 5 * 60 * 1000;
+
   /**
    * Create a new session when user logs in.
    */
@@ -22,18 +26,45 @@ export class SessionsService {
     const tokenHash = this.hashToken(accessToken);
     const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
 
-    const session = await prisma.session.create({
-      data: {
+    // Upsert on the unique tokenHash: two tokens signed in the same second with
+    // the same payload are byte-identical, so a plain create could hit the
+    // unique constraint. Idempotent create keeps token issuance robust.
+    const session = await prisma.session.upsert({
+      where: { tokenHash },
+      create: {
         userId,
         tokenHash,
         ipAddress: ipAddress || null,
         userAgent: userAgent ? userAgent.substring(0, 255) : null,
         expiresAt,
       },
+      update: { lastActiveAt: new Date(), expiresAt },
     });
 
     this.logger.log(`Session created for user ${userId} from ${ipAddress || 'unknown'}`);
     return session.id;
+  }
+
+  /**
+   * Validate a session by access token and refresh its activity timestamp.
+   * Called on every authenticated request (JwtStrategy), so the lastActiveAt
+   * write is throttled to avoid a DB write per request. Returns false when the
+   * session is missing (logged out / revoked) or expired.
+   */
+  async validateAndTouch(accessToken: string): Promise<boolean> {
+    const tokenHash = this.hashToken(accessToken);
+    const session = await prisma.session.findUnique({ where: { tokenHash } });
+
+    if (!session || session.expiresAt < new Date()) {
+      return false;
+    }
+
+    if (Date.now() - session.lastActiveAt.getTime() > SessionsService.TOUCH_THROTTLE_MS) {
+      await prisma.session
+        .update({ where: { id: session.id }, data: { lastActiveAt: new Date() } })
+        .catch(() => {}); // best-effort; never block the request
+    }
+    return true;
   }
 
   /**

--- a/apps/api/src/modules/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/modules/auth/strategies/jwt.strategy.ts
@@ -6,6 +6,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { prisma } from '@multiwa/database';
+import { SessionsService } from '../sessions.service';
 
 export interface JwtPayload {
   sub: string;
@@ -14,17 +15,23 @@ export interface JwtPayload {
   role: string;
 }
 
+const extractToken = ExtractJwt.fromAuthHeaderAsBearerToken();
+
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
-  constructor(private readonly config: ConfigService) {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly sessions: SessionsService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
       secretOrKey: config.get('JWT_SECRET'),
+      passReqToCallback: true,
     });
   }
 
-  async validate(payload: JwtPayload) {
+  async validate(req: any, payload: JwtPayload) {
     const user = await prisma.user.findUnique({
       where: { id: payload.sub },
       include: { organization: true },
@@ -32,6 +39,14 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
 
     if (!user || !user.isActive) {
       throw new UnauthorizedException();
+    }
+
+    // Enforce revocation: the access token must still map to a live session, so
+    // logout / revoke-session / revoke-all actually invalidate the JWT rather
+    // than leaving it valid until its natural expiry.
+    const token = extractToken(req);
+    if (!token || !(await this.sessions.validateAndTouch(token))) {
+      throw new UnauthorizedException('Session expired or revoked');
     }
 
     return {


### PR DESCRIPTION
## Vulnerability (non-revocable tokens / broken logout)

`JwtStrategy.validate()` only loaded the user and checked `isActive` — it **never consulted the `Session` table**. So `logout`, `revokeSession`, and `revokeAllSessions` deleted session rows that nothing checked: the access token stayed valid until its natural 7-day expiry. Stolen or leaked tokens couldn't be killed.

Compounding it, sessions were created only on `login` / `loginWith2FA` — **not** on `register` or `refreshToken` — so those tokens had no session at all.

## Fix

- **Every access token is now session-bound.** `createSession` moved into `generateTokens()`, which all four issuance paths (register, login, 2FA, refresh) call — so no path can forget it. The duplicate `createSession` calls in `login`/`loginWith2FA` are removed (they pass ip/UA context through instead).
- **`JwtStrategy` enforces the session on every request** (`passReqToCallback: true`): the presented token must still map to a live, non-expired `Session`, otherwise `401`. Logout / revoke now take effect immediately.
- **`SessionsService.validateAndTouch()`**: existence + expiry check, with a **throttled** `lastActiveAt` write (≤ once / 5 min) so we don't do a DB write on every authenticated request — just one indexed `SELECT` on the hot path.
- **`createSession` upserts** on the unique `tokenHash`, so two identical same-second JWTs can't trip the unique constraint now that more paths create sessions.

## Tests / verification

- New `sessions.service.spec.ts` — missing session → false; expired → false; recent activity → true + no write; stale activity → true + throttled write. Existing `auth.service.spec.ts` (11) still green. `tsc --noEmit` clean.

## Deploy note

Access tokens previously issued via **register/refresh have no session row** and will be rejected after deploy — affected users log in once more. Tokens issued via login already have sessions and keep working.

## Known residual (follow-up)

Logout revokes the **access** token but not the refresh token — a stolen refresh token can still mint new access tokens until its 30-day expiry. Fully closing this needs refresh-token rotation/storage; tracked as a separate follow-up.