### PR TITLE
docs: fix issue-template links + real security advisory channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,8 @@ This project is licensed under the **MIT License** — see the [LICENSE](LICENSE
 ## 🔗 Links
 
 - 📖 [Documentation](https://ribato22.github.io/MultiWA/docs/) · [Source](docs/)
-- 🐛 [Report a Bug](https://github.com/ribato22/MultiWA/issues/new?template=bug_report.yml)
-- 💡 [Request a Feature](https://github.com/ribato22/MultiWA/issues/new?template=feature_request.yml)
+- 🐛 [Report a Bug](https://github.com/ribato22/MultiWA/issues/new?template=bug_report.md)
+- 💡 [Request a Feature](https://github.com/ribato22/MultiWA/issues/new?template=feature_request.md)
 - 🔒 [Security Policy](SECURITY.md)
 - 📝 [Changelog](CHANGELOG.md)
 - 🕵️ [Privacy Policy](PRIVACY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ We take security seriously. If you discover a security vulnerability, please rep
 ### How to Report
 
 1. **DO NOT** open a public issue
-2. Email us at **security@multiwa.dev** or open a private security advisory on GitHub
+2. **Open a private security advisory** on GitHub (preferred — keeps the report private and lets us collaborate on a fix): <https://github.com/ribato22/MultiWA/security/advisories/new>
 3. Include:
    - Description of the vulnerability
    - Steps to reproduce


### PR DESCRIPTION
Small docs-only polish from the world-class audit (P1 tier).

- **README** — the *Report a Bug* / *Request a Feature* links pointed at `?template=bug_report.yml` / `feature_request.yml`, but the actual templates are Markdown (`.github/ISSUE_TEMPLATE/bug_report.md`, `feature_request.md`). GitHub silently ignores a non-matching `template=` param, so the prefill never worked. Fixed to `.md`.
- **SECURITY.md** — replaced the placeholder `security@multiwa.dev` with the real **GitHub private security advisory** URL as the preferred (private) reporting channel.

### Not changed (needs a maintainer decision)
- `CODE_OF_CONDUCT.md` still lists a placeholder enforcement contact (`hello@multiwa.io`). Left as-is rather than invent an address — please point it at a real maintainer-owned inbox (or the GitHub advisory) when convenient.

Docs-only, no code. Passes the release-gate (public-boundary/internal-files checks unaffected).