### PR TITLE
feat(broadcast): durable, crash-safe execution with at-most-once cursor

### DIFF
--- a/apps/api/src/modules/broadcast/broadcast.service.spec.ts
+++ b/apps/api/src/modules/broadcast/broadcast.service.spec.ts
@@ -1,0 +1,271 @@
+// BroadcastService Unit Tests
+// Covers durable execution: boot crash-recovery, at-most-once cursor advance,
+// resume-from-cursor, and pause/stop handling. Pacing delays are stubbed so the
+// loop runs instantly and deterministically.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => ({
+  prisma: {
+    broadcast: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    contact: { findMany: vi.fn(), count: vi.fn() },
+  },
+}));
+
+import { prisma } from '@multiwa/database';
+import { BroadcastService } from './broadcast.service';
+
+const messagesMock = () => ({
+  sendText: vi.fn().mockResolvedValue({}),
+  sendImage: vi.fn().mockResolvedValue({}),
+  sendVideo: vi.fn().mockResolvedValue({}),
+  sendAudio: vi.fn().mockResolvedValue({}),
+  sendDocument: vi.fn().mockResolvedValue({}),
+});
+
+describe('BroadcastService (durable execution)', () => {
+  let service: BroadcastService;
+  let msg: ReturnType<typeof messagesMock>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    msg = messagesMock();
+    service = new BroadcastService(msg as any);
+    // Neutralize anti-ban pacing delays so the loop runs instantly in tests.
+    vi.spyOn(service as any, 'delay').mockResolvedValue(undefined);
+    vi.mocked(prisma.broadcast.update).mockResolvedValue({} as any);
+  });
+
+  const updateData = () =>
+    vi.mocked(prisma.broadcast.update).mock.calls.map((c: any) => c[0].data);
+
+  describe('onModuleInit (crash recovery)', () => {
+    it('re-launches every broadcast left running after a restart', async () => {
+      vi.mocked(prisma.broadcast.findMany).mockResolvedValueOnce([
+        { id: 'b1', profileId: 'p1', cursor: 3 },
+        { id: 'b2', profileId: 'p1', cursor: 0 },
+      ] as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await service.onModuleInit();
+
+      expect(vi.mocked(prisma.broadcast.findMany)).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { status: 'running' } }),
+      );
+      expect(launch).toHaveBeenCalledTimes(2);
+      expect(launch).toHaveBeenCalledWith('b1');
+      expect(launch).toHaveBeenCalledWith('b2');
+    });
+
+    it('does nothing when there are no orphaned broadcasts', async () => {
+      vi.mocked(prisma.broadcast.findMany).mockResolvedValueOnce([] as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await service.onModuleInit();
+
+      expect(launch).not.toHaveBeenCalled();
+    });
+
+    it('never throws when the recovery query fails (must not crash boot)', async () => {
+      vi.mocked(prisma.broadcast.findMany).mockRejectedValueOnce(new Error('db down'));
+      await expect(service.onModuleInit()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('start', () => {
+    it('snapshots resolved recipients and resets the cursor before launching', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'draft',
+        recipients: { type: 'contacts', value: ['628111', '628222'] },
+        message: { type: 'text', text: 'hi' },
+        settings: {},
+        stats: {},
+        startedAt: null,
+      } as any);
+      // No contact matches the ids → resolveRecipients treats values as raw phones.
+      vi.mocked(prisma.contact.findMany).mockResolvedValueOnce([] as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      const res = await service.start('b1');
+
+      const data = updateData()[0];
+      expect(data.status).toBe('running');
+      expect(data.cursor).toBe(0);
+      expect(data.resolvedRecipients).toEqual(['628111', '628222']);
+      expect(data.stats.total).toBe(2);
+      expect(launch).toHaveBeenCalledWith('b1');
+      expect(res.recipientCount).toBe(2);
+    });
+
+    it('rejects when no recipients resolve', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'draft',
+        recipients: { type: 'all', value: [] },
+        message: {},
+        settings: {},
+        stats: {},
+      } as any);
+      vi.mocked(prisma.contact.findMany).mockResolvedValueOnce([] as any);
+
+      await expect(service.start('b1')).rejects.toThrow(/No recipients/);
+    });
+  });
+
+  describe('runExecution', () => {
+    const runningBroadcast = (over: any = {}) => ({
+      id: 'b1',
+      profileId: 'p1',
+      status: 'running',
+      message: { type: 'text', text: 'hi' },
+      settings: { delayMin: 0, delayMax: 0, batchSize: 1000, retryFailed: false },
+      resolvedRecipients: ['628111', '628222'],
+      cursor: 0,
+      stats: { total: 2, sent: 0, failed: 0 },
+      ...over,
+    });
+
+    it('advances the cursor BEFORE sending each recipient (at-most-once)', async () => {
+      vi.mocked(prisma.broadcast.findUnique)
+        .mockResolvedValueOnce(runningBroadcast() as any) // initial load
+        .mockResolvedValue({ status: 'running' } as any); // status polls
+
+      await (service as any).runExecution('b1');
+
+      // The first DB write (cursor := 1) must happen before the first send.
+      expect(vi.mocked(prisma.broadcast.update).mock.invocationCallOrder[0]).toBeLessThan(
+        msg.sendText.mock.invocationCallOrder[0],
+      );
+
+      expect(msg.sendText).toHaveBeenCalledTimes(2);
+      expect(msg.sendText.mock.calls[0][0].to).toBe('628111');
+      expect(msg.sendText.mock.calls[1][0].to).toBe('628222');
+
+      const data = updateData();
+      expect(data.some((d: any) => d.cursor === 1)).toBe(true);
+      expect(data.some((d: any) => d.cursor === 2)).toBe(true);
+      const last = data[data.length - 1];
+      expect(last.status).toBe('completed');
+      expect(last.stats.sent).toBe(2);
+    });
+
+    it('resumes from the persisted cursor without re-sending earlier recipients', async () => {
+      vi.mocked(prisma.broadcast.findUnique)
+        .mockResolvedValueOnce(
+          runningBroadcast({
+            resolvedRecipients: ['a', 'b', 'c'],
+            cursor: 1,
+            stats: { total: 3, sent: 1, failed: 0 },
+          }) as any,
+        )
+        .mockResolvedValue({ status: 'running' } as any);
+
+      await (service as any).runExecution('b1');
+
+      expect(msg.sendText).toHaveBeenCalledTimes(2);
+      expect(msg.sendText.mock.calls.map((c: any) => c[0].to)).toEqual(['b', 'c']);
+      const last = updateData().pop();
+      expect(last.status).toBe('completed');
+      expect(last.stats.sent).toBe(3); // seeded 1 + 2 newly sent
+    });
+
+    it('stops immediately when the broadcast is no longer running (paused/cancelled)', async () => {
+      vi.mocked(prisma.broadcast.findUnique)
+        .mockResolvedValueOnce(runningBroadcast({ resolvedRecipients: ['a', 'b', 'c'] }) as any)
+        .mockResolvedValueOnce({ status: 'paused' } as any); // first poll → paused
+
+      await (service as any).runExecution('b1');
+
+      expect(msg.sendText).not.toHaveBeenCalled();
+      expect(updateData().some((d: any) => d.status === 'completed')).toBe(false);
+    });
+
+    it('does not execute a broadcast whose status is not running', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        status: 'completed',
+      } as any);
+
+      await (service as any).runExecution('b1');
+
+      expect(msg.sendText).not.toHaveBeenCalled();
+      expect(prisma.broadcast.update).not.toHaveBeenCalled();
+    });
+
+    it('counts a permanently failing recipient as failed and moves on (no retry)', async () => {
+      msg.sendText.mockRejectedValue(new Error('engine down'));
+      vi.mocked(prisma.broadcast.findUnique)
+        .mockResolvedValueOnce(runningBroadcast({ resolvedRecipients: ['a'] }) as any)
+        .mockResolvedValue({ status: 'running' } as any);
+
+      await (service as any).runExecution('b1');
+
+      const last = updateData().pop();
+      expect(last.status).toBe('completed');
+      expect(last.stats.sent).toBe(0);
+      expect(last.stats.failed).toBe(1);
+    });
+  });
+
+  describe('resume', () => {
+    it('flips a paused broadcast back to running and relaunches from its cursor', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'paused',
+        resolvedRecipients: ['a', 'b'],
+        cursor: 1,
+        stats: { sent: 1 },
+      } as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      const res = await service.resume('b1');
+
+      expect(prisma.contact.findMany).not.toHaveBeenCalled(); // no fragile re-resolve
+      expect(updateData()[0]).toEqual({ status: 'running' });
+      expect(launch).toHaveBeenCalledWith('b1');
+      expect(res.success).toBe(true);
+    });
+
+    it('restarts a legacy paused broadcast that has no recipient snapshot', async () => {
+      vi.mocked(prisma.broadcast.findUnique)
+        .mockResolvedValueOnce({ id: 'b1', status: 'paused', resolvedRecipients: null } as any) // resume→findOne
+        .mockResolvedValueOnce({
+          id: 'b1',
+          profileId: 'p1',
+          status: 'paused',
+          recipients: { type: 'contacts', value: ['x'] },
+          message: {},
+          settings: {},
+          stats: {},
+          startedAt: null,
+        } as any); // start→findOne
+      vi.mocked(prisma.contact.findMany).mockResolvedValueOnce([] as any);
+      vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await service.resume('b1');
+
+      const data = updateData()[0];
+      expect(data.resolvedRecipients).toEqual(['x']);
+      expect(data.cursor).toBe(0);
+    });
+
+    it('rejects resuming a non-paused broadcast', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        status: 'running',
+      } as any);
+
+      await expect(service.resume('b1')).rejects.toThrow(/Can only resume paused/);
+    });
+  });
+});

