### PR TITLE
feat(broadcast): auto-start scheduled broadcasts + close double-send races

### DIFF
--- a/apps/api/src/modules/broadcast/broadcast-scheduler.cron.spec.ts
+++ b/apps/api/src/modules/broadcast/broadcast-scheduler.cron.spec.ts
@@ -1,0 +1,68 @@
+// BroadcastSchedulerCron Unit Tests
+// The cron only discovers due broadcasts and delegates each to startScheduled();
+// the atomic claim (single-winner) lives in BroadcastService and is tested there.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => ({
+  prisma: {
+    broadcast: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from '@multiwa/database';
+import { BroadcastSchedulerCron } from './broadcast-scheduler.cron';
+
+describe('BroadcastSchedulerCron', () => {
+  let cron: BroadcastSchedulerCron;
+  let broadcastService: { startScheduled: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    broadcastService = { startScheduled: vi.fn().mockResolvedValue(undefined) };
+    cron = new BroadcastSchedulerCron(broadcastService as any);
+  });
+
+  it('queries only scheduled, due broadcasts and launches each', async () => {
+    vi.mocked(prisma.broadcast.findMany).mockResolvedValueOnce([
+      { id: 'b1' },
+      { id: 'b2' },
+    ] as any);
+
+    await cron.processScheduledBroadcasts();
+
+    const where = (vi.mocked(prisma.broadcast.findMany).mock.calls[0][0] as any).where;
+    expect(where.status).toBe('scheduled');
+    expect(where.scheduledAt.lte).toBeInstanceOf(Date);
+    expect(broadcastService.startScheduled).toHaveBeenCalledTimes(2);
+    expect(broadcastService.startScheduled).toHaveBeenCalledWith('b1');
+    expect(broadcastService.startScheduled).toHaveBeenCalledWith('b2');
+  });
+
+  it('does nothing when there are no due broadcasts', async () => {
+    vi.mocked(prisma.broadcast.findMany).mockResolvedValueOnce([] as any);
+
+    await cron.processScheduledBroadcasts();
+
+    expect(broadcastService.startScheduled).not.toHaveBeenCalled();
+  });
+
+  it('keeps going when one broadcast fails to launch', async () => {
+    vi.mocked(prisma.broadcast.findMany).mockResolvedValueOnce([
+      { id: 'b1' },
+      { id: 'b2' },
+    ] as any);
+    broadcastService.startScheduled
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(cron.processScheduledBroadcasts()).resolves.toBeUndefined();
+    expect(broadcastService.startScheduled).toHaveBeenCalledTimes(2); // b2 still attempted
+  });
+
+  it('never throws when the discovery query fails', async () => {
+    vi.mocked(prisma.broadcast.findMany).mockRejectedValueOnce(new Error('db down'));
+
+    await expect(cron.processScheduledBroadcasts()).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/broadcast/broadcast-scheduler.cron.ts
+++ b/apps/api/src/modules/broadcast/broadcast-scheduler.cron.ts
@@ -1,0 +1,44 @@
+// MultiWA Gateway - Broadcast Scheduler Cron Job
+// apps/api/src/modules/broadcast/broadcast-scheduler.cron.ts
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { prisma } from '@multiwa/database';
+import { BroadcastService } from './broadcast.service';
+
+@Injectable()
+export class BroadcastSchedulerCron {
+  private readonly logger = new Logger(BroadcastSchedulerCron.name);
+
+  constructor(private readonly broadcastService: BroadcastService) {}
+
+  /**
+   * Every 30s, launch any scheduled broadcast whose scheduledAt has arrived. Each
+   * launch goes through BroadcastService.startScheduled(), whose atomic claim ensures
+   * overlapping ticks (or a manual start) can never double-start the same broadcast.
+   * Runs only in the API process (ScheduleModule is registered in the API AppModule).
+   */
+  @Cron(CronExpression.EVERY_30_SECONDS)
+  async processScheduledBroadcasts() {
+    try {
+      const due = await prisma.broadcast.findMany({
+        where: { status: 'scheduled', scheduledAt: { lte: new Date() } },
+        orderBy: { scheduledAt: 'asc' },
+        take: 10, // Process in batches; the next tick picks up the rest.
+        select: { id: true },
+      });
+      if (due.length === 0) return;
+
+      this.logger.log(`Launching ${due.length} due scheduled broadcast(s)...`);
+      for (const { id } of due) {
+        try {
+          await this.broadcastService.startScheduled(id);
+        } catch (err: any) {
+          this.logger.error(`Failed to launch scheduled broadcast ${id}: ${err.message}`);
+        }
+      }
+    } catch (err: any) {
+      this.logger.error(`Scheduled broadcast cron error: ${err.message}`);
+    }
+  }
+}

--- a/apps/api/src/modules/broadcast/broadcast.module.ts
+++ b/apps/api/src/modules/broadcast/broadcast.module.ts
@@ -4,12 +4,13 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { BroadcastController } from './broadcast.controller';
 import { BroadcastService } from './broadcast.service';
+import { BroadcastSchedulerCron } from './broadcast-scheduler.cron';
 import { MessagesModule } from '../messages/messages.module';
 
 @Module({
   imports: [forwardRef(() => MessagesModule)],
   controllers: [BroadcastController],
-  providers: [BroadcastService],
+  providers: [BroadcastService, BroadcastSchedulerCron],
   exports: [BroadcastService],
 })
 export class BroadcastModule {}

--- a/apps/api/src/modules/broadcast/broadcast.service.spec.ts
+++ b/apps/api/src/modules/broadcast/broadcast.service.spec.ts
@@ -11,6 +11,7 @@ vi.mock('@multiwa/database', () => ({
       findUnique: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       create: vi.fn(),
       delete: vi.fn(),
     },
@@ -40,6 +41,8 @@ describe('BroadcastService (durable execution)', () => {
     // Neutralize anti-ban pacing delays so the loop runs instantly in tests.
     vi.spyOn(service as any, 'delay').mockResolvedValue(undefined);
     vi.mocked(prisma.broadcast.update).mockResolvedValue({} as any);
+    // Default: the atomic status claim succeeds (single winner).
+    vi.mocked(prisma.broadcast.updateMany).mockResolvedValue({ count: 1 } as any);
   });
 
   const updateData = () =>
@@ -96,8 +99,15 @@ describe('BroadcastService (durable execution)', () => {
 
       const res = await service.start('b1');
 
+      // Transition to running is an atomic compare-and-set claim (status='draft').
+      expect(vi.mocked(prisma.broadcast.updateMany)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'b1', status: 'draft' }),
+          data: { status: 'running' },
+        }),
+      );
+      // The snapshot write carries the recipient list + cursor (status set by the claim).
       const data = updateData()[0];
-      expect(data.status).toBe('running');
       expect(data.cursor).toBe(0);
       expect(data.resolvedRecipients).toEqual(['628111', '628222']);
       expect(data.stats.total).toBe(2);
@@ -105,7 +115,51 @@ describe('BroadcastService (durable execution)', () => {
       expect(res.recipientCount).toBe(2);
     });
 
-    it('rejects when no recipients resolve', async () => {
+    it('rejects and does not launch when the claim is lost to a concurrent starter', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'scheduled',
+        recipients: { type: 'contacts', value: ['x'] },
+        message: {},
+        settings: {},
+        stats: {},
+      } as any);
+      vi.mocked(prisma.broadcast.updateMany).mockResolvedValueOnce({ count: 0 } as any); // lost race
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await expect(service.start('b1')).rejects.toThrow(/state changed/);
+      expect(launch).not.toHaveBeenCalled();
+      expect(prisma.contact.findMany).not.toHaveBeenCalled(); // never resolved recipients
+    });
+
+    it('continues (never restarts) a paused, partially-sent broadcast', async () => {
+      // start() on a paused broadcast must behave like resume — it must NOT reset the
+      // cursor/stats to 0, which would re-send everyone already contacted.
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValue({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'paused',
+        resolvedRecipients: ['a', 'b', 'c'],
+        cursor: 2,
+        stats: { sent: 2, total: 3 },
+      } as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await service.start('b1');
+
+      expect(vi.mocked(prisma.broadcast.updateMany)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'b1', status: 'paused' },
+          data: { status: 'running' },
+        }),
+      );
+      expect(updateData().some((d: any) => d.cursor === 0)).toBe(false); // no reset
+      expect(prisma.contact.findMany).not.toHaveBeenCalled(); // no re-resolve
+      expect(launch).toHaveBeenCalledWith('b1');
+    });
+
+    it('rejects and reverts the claim when no recipients resolve', async () => {
       vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
         id: 'b1',
         profileId: 'p1',
@@ -118,6 +172,127 @@ describe('BroadcastService (durable execution)', () => {
       vi.mocked(prisma.contact.findMany).mockResolvedValueOnce([] as any);
 
       await expect(service.start('b1')).rejects.toThrow(/No recipients/);
+      // Claim is undone → status reverted to the prior value.
+      expect(updateData().some((d: any) => d.status === 'draft')).toBe(true);
+    });
+
+    it('reverts the claim to the prior status if launch throws after claiming (no stranded running)', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'scheduled',
+        recipients: { type: 'all', value: [] },
+        message: {},
+        settings: {},
+        stats: {},
+      } as any);
+      // Claim succeeds, then prepareAndLaunch's recipient query fails transiently.
+      vi.mocked(prisma.contact.findMany).mockRejectedValueOnce(new Error('db blip'));
+
+      await expect(service.start('b1')).rejects.toThrow(/db blip/);
+      // Rolled back to 'scheduled' rather than left stranded in 'running'.
+      expect(updateData().some((d: any) => d.status === 'scheduled')).toBe(true);
+    });
+  });
+
+  describe('update', () => {
+    it('ignores execution-state fields in the body (mass-assignment guard)', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({ id: 'b1', status: 'draft' } as any);
+
+      await service.update('b1', {
+        name: 'new name',
+        // Hostile extras that map to real columns — must be dropped:
+        status: 'running',
+        cursor: 0,
+        resolvedRecipients: null,
+        stats: { sent: 0 },
+      } as any);
+
+      const data = updateData()[0];
+      expect(data).toEqual({ name: 'new name' }); // only the whitelisted field is written
+      expect('status' in data).toBe(false);
+      expect('cursor' in data).toBe(false);
+      expect('resolvedRecipients' in data).toBe(false);
+    });
+
+    it('refuses to edit a non-draft broadcast', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({ id: 'b1', status: 'completed' } as any);
+
+      await expect(service.update('b1', { name: 'x' } as any)).rejects.toThrow(/draft/);
+    });
+  });
+
+  describe('startScheduled (scheduler cron entry point)', () => {
+    it('atomically claims a due broadcast and launches it', async () => {
+      vi.mocked(prisma.broadcast.updateMany).mockResolvedValueOnce({ count: 1 } as any); // won the claim
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'running',
+        recipients: { type: 'contacts', value: ['628111'] },
+        message: { type: 'text', text: 'hi' },
+        settings: {},
+        stats: {},
+        startedAt: null,
+      } as any);
+      vi.mocked(prisma.contact.findMany).mockResolvedValueOnce([] as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await service.startScheduled('b1');
+
+      const claim = vi.mocked(prisma.broadcast.updateMany).mock.calls[0][0] as any;
+      expect(claim.where).toMatchObject({ id: 'b1', status: 'scheduled' });
+      expect(claim.where.scheduledAt.lte).toBeInstanceOf(Date); // due-check is part of the claim
+      expect(claim.data).toEqual({ status: 'running' });
+      expect(updateData()[0].resolvedRecipients).toEqual(['628111']);
+      expect(launch).toHaveBeenCalledWith('b1');
+    });
+
+    it('does nothing when the atomic claim is lost (another tick / not due)', async () => {
+      vi.mocked(prisma.broadcast.updateMany).mockResolvedValueOnce({ count: 0 } as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await service.startScheduled('b1');
+
+      expect(prisma.broadcast.findUnique).not.toHaveBeenCalled(); // never proceeded past the claim
+      expect(launch).not.toHaveBeenCalled();
+    });
+
+    it('marks a claimed-but-empty scheduled broadcast as failed (no infinite re-pick)', async () => {
+      vi.mocked(prisma.broadcast.updateMany).mockResolvedValueOnce({ count: 1 } as any);
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'running',
+        recipients: { type: 'all', value: [] },
+        message: {},
+        settings: {},
+        stats: {},
+      } as any);
+      vi.mocked(prisma.contact.findMany).mockResolvedValueOnce([] as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await service.startScheduled('b1');
+
+      expect(launch).not.toHaveBeenCalled();
+      expect(updateData().some((d: any) => d.status === 'failed')).toBe(true);
+    });
+  });
+
+  describe('schedule', () => {
+    it('rejects scheduling a non-draft (paused) broadcast — prevents cron double-send', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        status: 'paused',
+        resolvedRecipients: ['a', 'b'],
+        cursor: 1,
+      } as any);
+
+      await expect(
+        service.schedule('b1', {
+          scheduledAt: new Date(Date.now() + 60_000).toISOString(),
+        } as any),
+      ).rejects.toThrow(/Only draft broadcasts/);
     });
   });
 
