### PR TITLE
fix(profiles): honor engine selection from the create UI + honest multi-engine copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pnpm --filter admin dev   # Admin on http://localhost:3001
 
 ### Core
 - 📱 **Multi-Session Management** — Connect unlimited WhatsApp accounts
-- 🔌 **Pluggable Engine Adapters** — Clean engine interface; whatsapp-web.js by default, a Baileys adapter is included (per-profile engine selection is being wired)
+- 🔌 **Pluggable Engine Adapters** — Clean engine interface with per-profile engine selection: whatsapp-web.js (default, production) or a Baileys adapter (experimental)
 - 📨 **Unified Messaging API** — Send text, media, documents, contacts, locations
 - 📡 **Real-time WebSocket** — Live session status, QR codes, and events via Socket.IO
 - 🔐 **JWT Authentication** — Secure API access with refresh tokens

--- a/apps/admin/src/app/dashboard/profiles/new/page.tsx
+++ b/apps/admin/src/app/dashboard/profiles/new/page.tsx
@@ -275,6 +275,9 @@ export default function NewProfilePage() {
                       <p className="font-semibold text-foreground">Baileys</p>
                     </div>
                     <div className="flex flex-wrap gap-1.5 mb-2">
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-orange-500/15 text-orange-400">
+                        Experimental
+                      </span>
                       <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/15 text-amber-400">
                         <Zap className="w-3 h-3" aria-hidden="true" /> Fast
                       </span>
@@ -285,7 +288,7 @@ export default function NewProfilePage() {
                     <ul className="text-[11px] text-muted-foreground space-y-0.5">
                       <li>• No browser needed (~50MB RAM)</li>
                       <li>• Direct WA protocol, faster</li>
-                      <li>• Actively developed by community</li>
+                      <li>• Experimental — reactions/contacts limited</li>
                     </ul>
                   </button>
                 </div>

--- a/apps/api/src/modules/accounts/accounts.service.spec.ts
+++ b/apps/api/src/modules/accounts/accounts.service.spec.ts
@@ -7,7 +7,8 @@ vi.mock('@multiwa/database', () => ({
   prisma: {
     user: { findUnique: vi.fn() },
     workspace: { create: vi.fn() },
-    account: { findMany: vi.fn(), create: vi.fn() },
+    account: { findMany: vi.fn(), create: vi.fn(), findUnique: vi.fn() },
+    profile: { create: vi.fn() },
   },
 }));
 
@@ -79,6 +80,35 @@ describe('AccountsService', () => {
       expect(prisma.workspace.create).not.toHaveBeenCalled();
       expect(prisma.account.create).not.toHaveBeenCalled();
       expect(result).toEqual([{ id: 'acc-1' }]);
+    });
+  });
+
+  describe('createProfile — engine selection', () => {
+    const createdEngine = () => (vi.mocked(prisma.profile.create).mock.calls[0][0] as any).data.engine;
+
+    beforeEach(() => {
+      vi.mocked(prisma.account.findUnique).mockReset().mockResolvedValue({ id: 'a1', workspaceId: 'w1' } as any);
+      vi.mocked(prisma.profile.create).mockReset().mockImplementation(async (args: any) => args.data);
+    });
+
+    it('persists a valid engine from settings.engine (baileys)', async () => {
+      await service.createProfile('a1', { displayName: 'x', settings: { engine: 'baileys' } });
+      expect(createdEngine()).toBe('baileys');
+    });
+
+    it('honors dto.engine when settings.engine is absent (mock)', async () => {
+      await service.createProfile('a1', { displayName: 'x', engine: 'mock' });
+      expect(createdEngine()).toBe('mock');
+    });
+
+    it('falls back to whatsapp-web-js for an unknown engine', async () => {
+      await service.createProfile('a1', { displayName: 'x', settings: { engine: 'evil-engine' } });
+      expect(createdEngine()).toBe('whatsapp-web-js');
+    });
+
+    it('defaults to whatsapp-web-js when no engine is provided', async () => {
+      await service.createProfile('a1', { displayName: 'x' });
+      expect(createdEngine()).toBe('whatsapp-web-js');
     });
   });
 });