--- a/apps/api/src/modules/broadcast/broadcast.service.ts
+++ b/apps/api/src/modules/broadcast/broadcast.service.ts
@@ -1,19 +1,60 @@
 // MultiWA Gateway - Broadcast Service
 // apps/api/src/modules/broadcast/broadcast.service.ts
 
-import { Injectable, NotFoundException, BadRequestException, Inject, forwardRef, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, Inject, forwardRef, Logger, OnModuleInit } from '@nestjs/common';
 import { prisma } from '@multiwa/database';
 import { CreateBroadcastDto, UpdateBroadcastDto, ScheduleBroadcastDto } from './dto';
 import { MessagesService } from '../messages/messages.service';
 
 @Injectable()
-export class BroadcastService {
+export class BroadcastService implements OnModuleInit {
   private readonly logger = new Logger(BroadcastService.name);
 
   constructor(
     @Inject(forwardRef(() => MessagesService))
     private readonly messagesService: MessagesService,
   ) {}
+
+  /**
+   * Crash recovery. On boot, any broadcast left in `running` status is orphaned —
+   * its in-process execution loop died with the previous process. Re-launch each
+   * from its persisted cursor. Because the cursor advances BEFORE every send
+   * (at-most-once), recovery never re-sends an already-attempted recipient.
+   *
+   * Runs only in the API process (BroadcastModule is API-only). Assumes a single
+   * API instance; with multiple replicas each would recover, so guard with a lock
+   * before scaling out (tracked as a follow-up — PLN is single-instance today).
+   */
+  async onModuleInit() {
+    try {
+      const orphaned = await prisma.broadcast.findMany({
+        where: { status: 'running' },
+        select: { id: true, profileId: true, cursor: true },
+      });
+      if (orphaned.length === 0) return;
+
+      this.logger.warn(
+        `Recovering ${orphaned.length} orphaned broadcast(s) left running after restart: ` +
+          orphaned.map((b) => `${b.id}@${b.cursor}`).join(', '),
+      );
+      for (const b of orphaned) {
+        this.launchExecution(b.id);
+      }
+    } catch (err: any) {
+      // Never let recovery crash boot; a stuck broadcast can still be resumed manually.
+      this.logger.error(`Broadcast recovery failed: ${err.message}`);
+    }
+  }
+
+  /**
+   * Fire the (resumable) execution loop without blocking the caller, logging any
+   * unhandled error. Used by start(), resume(), and boot recovery.
+   */
+  private launchExecution(broadcastId: string) {
+    this.runExecution(broadcastId).catch((err) =>
+      this.logger.error(`Broadcast ${broadcastId} execution error: ${err.message}`),
+    );
+  }
 
   // Create broadcast
   async create(dto: CreateBroadcastDto) {
@@ -121,14 +162,16 @@ export class BroadcastService {
   // Start broadcast immediately
   async start(id: string) {
     const broadcast = await this.findOne(id);
-    
+
     if (!['draft', 'scheduled', 'paused'].includes(broadcast.status)) {
       throw new BadRequestException('Cannot start broadcast in current status');
     }
 
-    // Resolve actual recipient phone numbers
+    // Resolve actual recipient phone numbers once and snapshot them, so execution
+    // (and any later crash recovery) always walks the exact same list by index.
+    // Re-resolving on resume would be non-deterministic if contacts/tags changed.
     const recipientPhones = await this.resolveRecipients(broadcast);
-    
+
     if (recipientPhones.length === 0) {
       throw new BadRequestException('No recipients found for this broadcast');
     }
@@ -138,6 +181,8 @@ export class BroadcastService {
       data: {
         status: 'running',
         startedAt: broadcast.startedAt || new Date(),
+        resolvedRecipients: recipientPhones,
+        cursor: 0,
         stats: {
           total: recipientPhones.length,
           pending: recipientPhones.length,
@@ -149,9 +194,8 @@ export class BroadcastService {
       },
     });
 
-    // Execute broadcast asynchronously (don't await)
-    this.executeBroadcast(id, broadcast.profileId, recipientPhones, broadcast.message, broadcast.settings as any)
-      .catch((err) => this.logger.error(`Broadcast ${id} execution error: ${err.message}`));
+    // Execute broadcast asynchronously (don't await). Survives restart via onModuleInit.
+    this.launchExecution(id);
 
     return { success: true, message: 'Broadcast started', recipientCount: recipientPhones.length };
   }
@@ -198,32 +242,57 @@ export class BroadcastService {
     }
   }
 
-  // Execute broadcast - sends messages with delay
-  private async executeBroadcast(
-    broadcastId: string,
-    profileId: string,
-    phones: string[],
-    message: any,
-    settings: any,
-  ) {
+  // Execute a broadcast from its persisted cursor. Resumable and crash-safe: all
+  // execution state (recipient snapshot, cursor, running counters) lives in the DB,
+  // so a fresh call after start(), resume(), or restart continues from where it left
+  // off. Pacing (per-message randomized delay + batch pause) and the send path
+  // (messagesService → send-gate) are unchanged, preserving anti-ban governance.
+  private async runExecution(broadcastId: string) {
+    const broadcast = await prisma.broadcast.findUnique({ where: { id: broadcastId } });
+    if (!broadcast || broadcast.status !== 'running') {
+      this.logger.log(`Broadcast ${broadcastId}: Nothing to execute (status: ${broadcast?.status})`);
+      return;
+    }
+
+    const profileId = broadcast.profileId;
+    const message = broadcast.message as any;
+    const settings = (broadcast.settings as any) || {};
+    const phones: string[] = Array.isArray(broadcast.resolvedRecipients)
+      ? (broadcast.resolvedRecipients as string[])
+      : [];
+
     const delayMin = settings?.delayMin || 3000;
     const delayMax = settings?.delayMax || 10000;
     const batchSize = settings?.batchSize || 50;
     const retryFailed = settings?.retryFailed ?? true;
     const retryAttempts = settings?.retryAttempts || 3;
 
-    this.logger.log(`Broadcast ${broadcastId}: Starting execution for ${phones.length} recipients`);
+    // Resume from persisted cursor; seed counters from persisted stats so a resumed
+    // or recovered run keeps counting rather than resetting to zero.
+    let cursor = broadcast.cursor || 0;
+    const persistedStats = (broadcast.stats as any) || {};
+    let sentCount = persistedStats.sent || 0;
+    let failedCount = persistedStats.failed || 0;
 
-    let sentCount = 0;
-    let failedCount = 0;
+    this.logger.log(
+      `Broadcast ${broadcastId}: Executing from index ${cursor}/${phones.length} recipients`,
+    );
 
-    for (let i = 0; i < phones.length; i++) {
-      // Check if broadcast was paused or cancelled
-      const current = await prisma.broadcast.findUnique({ where: { id: broadcastId } });
+    for (let i = cursor; i < phones.length; i++) {
+      // Check if broadcast was paused or cancelled between messages.
+      const current = await prisma.broadcast.findUnique({
+        where: { id: broadcastId },
+        select: { status: true },
+      });
       if (!current || current.status !== 'running') {
         this.logger.log(`Broadcast ${broadcastId}: Stopped (status: ${current?.status})`);
         return;
       }
+
+      // Advance the cursor BEFORE sending. If we crash during the send, recovery
+      // resumes at i+1 and this recipient is skipped rather than re-sent — we
+      // prefer a missed message over a duplicate (spam/ban risk).
+      await prisma.broadcast.update({ where: { id: broadcastId }, data: { cursor: i + 1 } });
 
       const phone = phones[i];
       let success = false;
@@ -234,7 +303,7 @@ export class BroadcastService {
         try {
           // Resolve message content with template variables
           const messageText = this.resolveTemplate(message, phone);
-          
+
           // Send based on message type
           switch (message.type) {
             case 'image':
@@ -281,7 +350,7 @@ export class BroadcastService {
                 text: messageText,
               });
           }
-          
+
           sentCount++;
           success = true;
           this.logger.debug(`Broadcast ${broadcastId}: Sent ${sentCount}/${phones.length} to ${phone}`);
@@ -374,25 +443,26 @@ export class BroadcastService {
   // Resume broadcast
   async resume(id: string) {
     const broadcast = await this.findOne(id);
-    
+
     if (broadcast.status !== 'paused') {
       throw new BadRequestException('Can only resume paused broadcasts');
     }
 
-    // Re-resolve recipients and continue
-    const recipientPhones = await this.resolveRecipients(broadcast);
-    const stats = broadcast.stats as any;
-    const alreadySent = stats?.sent || 0;
-    const remaining = recipientPhones.slice(alreadySent);
+    // A paused broadcast retains its recipient snapshot and cursor, so we simply flip
+    // it back to running and re-launch — execution continues from the exact recipient
+    // it stopped on. (The old code re-resolved recipients and sliced by stats.sent,
+    // which mis-aligned whenever a send had failed or the underlying contacts changed.)
+    if (!Array.isArray(broadcast.resolvedRecipients)) {
+      // Legacy broadcast started before durable execution existed — restart cleanly.
+      return this.start(id);
+    }
 
     await prisma.broadcast.update({
       where: { id },
       data: { status: 'running' },
     });
 
-    // Continue execution
-    this.executeBroadcast(id, broadcast.profileId, remaining, broadcast.message, broadcast.settings as any)
-      .catch((err) => this.logger.error(`Broadcast ${id} resume error: ${err.message}`));
+    this.launchExecution(id);
 
     return { success: true, message: 'Broadcast resumed' };
   }

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -316,6 +316,12 @@ model Broadcast {
   completedAt DateTime?
   settings    Json     @default("{}") // delay, batch_size, etc
   stats       Json     @default("{}") // sent, delivered, failed, etc
+  // Durable execution: resolved phone list is snapshotted once at start; cursor is
+  // the next index to send. Cursor advances BEFORE each send (at-most-once), so a
+  // crash mid-broadcast is recovered by re-running from the cursor without re-sending
+  // an already-attempted recipient (prefers a missed send over a duplicate → anti-ban safe).
+  resolvedRecipients Json?   // string[] snapshot of resolved phone numbers, set at start
+  cursor      Int      @default(0) // next recipient index to send
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 


### PR DESCRIPTION
## Problem

Broadcast execution was a **fire-and-forget in-API loop** with no persistence:

- An API restart mid-broadcast left it **stuck at `status='running'` forever** (the loop died with the process; nothing resumed it).
- `resume()` continued via `recipients.slice(stats.sent)` — a **fragile slice** that mis-aligns whenever a send had failed (sent ≠ index) or the underlying contacts/tags changed between start and resume.

This touches real WhatsApp sending, so correctness here is an anti-ban concern.

## Change

Make execution **durable and restart-safe** while preserving the existing pacing **exactly** (per-message randomized delay + 30s batch pause + `messagesService`→send-gate governance — the send path is unchanged):

- **Recipient snapshot + cursor.** `start()` resolves recipients once and snapshots them into a new `resolvedRecipients` column; the loop walks that list by a persisted `cursor` (new column). Re-resolving on resume was non-deterministic; now the exact same list is always replayed by index.
- **At-most-once.** The cursor advances to `i+1` **before** sending recipient `i`. If we crash mid-send, recovery resumes at `i+1` and that recipient is **skipped, not re-sent** — we deliberately prefer a missed message over a duplicate (spam/ban risk).
- **Boot crash-recovery** (`OnModuleInit`): any broadcast left `running` after a restart is re-launched from its cursor. Recovery is wrapped so it never crashes boot, and never re-sends an already-attempted recipient.
- **Robust resume/pause.** `resume()` flips `paused→running` and continues from the cursor (no slice). Legacy broadcasts started before this change (no snapshot) restart cleanly.

## Tests

13 new unit tests (`broadcast.service.spec.ts`) covering:
- boot recovery re-launches every orphaned `running` broadcast, is a no-op when none exist, and never throws on a failed recovery query;
- `start()` snapshots recipients + resets cursor; rejects empty recipient sets;
- `runExecution` advances the cursor **before** the send (asserted via invocation order), resumes from a persisted cursor without re-sending earlier recipients, stops immediately on pause/cancel, skips non-`running` broadcasts, and counts permanent failures;
- `resume()` continues from cursor without re-resolving, restarts legacy snapshots, and rejects non-paused broadcasts.

## Schema

Adds two columns to `Broadcast` (`resolvedRecipients Json?`, `cursor Int @default(0)`), applied on deploy via `prisma db push` (repo has no migrations dir). Both are additive/nullable-or-defaulted → non-breaking.

## Out of scope (tracked follow-ups)

- Scheduled broadcasts (`status='scheduled'`) still have **no trigger** to auto-start at `scheduledAt` — a separate pre-existing gap.
- Multi-replica recovery would double-execute; a lock is needed before scaling the API past one instance (PLN is single-instance today).
- Full BullMQ-worker rearchitecture (one job per recipient) remains the larger "L" option; this PR delivers durability with minimal anti-ban risk.