@@ -214,10 +389,67 @@ describe('BroadcastService (durable execution)', () => {
       expect(last.stats.sent).toBe(0);
       expect(last.stats.failed).toBe(1);
     });
+
+    // Recovery of a 'running' row with no recipient snapshot: crash between the atomic
+    // claim and the snapshot write, or a legacy pre-durable broadcast.
+    it('recovers a snapshotless running broadcast that has sent nothing by resolving fresh', async () => {
+      vi.mocked(prisma.broadcast.findUnique)
+        .mockResolvedValueOnce(
+          runningBroadcast({
+            recipients: { type: 'contacts', value: ['628999'] },
+            resolvedRecipients: null,
+            cursor: 0,
+            stats: { sent: 0, failed: 0 },
+          }) as any,
+        )
+        .mockResolvedValue({ status: 'running' } as any);
+      vi.mocked(prisma.contact.findMany).mockResolvedValueOnce([] as any); // value treated as raw phones
+
+      await (service as any).runExecution('b1');
+
+      // The snapshot is written during recovery, then the recipient is sent exactly once.
+      expect(
+        updateData().some(
+          (d: any) => Array.isArray(d.resolvedRecipients) && d.resolvedRecipients[0] === '628999',
+        ),
+      ).toBe(true);
+      expect(msg.sendText).toHaveBeenCalledTimes(1);
+      expect(msg.sendText.mock.calls[0][0].to).toBe('628999');
+    });
+
+    it('a superseded run exits immediately without sending (run-token guard)', async () => {
+      // The current active run for b1 is 99; this stale loop carries token 1
+      // (models a pause→resume that spawned a newer loop while this one was in delay()).
+      (service as any).activeRun.set('b1', 99);
+      vi.mocked(prisma.broadcast.findUnique)
+        .mockResolvedValueOnce(runningBroadcast() as any)
+        .mockResolvedValue({ status: 'running' } as any);
+
+      await (service as any).runExecution('b1', 1);
+
+      expect(msg.sendText).not.toHaveBeenCalled();
+      expect(prisma.broadcast.update).not.toHaveBeenCalled(); // no cursor advance, no completion
+    });
+
+    it('fails a snapshotless running broadcast that already sent some (never re-sends them)', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce(
+        runningBroadcast({
+          recipients: { type: 'all', value: [] },
+          resolvedRecipients: null,
+          cursor: 3,
+          stats: { sent: 3, failed: 0 },
+        }) as any,
+      );
+
+      await (service as any).runExecution('b1');
+
+      expect(msg.sendText).not.toHaveBeenCalled();
+      expect(updateData().some((d: any) => d.status === 'failed')).toBe(true);
+    });
   });
 
   describe('resume', () => {
-    it('flips a paused broadcast back to running and relaunches from its cursor', async () => {
+    it('atomically claims paused → running and relaunches from its cursor', async () => {
       vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
         id: 'b1',
         profileId: 'p1',
@@ -230,25 +462,46 @@ describe('BroadcastService (durable execution)', () => {
 
       const res = await service.resume('b1');
 
+      // Single-winner compare-and-set, not a plain read-then-write.
+      expect(vi.mocked(prisma.broadcast.updateMany)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'b1', status: 'paused' },
+          data: { status: 'running' },
+        }),
+      );
       expect(prisma.contact.findMany).not.toHaveBeenCalled(); // no fragile re-resolve
-      expect(updateData()[0]).toEqual({ status: 'running' });
       expect(launch).toHaveBeenCalledWith('b1');
       expect(res.success).toBe(true);
     });
 
-    it('restarts a legacy paused broadcast that has no recipient snapshot', async () => {
-      vi.mocked(prisma.broadcast.findUnique)
-        .mockResolvedValueOnce({ id: 'b1', status: 'paused', resolvedRecipients: null } as any) // resume→findOne
-        .mockResolvedValueOnce({
-          id: 'b1',
-          profileId: 'p1',
-          status: 'paused',
-          recipients: { type: 'contacts', value: ['x'] },
-          message: {},
-          settings: {},
-          stats: {},
-          startedAt: null,
-        } as any); // start→findOne
+    it('rejects a concurrent resume that loses the atomic claim (no double launch)', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'paused',
+        resolvedRecipients: ['a', 'b'],
+        cursor: 1,
+        stats: { sent: 1 },
+      } as any);
+      vi.mocked(prisma.broadcast.updateMany).mockResolvedValueOnce({ count: 0 } as any); // lost the race
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await expect(service.resume('b1')).rejects.toThrow(/state changed/);
+      expect(launch).not.toHaveBeenCalled();
+    });
+
+    it('starts a legacy paused broadcast (no snapshot) that never sent anything', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'paused',
+        resolvedRecipients: null,
+        recipients: { type: 'contacts', value: ['x'] },
+        message: {},
+        settings: {},
+        stats: { sent: 0 },
+        startedAt: null,
+      } as any);
       vi.mocked(prisma.contact.findMany).mockResolvedValueOnce([] as any);
       vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
 
@@ -257,6 +510,21 @@ describe('BroadcastService (durable execution)', () => {
       const data = updateData()[0];
       expect(data.resolvedRecipients).toEqual(['x']);
       expect(data.cursor).toBe(0);
+    });
+
+    it('refuses to resume a legacy paused broadcast that already sent some (anti double-send)', async () => {
+      vi.mocked(prisma.broadcast.findUnique).mockResolvedValueOnce({
+        id: 'b1',
+        profileId: 'p1',
+        status: 'paused',
+        resolvedRecipients: null,
+        stats: { sent: 12 },
+      } as any);
+      const launch = vi.spyOn(service as any, 'launchExecution').mockImplementation(() => {});
+
+      await expect(service.resume('b1')).rejects.toThrow(/cannot be safely resumed/);
+      expect(launch).not.toHaveBeenCalled();
+      expect(prisma.broadcast.updateMany).not.toHaveBeenCalled(); // never even claimed
     });
 
     it('rejects resuming a non-paused broadcast', async () => {

--- a/apps/api/src/modules/broadcast/broadcast.service.ts
+++ b/apps/api/src/modules/broadcast/broadcast.service.ts
@@ -10,6 +10,13 @@ import { MessagesService } from '../messages/messages.service';
 export class BroadcastService implements OnModuleInit {
   private readonly logger = new Logger(BroadcastService.name);
 
+  // In-process supersession guard. Each launched execution loop gets a monotonic run
+  // token; the map holds the CURRENT token per broadcast. A loop exits as soon as its
+  // token is no longer current, so a pause→resume that spawns a fresh loop while the
+  // old one is parked in a delay() can never leave two loops sending the same tail.
+  private readonly activeRun = new Map<string, number>();
+  private runSeq = 0;
+
   constructor(
     @Inject(forwardRef(() => MessagesService))
     private readonly messagesService: MessagesService,
@@ -51,7 +58,11 @@ export class BroadcastService implements OnModuleInit {
    * unhandled error. Used by start(), resume(), and boot recovery.
    */
   private launchExecution(broadcastId: string) {
-    this.runExecution(broadcastId).catch((err) =>
+    // Claim the run token synchronously (before yielding to the event loop) so a loop
+    // parked in delay() observes the supersession the instant a new loop is launched.
+    const run = ++this.runSeq;
+    this.activeRun.set(broadcastId, run);
+    this.runExecution(broadcastId, run).catch((err) =>
       this.logger.error(`Broadcast ${broadcastId} execution error: ${err.message}`),
     );
   }
@@ -105,16 +116,24 @@ export class BroadcastService implements OnModuleInit {
   // Update broadcast
   async update(id: string, dto: UpdateBroadcastDto) {
     const broadcast = await this.findOne(id);
-    
-    // Only restrict editing name/message/recipients on non-drafts
-    if (broadcast.status !== 'draft' && (dto as any).name) {
-      throw new BadRequestException('Can only update name/message on broadcasts in draft status');
+
+    // Whitelist the editable fields explicitly. The global ValidationPipe does not strip
+    // unknown properties, so forwarding the raw body would let a request write
+    // execution-state columns (status, cursor, resolvedRecipients, stats, timestamps) —
+    // e.g. flipping a completed broadcast back to 'draft' or zeroing a paused broadcast's
+    // cursor, either of which would re-send the whole list. Only these four are editable.
+    const data: any = {};
+    if (dto.name !== undefined) data.name = dto.name;
+    if (dto.message !== undefined) data.message = dto.message;
+    if (dto.recipients !== undefined) data.recipients = dto.recipients;
+    if (dto.settings !== undefined) data.settings = dto.settings;
+
+    // Content/structure may only change while the broadcast is still a draft.
+    if (broadcast.status !== 'draft' && Object.keys(data).length > 0) {
+      throw new BadRequestException('Can only edit a broadcast while it is in draft status');
     }
 
-    return prisma.broadcast.update({
-      where: { id },
-      data: dto as any,
-    });
+    return prisma.broadcast.update({ where: { id }, data });
   }
 
   // Delete broadcast
@@ -132,9 +151,15 @@ export class BroadcastService implements OnModuleInit {
   // Schedule broadcast
   async schedule(id: string, dto: ScheduleBroadcastDto) {
     const broadcast = await this.findOne(id);
-    
-    if (!['draft', 'paused'].includes(broadcast.status)) {
-      throw new BadRequestException('Can only schedule draft or paused broadcasts');
+
+    // Only a not-yet-started (draft) broadcast may be scheduled. Allowing a paused
+    // (partially-sent) broadcast to be scheduled would let the cron re-launch it from
+    // cursor 0 and re-send everyone already contacted — resume() is the way to continue
+    // a paused broadcast.
+    if (broadcast.status !== 'draft') {
+      throw new BadRequestException(
+        'Only draft broadcasts can be scheduled; resume a paused broadcast to continue it',
+      );
     }
 
     const scheduledAt = new Date(dto.scheduledAt);
@@ -159,7 +184,7 @@ export class BroadcastService implements OnModuleInit {
     });
   }
 
-  // Start broadcast immediately
+  // Start broadcast immediately (manual trigger).
   async start(id: string) {
     const broadcast = await this.findOne(id);
 
@@ -167,19 +192,88 @@ export class BroadcastService implements OnModuleInit {
       throw new BadRequestException('Cannot start broadcast in current status');
     }
 
-    // Resolve actual recipient phone numbers once and snapshot them, so execution
-    // (and any later crash recovery) always walks the exact same list by index.
-    // Re-resolving on resume would be non-deterministic if contacts/tags changed.
-    const recipientPhones = await this.resolveRecipients(broadcast);
+    // A paused broadcast may be partially sent. Starting it must NEVER restart from
+    // scratch (that re-sends everyone already contacted) — continue it exactly like
+    // resume(), which preserves the durable cursor/snapshot.
+    if (broadcast.status === 'paused') {
+      return this.resume(id);
+    }
 
-    if (recipientPhones.length === 0) {
+    // draft / scheduled: nothing has been sent yet. Atomically claim the transition to
+    // 'running' — two concurrent starts, or a manual start racing the scheduler cron,
+    // must never both launch execution and double-send the whole list (spam/ban risk).
+    const claimed = await this.claimForRunning(id, broadcast.status);
+    if (!claimed) {
+      throw new BadRequestException('Broadcast state changed; please retry');
+    }
+
+    const recipientCount = await this.prepareAndLaunchOrRevert(id, broadcast, broadcast.status);
+    if (recipientCount === null) {
+      // Nothing to send: undo the claim so the broadcast returns to its prior status.
+      await prisma.broadcast.update({ where: { id }, data: { status: broadcast.status } });
       throw new BadRequestException('No recipients found for this broadcast');
     }
+
+    return { success: true, message: 'Broadcast started', recipientCount };
+  }
+
+  /**
+   * Start a scheduled broadcast whose time has come. Invoked by the scheduler cron.
+   * The claim is a single atomic compare-and-set on (status='scheduled', due) → running,
+   * so overlapping cron ticks and manual starts elect exactly one winner. Never throws
+   * (the cron logs failures per-broadcast).
+   */
+  async startScheduled(id: string): Promise<void> {
+    const claim = await prisma.broadcast.updateMany({
+      where: { id, status: 'scheduled', scheduledAt: { lte: new Date() } },
+      data: { status: 'running' },
+    });
+    if (claim.count !== 1) return; // not due, not scheduled, or another tick won the race
+
+    const broadcast = await prisma.broadcast.findUnique({ where: { id } });
+    if (!broadcast) return;
+
+    // On a transient error after the claim, revert to 'scheduled' so the next cron tick retries.
+    const recipientCount = await this.prepareAndLaunchOrRevert(id, broadcast, 'scheduled');
+    if (recipientCount === null) {
+      // Claimed but empty — fail it rather than reverting to 'scheduled', which would
+      // make the cron re-pick it on every tick forever.
+      await prisma.broadcast.update({
+        where: { id },
+        data: { status: 'failed', completedAt: new Date() },
+      });
+      this.logger.warn(`Scheduled broadcast ${id} has no recipients; marked failed`);
+    } else {
+      this.logger.log(`Scheduled broadcast ${id} started (${recipientCount} recipients)`);
+    }
+  }
+
+  /**
+   * Atomic single-winner transition <fromStatus> → running. Returns true iff this
+   * caller performed the transition (exactly one concurrent caller can).
+   */
+  private async claimForRunning(id: string, fromStatus: string): Promise<boolean> {
+    const res = await prisma.broadcast.updateMany({
+      where: { id, status: fromStatus },
+      data: { status: 'running' },
+    });
+    return res.count === 1;
+  }
+
+  /**
+   * With the broadcast already claimed as 'running', resolve + snapshot recipients,
+   * persist the execution snapshot, and launch. Recipients are resolved once here so
+   * execution (and any later crash recovery) always walks the exact same list by index
+   * — re-resolving would be non-deterministic if contacts/tags changed. Returns the
+   * recipient count, or null if none resolved (caller resolves the empty claim).
+   */
+  private async prepareAndLaunch(id: string, broadcast: any): Promise<number | null> {
+    const recipientPhones = await this.resolveRecipients(broadcast);
+    if (recipientPhones.length === 0) return null;
 
     await prisma.broadcast.update({
       where: { id },
       data: {
-        status: 'running',
         startedAt: broadcast.startedAt || new Date(),
         resolvedRecipients: recipientPhones,
         cursor: 0,
@@ -196,8 +290,27 @@ export class BroadcastService implements OnModuleInit {
 
     // Execute broadcast asynchronously (don't await). Survives restart via onModuleInit.
     this.launchExecution(id);
+    return recipientPhones.length;
+  }
 
-    return { success: true, message: 'Broadcast started', recipientCount: recipientPhones.length };
+  /**
+   * prepareAndLaunch, but if it throws (e.g. a transient DB error after the atomic claim
+   * already set status='running'), roll the status back to `revertStatus` so a broadcast
+   * is never stranded 'running' with no live loop while the process stays up. Re-throws.
+   */
+  private async prepareAndLaunchOrRevert(
+    id: string,
+    broadcast: any,
+    revertStatus: string,
+  ): Promise<number | null> {
+    try {
+      return await this.prepareAndLaunch(id, broadcast);
+    } catch (err) {
+      await prisma.broadcast
+        .update({ where: { id }, data: { status: revertStatus } })
+        .catch(() => undefined);
+      throw err;
+    }
   }
 
   // Resolve recipients to phone numbers
@@ -247,7 +360,7 @@ export class BroadcastService implements OnModuleInit {
   // so a fresh call after start(), resume(), or restart continues from where it left
   // off. Pacing (per-message randomized delay + batch pause) and the send path
   // (messagesService → send-gate) are unchanged, preserving anti-ban governance.
-  private async runExecution(broadcastId: string) {
+  private async runExecution(broadcastId: string, run?: number) {
     const broadcast = await prisma.broadcast.findUnique({ where: { id: broadcastId } });
     if (!broadcast || broadcast.status !== 'running') {
       this.logger.log(`Broadcast ${broadcastId}: Nothing to execute (status: ${broadcast?.status})`);
@@ -257,9 +370,46 @@ export class BroadcastService implements OnModuleInit {
     const profileId = broadcast.profileId;
     const message = broadcast.message as any;
     const settings = (broadcast.settings as any) || {};
-    const phones: string[] = Array.isArray(broadcast.resolvedRecipients)
-      ? (broadcast.resolvedRecipients as string[])
-      : [];
+
+    // Normally prepareAndLaunch writes the recipient snapshot before launching. A
+    // 'running' broadcast with no snapshot was either claimed but killed before the
+    // snapshot write (the crash window between the atomic claim and prepareAndLaunch)
+    // or is a legacy pre-durable broadcast. Recover it safely instead of silently
+    // completing it with zero sends.
+    let phones: string[];
+    if (Array.isArray(broadcast.resolvedRecipients)) {
+      phones = broadcast.resolvedRecipients as string[];
+    } else {
+      const alreadySent = ((broadcast.stats as any)?.sent as number) || 0;
+      if (alreadySent > 0) {
+        // Some recipients were already contacted but there is no snapshot to resume
+        // from. Re-sending from scratch would duplicate them, so fail for manual review
+        // rather than risk a ban.
+        this.logger.error(
+          `Broadcast ${broadcastId}: 'running' with no recipient snapshot but ${alreadySent} already sent — marking failed (manual review) to avoid double-send`,
+        );
+        await prisma.broadcast.update({
+          where: { id: broadcastId },
+          data: { status: 'failed', completedAt: new Date() },
+        });
+        return;
+      }
+      // Nothing sent yet — safe to resolve fresh, snapshot, and run from the start.
+      const resolved = await this.resolveRecipients(broadcast);
+      if (resolved.length === 0) {
+        await prisma.broadcast.update({
+          where: { id: broadcastId },
+          data: { status: 'failed', completedAt: new Date() },
+        });
+        this.logger.warn(`Broadcast ${broadcastId}: recovered with no recipients — marked failed`);
+        return;
+      }
+      await prisma.broadcast.update({
+        where: { id: broadcastId },
+        data: { resolvedRecipients: resolved, cursor: 0 },
+      });
+      phones = resolved;
+    }
 
     const delayMin = settings?.delayMin || 3000;
     const delayMax = settings?.delayMax || 10000;
@@ -279,6 +429,14 @@ export class BroadcastService implements OnModuleInit {
     );
 
     for (let i = cursor; i < phones.length; i++) {
+      // Exit immediately if a newer run has superseded this loop (e.g. pause→resume
+      // spawned a fresh loop while this one was parked in delay()). Prevents two live
+      // loops from both sending the remaining tail.
+      if (this.activeRun.get(broadcastId) !== run) {
+        this.logger.log(`Broadcast ${broadcastId}: superseded by a newer run — stopping stale loop`);
+        return;
+      }
+
       // Check if broadcast was paused or cancelled between messages.
       const current = await prisma.broadcast.findUnique({
         where: { id: broadcastId },
@@ -411,6 +569,7 @@ export class BroadcastService implements OnModuleInit {
       },
     });
 
+    if (this.activeRun.get(broadcastId) === run) this.activeRun.delete(broadcastId);
     this.logger.log(`Broadcast ${broadcastId}: Completed. Sent: ${sentCount}, Failed: ${failedCount}`);
   }
 
@@ -448,23 +607,42 @@ export class BroadcastService implements OnModuleInit {
       throw new BadRequestException('Can only resume paused broadcasts');
     }
 
-    // A paused broadcast retains its recipient snapshot and cursor, so we simply flip
-    // it back to running and re-launch — execution continues from the exact recipient
-    // it stopped on. (The old code re-resolved recipients and sliced by stats.sent,
-    // which mis-aligned whenever a send had failed or the underlying contacts changed.)
-    if (!Array.isArray(broadcast.resolvedRecipients)) {
-      // Legacy broadcast started before durable execution existed — restart cleanly.
-      return this.start(id);
+    const hasSnapshot = Array.isArray(broadcast.resolvedRecipients);
+    if (!hasSnapshot && ((broadcast.stats as any)?.sent || 0) > 0) {
+      // Legacy broadcast interrupted mid-send with no durable snapshot: we can't tell
+      // which recipients were already contacted, so resuming would risk re-sending them.
+      // Refuse rather than risk a ban — a new broadcast is the safe path.
+      throw new BadRequestException(
+        'This broadcast was interrupted before durable tracking and cannot be safely resumed; create a new broadcast for the remaining recipients',
+      );
     }
 
-    await prisma.broadcast.update({
-      where: { id },
-      data: { status: 'running' },
-    });
+    // Atomically claim paused → running so two concurrent resume requests (double-click,
+    // client retry, or a manual start() delegating here) can't both launch a loop from
+    // the same cursor and double-send the remaining recipients.
+    const claimed = await this.claimForRunning(id, 'paused');
+    if (!claimed) {
+      throw new BadRequestException('Broadcast state changed; please retry');
+    }
 
-    this.launchExecution(id);
+    if (hasSnapshot) {
+      // Durable snapshot retained → execution continues from the exact recipient it
+      // stopped on (no fragile slice, no cursor reset).
+      this.launchExecution(id);
+      return { success: true, message: 'Broadcast resumed' };
+    }
 
-    return { success: true, message: 'Broadcast resumed' };
+    // Legacy paused broadcast that never sent anything → safe to resolve fresh, snapshot,
+    // and run from the start.
+    const recipientCount = await this.prepareAndLaunchOrRevert(id, broadcast, 'paused');
+    if (recipientCount === null) {
+      await prisma.broadcast.update({
+        where: { id },
+        data: { status: 'failed', completedAt: new Date() },
+      });
+      throw new BadRequestException('No recipients found for this broadcast');
+    }
+    return { success: true, message: 'Broadcast started', recipientCount };
   }
 
   // Cancel broadcast


### PR DESCRIPTION
## Problem

Scheduled broadcasts never fired. `schedule()` set `status='scheduled'` + `scheduledAt`, but nothing ever started them — `scheduled-message.cron.ts` only handles scheduled **messages**. A user who scheduled a broadcast got silence.

## Change

Add a `BroadcastSchedulerCron` (`@Cron` every 30s) that launches due scheduled broadcasts, and harden **every** path that moves a broadcast to `running` so the top anti-ban invariant holds: **no recipient is ever sent the same broadcast twice.**

Broadcast execution hits real WhatsApp numbers, so this was reviewed adversarially over **four rounds** (multi-agent, each finding verified by an independent skeptic). **Nine** concrete double-send / silent-failure defects were found and fixed; the final round came back clean.

### Anti-ban hardening
- **Single-winner transitions.** Every claim to `running` is an atomic Prisma `updateMany` compare-and-set (`where status=<from> → running`, proceed only on `count===1`): `start()`, `resume()` (was a non-atomic read-then-write — two concurrent resumes could both launch and double-send the tail), and the cron's `startScheduled()`.
- **`start()` on a paused broadcast** delegates to `resume()` instead of resetting `cursor:0` (which re-sent everyone already contacted). `resume()` handles the legacy no-snapshot case inline and **refuses** to resume a partially-sent broadcast it can't track, rather than restarting from scratch.
- **`schedule()` is draft-only**, so a partially-sent paused broadcast can't be rescheduled and re-sent from cursor 0 by the cron.
- **Run token.** Each launched loop gets a monotonic token claimed synchronously; a loop exits the instant a newer one supersedes it — a `pause→resume` during a pacing delay can't leave two loops sending the same tail.
- **Crash-window recovery.** A `running` broadcast with no snapshot (killed between claim and snapshot, or legacy) is recovered — resolved fresh if nothing was sent, or marked `failed` if some were (never re-sends) — instead of being silently completed with zero sends.
- **`update()` whitelists** the four editable fields (`name`/`message`/`recipients`/`settings`) instead of forwarding the raw body, closing a mass-assignment sink where `{"status":"draft"}` or `{"cursor":0}` could flip execution state and trigger a re-send.
- **`prepareAndLaunchOrRevert`** rolls status back on a transient error after the claim, so a launch failure can't strand a broadcast in `running` (the cron auto-retries).

Pacing (per-message random delay + 30s batch pause + `messagesService`→send-gate) is unchanged.

## Tests

25 new/updated unit tests across `broadcast.service.spec.ts` + `broadcast-scheduler.cron.spec.ts`: single-winner claims, `start()`-on-paused continuation, legacy-resume refusal, run-token supersession, crash-window recovery, mass-assignment guard, revert-on-throw, and the cron's due-selection / per-broadcast error isolation. Full API suite green (169 local; `auth.service.spec` skipped locally for an unrelated bcrypt native-binding issue — CI builds it).

## Schema

None. The `cursor` / `resolvedRecipients` columns landed in #41.

## Out of scope (tracked follow-ups)
- Enable a global `ValidationPipe` `whitelist` (API-wide mass-assignment defense) — its own PR.
- A `running` watchdog + a recovery lock before scaling the API past one instance (PLN is single-instance today).