--- a/apps/api/src/modules/accounts/accounts.service.spec.ts
+++ b/apps/api/src/modules/accounts/accounts.service.spec.ts
@@ -88,7 +88,7 @@ describe('AccountsService', () => {
 
     beforeEach(() => {
       vi.mocked(prisma.account.findUnique).mockReset().mockResolvedValue({ id: 'a1', workspaceId: 'w1' } as any);
-      vi.mocked(prisma.profile.create).mockReset().mockImplementation(async (args: any) => args.data);
+      vi.mocked(prisma.profile.create).mockReset().mockResolvedValue({} as any);
     });
 
     it('persists a valid engine from settings.engine (baileys)', async () => {

--- a/apps/api/src/modules/accounts/accounts.service.ts
+++ b/apps/api/src/modules/accounts/accounts.service.ts
@@ -154,6 +154,15 @@ export class AccountsService {
       throw new NotFoundException('Account not found');
     }
 
+    // Honor the engine chosen in the create UI. The admin sends it as
+    // settings.engine; older callers may send `engine`. Persist to the
+    // authoritative `engine` column (what EngineManager.resolveEngineType reads),
+    // falling back to the production default for a missing/unknown value — so
+    // the Baileys option in the UI is no longer silently dropped.
+    const VALID_ENGINES = ['whatsapp-web-js', 'baileys', 'mock'];
+    const requestedEngine = dto.settings?.engine ?? dto.engine;
+    const engine = VALID_ENGINES.includes(requestedEngine) ? requestedEngine : 'whatsapp-web-js';
+
     return prisma.profile.create({
       data: {
         accountId: accountId,
@@ -161,6 +170,7 @@ export class AccountsService {
         displayName: dto.name || dto.displayName,
         phoneNumber: dto.phoneNumber || dto.phone,
         status: 'DISCONNECTED',
+        engine,
         settings: {},
       },
     });

--- a/docs/PROMOTION_DRAFTS.md
+++ b/docs/PROMOTION_DRAFTS.md
@@ -20,7 +20,7 @@ docker compose up -d
 
 ### Key features:
 - 📱 **Multi-Session** — Connect unlimited WhatsApp numbers via single API
-- 🔌 **Multi-Engine** — Switch between whatsapp-web.js and Baileys
+- 🔌 **Pluggable engines** — pick whatsapp-web.js (production) or Baileys (experimental) per profile
 - 🤖 **AI Auto-Reply** — Knowledge base powered by OpenAI or Google AI
 - ⚡ **Visual Flow Builder** — Drag & drop automation (no code needed)
 - 📢 **Broadcast** — Bulk messaging with templates, variables, tracking
@@ -54,7 +54,7 @@ Would love to hear your feedback! What features would you want to see next?
 I'm sharing my open-source project **MultiWA** — a self-hosted WhatsApp Business API gateway.
 
 **What makes it different from other WhatsApp tools:**
-- Multi-engine: supports both whatsapp-web.js AND Baileys (switch anytime)
+- Pluggable engines: whatsapp-web.js (production) or Baileys (experimental), selectable per profile
 - Visual automation builder: drag & drop, no coding required
 - AI-powered knowledge base: plug in OpenAI or Google AI for smart auto-replies
 - Full admin dashboard with real-time chat, analytics, broadcast


### PR DESCRIPTION
## Problem (P1: "multi-engine" claim vs a dead UI control)

The new-profile UI (`profiles/new`) lets you choose **whatsapp-web.js** or **Baileys** and POSTs it as `settings.engine` to `POST /accounts/:accountId/profiles`. But `accounts.service.createProfile` hardcoded `settings: {}` and never set the authoritative **`engine`** column — so the choice was **silently dropped** and Baileys could never actually be selected from the UI, even though the Baileys adapter is real. That made "multi-engine" ring hollow.

## Fix

- **`createProfile` now honors the engine.** Reads `dto.settings?.engine ?? dto.engine`, validates against `['whatsapp-web-js','baileys','mock']`, and persists it to the `engine` column that `EngineManager.resolveEngineType` reads. Unknown/missing → the production default `whatsapp-web-js` (default behavior unchanged).
- **Honesty pass** (the claim is now true, but Baileys is experimental):
  - The Baileys card in the create UI gets an **"Experimental"** badge and a "reactions/contacts limited" note — matching the runtime warning the engine manager already logs when a profile uses Baileys.
  - README: "per-profile engine selection is being wired" → it now works (whatsapp-web.js production / Baileys experimental).
  - Toned two "switch anytime" / "Switch between engines" overclaims in `PROMOTION_DRAFTS.md` to "selectable per profile".

## Tests / verification

- New unit tests on `createProfile`: valid `settings.engine` (baileys) persisted; `dto.engine` honored; unknown → `whatsapp-web-js`; absent → `whatsapp-web-js`. Full `accounts.service.spec.ts` (8 tests) green.
- `tsc --noEmit` clean on api; admin change is JSX-only.

Note: the admin type errors flagged by CI are fixed on the separate typecheck-gate PR — not introduced here (this branch is off `main`).

Out of scope (bigger follow-up): making Baileys **production-grade** (reactions, contacts, identity resolution) — tracked separately.