### PR TITLE
feat(ops): real Redis readiness check + worker liveness probe & healthcheck

### DIFF
--- a/apps/api/src/health.controller.ts
+++ b/apps/api/src/health.controller.ts
@@ -39,13 +39,27 @@ export class HealthController {
       allHealthy = false;
     }
 
-    // Check Redis connectivity (via environment)
-    try {
-      const redisUrl = process.env.REDIS_URL;
-      checks.redis = redisUrl ? 'configured' : 'not_configured';
-    } catch {
-      checks.redis = 'error';
-      allHealthy = false;
+    // Check Redis connectivity with an actual PING (not just env presence).
+    // Short-lived client, bounded connect timeout, disconnected in finally so a
+    // probe every ~30s never leaks sockets or hangs the endpoint.
+    {
+      const IORedis = (await import('ioredis')).default;
+      const redis = new IORedis(process.env.REDIS_URL || 'redis://localhost:6379', {
+        maxRetriesPerRequest: 1,
+        enableOfflineQueue: false,
+        lazyConnect: true,
+        connectTimeout: 1500,
+      });
+      redis.on('error', () => {}); // swallow background errors; the ping result decides
+      try {
+        await redis.connect();
+        checks.redis = (await redis.ping()) === 'PONG' ? 'ok' : 'error';
+      } catch {
+        checks.redis = 'error';
+      } finally {
+        redis.disconnect();
+      }
+      if (checks.redis !== 'ok') allHealthy = false;
     }
 
     const statusCode = allHealthy ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE;

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -2,6 +2,7 @@
 import 'reflect-metadata'; // MUST be first — required for NestJS DI decorator metadata
 import { Worker, Queue } from 'bullmq';
 import Redis from 'ioredis';
+import http from 'node:http';
 import pino from 'pino';
 import { PrismaClient } from '@prisma/client';
 import { NestFactory } from '@nestjs/core';
@@ -72,6 +73,23 @@ const scheduledWorker = new Worker(
   { connection, concurrency: 1 }
 );
 
+// Liveness/readiness probe. The worker has no HTTP surface otherwise, so Docker
+// (and any orchestrator) had no way to detect a hung/disconnected worker and
+// restart it. Reports 200 only while the Redis connection — the worker's whole
+// reason to exist — is ready. Returns a minimal body (no queue internals).
+const HEALTH_PORT = Number(process.env.WORKER_HEALTH_PORT) || 3002;
+const healthServer = http.createServer((req, res) => {
+  if (req.method !== 'GET') {
+    res.writeHead(405).end();
+    return;
+  }
+  const redisReady = connection.status === 'ready';
+  res.writeHead(redisReady ? 200 : 503, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ status: redisReady ? 'ok' : 'degraded', redis: connection.status }));
+});
+healthServer.on('error', (err) => logger.error({ error: err.message }, 'Health server error'));
+healthServer.listen(HEALTH_PORT, () => logger.info(`❤️  Worker health probe listening on :${HEALTH_PORT}`));
+
 // Event handlers
 messageWorker.on('completed', (job) => {
   logger.info({ jobId: job.id, queue: 'messages' }, 'Job completed');
@@ -135,6 +153,7 @@ const setupScheduledJobs = async () => {
 // Graceful shutdown
 const shutdown = async () => {
   logger.info('Shutting down workers...');
+  healthServer.close();
   await Promise.all([
     messageWorker.close(),
     automationWorker.close(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
       SESSIONS_DIR: /data/sessions
+      WORKER_HEALTH_PORT: 3002
       S3_ENDPOINT: ${S3_ENDPOINT:-}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-}
@@ -129,6 +130,14 @@ services:
       WEBHOOK_LOG_PAYLOAD_MAX_BYTES: ${WEBHOOK_LOG_PAYLOAD_MAX_BYTES:-512}
     volumes:
       - sessions_data:/data/sessions
+    healthcheck:
+      # The worker exposes a liveness probe on WORKER_HEALTH_PORT (200 while Redis
+      # is ready). The image ships node; 127.0.0.1 avoids IPv6 localhost issues.
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3002', r => process.exit(r.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -88,8 +88,15 @@ ENV SESSIONS_PATH=/data/sessions
 ENV SESSIONS_DIR=/data/sessions
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV WORKER_HEALTH_PORT=3002
 
 WORKDIR /app/apps/worker
+
+# Liveness probe served by apps/worker/src/main.ts (200 while Redis is ready).
+# Lets Docker/orchestrators detect and restart a hung or disconnected worker.
+EXPOSE 3002
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=40s \
+  CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.WORKER_HEALTH_PORT||3002), r => process.exit(r.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))"
 
 CMD ["node", "dist/main.js"]
 


### PR DESCRIPTION
## Problem (P1: ops — faked readiness, no worker health probe)

- `GET /health/ready` "checked" Redis by testing whether `REDIS_URL` was **set** — it never contacted Redis. A down or unreachable Redis still reported `ready`, so orchestrators would route traffic to a broken API.
- The **worker** exposed no HTTP surface, so Docker (and any orchestrator) had no way to detect a hung or Redis-disconnected worker and restart it.

## Fix

- **API readiness now really pings Redis.** A short-lived `ioredis` client (`lazyConnect`, `connectTimeout: 1500ms`, `enableOfflineQueue: false`, `disconnect()` in `finally`) does a `PING`; `/health/ready` returns **503** when Redis is unreachable. Leak-safe (one connect/ping/disconnect per probe) and bounded so the endpoint can't hang. The DB check already did a real `SELECT 1`.
- **Worker liveness probe.** `apps/worker/src/main.ts` starts a tiny HTTP server on `WORKER_HEALTH_PORT` (default `3002`) returning **200 while the Redis connection is `ready`**, else **503**, with a minimal body (no queue internals). Closed on graceful shutdown.
- **Docker wiring.** `docker/Dockerfile.worker` gets a `HEALTHCHECK` hitting that port, and the base `docker-compose.yml` worker service gets a matching `healthcheck` block — so Docker restarts a hung worker (`restart: unless-stopped`).

## Verification

- `tsc --noEmit` clean on api + worker; `docker compose config` valid.
- Ran the probes: the down-Redis path returns `error` in **~3ms** (no hang, no socket leak); the worker health server returns **503** while `connecting` and **200** once `ready`.

Note: the production compose worker (added in a separate open PR) will pick up the same `WORKER_HEALTH_PORT`/healthcheck when both land; happy to add it there on rebase.