### PR TITLE
feat(observability): Prometheus /metrics for API + worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ pnpm --filter admin dev   # Admin on http://localhost:3001
 ### Enterprise
 - 🛡️ **Security** — Helmet, CSP, rate limiting, encryption at rest
 - 🐳 **Docker** — Production-ready containers with health checks
+- 📈 **Metrics** — Prometheus `/metrics` (API, root path) + `/metrics` on the worker health port: default Node/process metrics plus BullMQ queue depth. Public like `/health` — restrict at your proxy/firewall
 - ⚙️ **Background Worker** — BullMQ worker scaffolding (a durable async send queue is on the roadmap; today message sending and scheduling run in the API process)
 - 🔒 **GDPR** — Data export and deletion endpoints
 - 🔌 **Plugin System** — Extend with custom plugins

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,6 +46,7 @@
     "passport": "^0.7.0",
     "passport-custom": "^1.1.1",
     "passport-jwt": "^4.0.1",
+    "prom-client": "^15",
     "qrcode": "^1.5.4",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -45,12 +45,15 @@ import { IntegrationsModule } from './modules/integrations/integrations.module';
 // Competitive parity modules
 import { GroupsModule } from './modules/groups/groups.module';
 import { BulkModule } from './modules/bulk/bulk.module';
+import { MetricsModule } from './metrics/metrics.module';
 // WebSocketModule (RealtimeGateway) intentionally not imported: it was a second,
 // unauthenticated gateway on the same /ws namespace as the (now authenticated)
 // EventsGateway and is unused by any service. Consolidated to one gateway.
 
 @Module({
   imports: [
+    // Prometheus metrics at GET /metrics (default runtime metrics)
+    MetricsModule,
     // Rate limiting — global default; tighten per-route with @Throttle()
     ThrottlerModule.forRoot([{ ttl: 60000, limit: 120 }]),
     // Cross-tenant ownership guard (opt-in per route via @RequireTenant)

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -76,7 +76,11 @@ async function bootstrap() {
     // Global prefix for REST API
     console.log('🔧 [3/7] Setting global prefix...');
     app.setGlobalPrefix('api/v1', {
-      exclude: [{ path: '/', method: RequestMethod.GET }],
+      exclude: [
+        { path: '/', method: RequestMethod.GET },
+        // Prometheus scrapes the conventional root /metrics path.
+        { path: 'metrics', method: RequestMethod.GET },
+      ],
     });
     console.log('✅ [3/7] Global prefix set');
 

--- a/apps/api/src/metrics/metrics.controller.ts
+++ b/apps/api/src/metrics/metrics.controller.ts
@@ -16,8 +16,10 @@ import { MetricsService } from './metrics.service';
 export class MetricsController {
   constructor(private readonly metricsService: MetricsService) {}
 
-  @Get('metrics')
+  // @ApiExcludeEndpoint must precede @Get so the API-contract drift check (which
+  // scans decorators above the route) also skips this ops-only endpoint.
   @ApiExcludeEndpoint()
+  @Get('metrics')
   async getMetrics(@Res() reply: FastifyReply) {
     reply.header('Content-Type', this.metricsService.registry.contentType);
     reply.send(await this.metricsService.metrics());

--- a/apps/api/src/metrics/metrics.controller.ts
+++ b/apps/api/src/metrics/metrics.controller.ts
@@ -1,0 +1,25 @@
+// MultiWA Gateway API - Metrics Controller
+// apps/api/src/metrics/metrics.controller.ts
+//
+// Exposes Prometheus metrics at GET /metrics (excluded from the /api/v1 global
+// prefix in main.ts, so it lives at the conventional root path). Public, like
+// /health — restrict access at your reverse proxy / firewall in production.
+
+import { Controller, Get, Res } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
+import { FastifyReply } from 'fastify';
+import { MetricsService } from './metrics.service';
+
+@Controller()
+@SkipThrottle()
+export class MetricsController {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  @Get('metrics')
+  @ApiExcludeEndpoint()
+  async getMetrics(@Res() reply: FastifyReply) {
+    reply.header('Content-Type', this.metricsService.registry.contentType);
+    reply.send(await this.metricsService.metrics());
+  }
+}

--- a/apps/api/src/metrics/metrics.module.ts
+++ b/apps/api/src/metrics/metrics.module.ts
@@ -1,0 +1,13 @@
+// MultiWA Gateway API - Metrics Module
+// apps/api/src/metrics/metrics.module.ts
+
+import { Module } from '@nestjs/common';
+import { MetricsController } from './metrics.controller';
+import { MetricsService } from './metrics.service';
+
+@Module({
+  controllers: [MetricsController],
+  providers: [MetricsService],
+  exports: [MetricsService],
+})
+export class MetricsModule {}

--- a/apps/api/src/metrics/metrics.service.spec.ts
+++ b/apps/api/src/metrics/metrics.service.spec.ts
@@ -1,0 +1,25 @@
+// MetricsService tests — verifies the /metrics payload is valid Prometheus text
+// with default runtime metrics on an isolated registry.
+
+import { describe, it, expect } from 'vitest';
+import { MetricsService } from './metrics.service';
+
+describe('MetricsService', () => {
+  it('renders default Node/process metrics in Prometheus exposition format', async () => {
+    const svc = new MetricsService();
+    const out = await svc.metrics();
+    expect(out).toContain('process_cpu_user_seconds_total');
+    expect(out).toContain('nodejs_heap_size_total_bytes');
+    expect(out).toContain('nodejs_eventloop_lag_seconds');
+    // Default label applied to every series.
+    expect(out).toContain('app="multiwa-api"');
+    // Exposition format has HELP/TYPE comment lines.
+    expect(out).toMatch(/# TYPE process_cpu_user_seconds_total counter/);
+  });
+
+  it('advertises the Prometheus text content type', () => {
+    const svc = new MetricsService();
+    expect(svc.registry.contentType).toContain('text/plain');
+    expect(svc.registry.contentType).toContain('version=0.0.4');
+  });
+});

--- a/apps/api/src/metrics/metrics.service.ts
+++ b/apps/api/src/metrics/metrics.service.ts
@@ -1,0 +1,24 @@
+// MultiWA Gateway API - Metrics Service
+// apps/api/src/metrics/metrics.service.ts
+//
+// Owns a dedicated prom-client Registry (not the global one) so tests and
+// multiple instantiations stay isolated. Collects default Node/process metrics
+// (CPU, memory, event-loop lag, GC, handles). Domain metrics can be added by
+// injecting this service and registering on `registry`.
+
+import { Injectable } from '@nestjs/common';
+import { collectDefaultMetrics, Registry } from 'prom-client';
+
+@Injectable()
+export class MetricsService {
+  readonly registry = new Registry();
+
+  constructor() {
+    this.registry.setDefaultLabels({ app: 'multiwa-api' });
+    collectDefaultMetrics({ register: this.registry });
+  }
+
+  metrics(): Promise<string> {
+    return this.registry.metrics();
+  }
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -25,6 +25,7 @@
     "ioredis": "^5.4.0",
     "nodemailer": "^8.0.1",
     "pino": "^9.0.0",
+    "prom-client": "^15",
     "qrcode": "^1.5.3",
     "reflect-metadata": "^0.2.0",
     "web-push": "^3.6.7"

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata'; // MUST be first — required for NestJS DI decorator
 import { Worker, Queue } from 'bullmq';
 import Redis from 'ioredis';
 import http from 'node:http';
+import { collectDefaultMetrics, Gauge, Registry } from 'prom-client';
 import pino from 'pino';
 import { PrismaClient } from '@prisma/client';
 import { NestFactory } from '@nestjs/core';
@@ -73,14 +74,55 @@ const scheduledWorker = new Worker(
   { connection, concurrency: 1 }
 );
 
-// Liveness/readiness probe. The worker has no HTTP surface otherwise, so Docker
-// (and any orchestrator) had no way to detect a hung/disconnected worker and
-// restart it. Reports 200 only while the Redis connection — the worker's whole
-// reason to exist — is ready. Returns a minimal body (no queue internals).
+// Prometheus metrics: default Node/process metrics + BullMQ queue-depth gauges.
+const metricsRegistry = new Registry();
+metricsRegistry.setDefaultLabels({ app: 'multiwa-worker' });
+collectDefaultMetrics({ register: metricsRegistry });
+
+// Lightweight Queue handles used only to read job counts on scrape (share the
+// worker's Redis connection; getJobCounts is read-only).
+const metricsQueues: Record<string, Queue> = {
+  messages: new Queue('messages', { connection }),
+  automation: new Queue('automation', { connection }),
+  webhooks: new Queue('webhooks', { connection }),
+  scheduled: scheduledQueue,
+};
+new Gauge({
+  name: 'multiwa_bullmq_jobs',
+  help: 'BullMQ job counts by queue and state',
+  labelNames: ['queue', 'state'],
+  registers: [metricsRegistry],
+  async collect() {
+    for (const [name, q] of Object.entries(metricsQueues)) {
+      try {
+        const counts = await q.getJobCounts('waiting', 'active', 'completed', 'failed', 'delayed');
+        for (const [state, value] of Object.entries(counts)) {
+          this.set({ queue: name, state }, value as number);
+        }
+      } catch {
+        // Redis unavailable — skip this scrape rather than fail the endpoint.
+      }
+    }
+  },
+});
+
+// Liveness probe (GET / — used by the Docker HEALTHCHECK; 200 only while Redis
+// is ready) + Prometheus GET /metrics. The worker has no other HTTP surface.
+// WORKER_HEALTH_PORT is internal (not published in compose) — scrape it from a
+// Prometheus on the same network.
 const HEALTH_PORT = Number(process.env.WORKER_HEALTH_PORT) || 3002;
-const healthServer = http.createServer((req, res) => {
+const healthServer = http.createServer(async (req, res) => {
   if (req.method !== 'GET') {
     res.writeHead(405).end();
+    return;
+  }
+  if ((req.url || '').startsWith('/metrics')) {
+    try {
+      res.writeHead(200, { 'Content-Type': metricsRegistry.contentType });
+      res.end(await metricsRegistry.metrics());
+    } catch {
+      res.writeHead(500).end();
+    }
     return;
   }
   const redisReady = connection.status === 'ready';
@@ -88,7 +130,7 @@ const healthServer = http.createServer((req, res) => {
   res.end(JSON.stringify({ status: redisReady ? 'ok' : 'degraded', redis: connection.status }));
 });
 healthServer.on('error', (err) => logger.error({ error: err.message }, 'Health server error'));
-healthServer.listen(HEALTH_PORT, () => logger.info(`❤️  Worker health probe listening on :${HEALTH_PORT}`));
+healthServer.listen(HEALTH_PORT, () => logger.info(`❤️  Worker health + metrics on :${HEALTH_PORT} (/, /metrics)`));
 
 // Event handlers
 messageWorker.on('completed', (job) => {
@@ -160,6 +202,10 @@ const shutdown = async () => {
     webhookWorker.close(),
     scheduledWorker.close(),
     scheduledQueue.close(),
+    // Metrics-only queue handles (scheduledQueue is closed above).
+    metricsQueues.messages.close(),
+    metricsQueues.automation.close(),
+    metricsQueues.webhooks.close(),
   ]);
   if (engineCommandWorker) await engineCommandWorker.close();
   if (outboundSendWorker) await outboundSendWorker.close();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
         version: 0.460.0(react@18.3.1)
       next:
         specifier: 14.2.0
-        version: 14.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.0(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -241,6 +241,9 @@ importers:
       passport-jwt:
         specifier: ^4.0.1
         version: 4.0.1
+      prom-client:
+        specifier: ^15
+        version: 15.1.3
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -341,6 +344,9 @@ importers:
       pino:
         specifier: ^9.0.0
         version: 9.14.0
+      prom-client:
+        specifier: ^15
+        version: 15.1.3
       qrcode:
         specifier: ^1.5.3
         version: 1.5.4
@@ -1650,6 +1656,10 @@ packages:
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@otplib/core@13.2.1':
     resolution: {integrity: sha512-IyfHvYNCyipDxhmJdcUUvUeT3Hz84/GgM6G2G6BTEmnAKPzNA7U0kYGkxKZWY9h23W94RJk4qiClJRJN5zKGvg==}
@@ -3562,6 +3572,9 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -6458,6 +6471,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   promise-coalesce@1.5.0:
     resolution: {integrity: sha512-cTJ30U+ur1LD7pMPyQxiKIwxjtAjLsyU7ivRhVWZrX9BNIXtf78pc37vSMc8Vikx7DVzEKNk2SEJ5KWUpSG2ig==}
     engines: {node: '>=16'}
@@ -7262,6 +7279,9 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -9375,6 +9395,8 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@otplib/core@13.2.1': {}
 
@@ -11554,6 +11576,8 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
     optional: true
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -14298,7 +14322,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.0(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.0
       '@swc/helpers': 0.5.5
@@ -14319,6 +14343,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.0
       '@next/swc-win32-ia32-msvc': 14.2.0
       '@next/swc-win32-x64-msvc': 14.2.0
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -14832,6 +14857,11 @@ snapshots:
   process@0.11.10: {}
 
   progress@2.0.3: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
 
   promise-coalesce@1.5.0: {}
 
@@ -15812,6 +15842,10 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   terser-webpack-plugin@5.3.16(@swc/core@1.15.11)(webpack@5.97.1(@swc/core@1.15.11)):
     dependencies:


### PR DESCRIPTION
## P1: observability — no metrics/tracing

Adds a Prometheus scrape endpoint to **both** the API and the worker (via `prom-client`), closing the audit's "no metrics" ops gap.

## What's exposed

- **API** — `GET /metrics` (at the conventional **root** path; excluded from the `/api/v1` global prefix, `@SkipThrottle()` so scraping isn't rate-limited). A dedicated `Registry` with **default Node/process metrics**: CPU, resident/heap memory, event-loop lag, GC, handles.
- **Worker** — the existing health HTTP server (`WORKER_HEALTH_PORT`, added with the liveness probe) now also serves `GET /metrics`: default process metrics **plus** a `multiwa_bullmq_jobs{queue,state}` gauge reporting `waiting/active/completed/failed/delayed` counts for the `messages`/`automation`/`webhooks`/`scheduled` queues, read on scrape. Metrics-only `Queue` handles share the worker's Redis connection and are closed on shutdown.

Both are **public like `/health`** (no global auth guard gates them) — documented to restrict at the reverse proxy / firewall. The worker port is internal (not published in compose); scrape it from a Prometheus on the same network.

## Verification

- New `metrics.service.spec.ts` — asserts the payload is valid Prometheus exposition text with default metrics + the `multiwa-api` label + correct content type. **Passes.**
- A harness confirmed the worker gauge emits `multiwa_bullmq_jobs{queue="messages",state="waiting",app="multiwa-worker"} 3` alongside default metrics.
- `nest build` (api) + `tsc` (worker) + `tsc --noEmit` (api & worker) all clean.
- The `src/metrics/` dir is outside the coverage `modules/**` include glob, so the coverage gate is unaffected.

## Deliberately out of scope (follow-ups)

- **Domain metrics** (send-gate lanes SERVICE/cold, webhook success/fail) — need cross-package instrumentation (engine-runtime + webhook paths); a focused follow-up.
- **OpenTelemetry tracing** — a separate, larger track.
- **HTTP request metrics** on the API — needs a Fastify hook; follow-up.