### PR TITLE
ci(api): recalibrate coverage functions floor to match merged main

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -16,14 +16,15 @@ export default defineConfig({
       all: true,
       include: ['modules/**/*.ts'],
       exclude: ['**/*.dto.ts', '**/*.module.ts', '**/*.guard.ts', '**/*.spec.ts', '**/dto/**'],
-      // Ratchet floor set just below the current measured coverage so the gate
-      // passes today and only fails on a REGRESSION (deleting tests, or adding a
-      // large untested module). Raise these as coverage grows — the unmerged
-      // P0/P1 branches already add several specs.
+      // Ratchet floor set just below the current coverage measured on main
+      // (stmts/lines 5.93, funcs 14.81, branches 52.27) so the gate passes today
+      // and only fails on a REGRESSION. Recalibrated after the email/push
+      // extraction (#33) moved those services out of the api. Raise as coverage
+      // grows.
       thresholds: {
         lines: 5,
         statements: 5,
-        functions: 15,
+        functions: 14,
         branches: 40,
       },
     },


### PR DESCRIPTION
## Problem

`main`'s CI is red on one step: the v8 coverage gate.

```
Coverage for functions (14.81%) does not meet global threshold (15%)
```

The gate (#34) set `functions: 15` based on the value measured on the #34 branch. After #33 moved `EmailService`/`PushService` out of `apps/api` into `@multiwa/engine-runtime`, the api's function coverage on merged `main` is **14.81%** — just below the floor. (Build, typecheck api/worker/admin, Docker build, and Release Gate are all green.)

## Fix

Lower the `functions` floor `15 → 14`. Current measured on main: statements/lines **5.93**, functions **14.81**, branches **52.27** — all now pass. Ratchet intent preserved (floor just below current; raise as coverage grows). No product code changes.