### PR TITLE
feat(api): enable ValidationPipe whitelist + validate the DTOs that lacked it

### DIFF
--- a/apps/api/src/common/validation-whitelist.spec.ts
+++ b/apps/api/src/common/validation-whitelist.spec.ts
@@ -1,0 +1,61 @@
+// Locks the global ValidationPipe whitelist contract (mirrors main.ts config):
+// unknown request-body fields are stripped (mass-assignment defense), and the DTO
+// fields that were newly decorated in this change survive.
+
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+import { ValidationPipe, ArgumentMetadata } from '@nestjs/common';
+import { CreateAutoreplyDto } from '../modules/autoreply/dto';
+import { AssignRoleDto } from '../modules/rbac/dto';
+
+const pipe = new ValidationPipe({
+  whitelist: true,
+  transform: true,
+  transformOptions: { enableImplicitConversion: true },
+});
+
+const bodyMeta = (metatype: any): ArgumentMetadata => ({ type: 'body', metatype, data: '' });
+
+describe('ValidationPipe whitelist', () => {
+  it('keeps CreateAutoreplyDto fields and strips unknown/execution-state fields', async () => {
+    const out: any = await pipe.transform(
+      {
+        profileId: 'p1',
+        keywords: ['hi'],
+        response: 'hello',
+        isActive: false,
+        cooldownSecs: 30,
+        // hostile extras that must be dropped:
+        status: 'HACK',
+        cursor: 9,
+        id: 'forged',
+      },
+      bodyMeta(CreateAutoreplyDto),
+    );
+
+    expect(out.profileId).toBe('p1');
+    expect(out.keywords).toEqual(['hi']);
+    expect(out.response).toBe('hello');
+    expect(out.isActive).toBe(false);
+    expect(out.cooldownSecs).toBe(30);
+    expect('status' in out).toBe(false);
+    expect('cursor' in out).toBe(false);
+    expect('id' in out).toBe(false);
+  });
+
+  it('rejects a CreateAutoreplyDto missing now-required fields', async () => {
+    // keywords + response are required — before decorators this passed and 500'd downstream.
+    await expect(pipe.transform({ profileId: 'p1' }, bodyMeta(CreateAutoreplyDto))).rejects.toBeTruthy();
+  });
+
+  it('keeps AssignRoleDto ids and strips extras', async () => {
+    const out: any = await pipe.transform(
+      { userId: 'u1', roleId: 'r1', organizationId: 'forged', extra: 'x' },
+      bodyMeta(AssignRoleDto),
+    );
+    expect(out.userId).toBe('u1');
+    expect(out.roleId).toBe('r1');
+    expect('organizationId' in out).toBe(false); // not a field on AssignRoleDto → stripped
+    expect('extra' in out).toBe(false);
+  });
+});

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -101,6 +101,12 @@ async function bootstrap() {
     console.log('🔧 [6/7] Setting up validation & Swagger...');
     app.useGlobalPipes(
       new ValidationPipe({
+        // Strip any request-body property that isn't a validated DTO field. This is an
+        // API-wide mass-assignment defense: without it, a body like {"status":"draft"}
+        // or {"cursor":0} flows through `dto as any` writes into columns the client
+        // should never control. `forbidNonWhitelisted` is left OFF (strip, don't reject)
+        // so existing clients that send extra fields keep working.
+        whitelist: true,
         transform: true,
         transformOptions: {
           enableImplicitConversion: true,

--- a/apps/api/src/modules/autoreply/dto/index.ts
+++ b/apps/api/src/modules/autoreply/dto/index.ts
@@ -2,77 +2,107 @@
 // apps/api/src/modules/autoreply/dto/index.ts
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsBoolean, IsIn, IsInt, IsOptional, IsString } from 'class-validator';
 
 // Quick Reply (preset response)
 export class QuickReplyDto {
   @ApiProperty({ example: 'profile-uuid' })
+  @IsString()
   profileId: string;
 
   @ApiProperty({ example: '/greeting', description: 'Shortcut command' })
+  @IsString()
   shortcut: string;
 
   @ApiProperty({ example: 'Greeting Message' })
+  @IsString()
   title: string;
 
   @ApiProperty({ example: 'Hello! How can I help you today?' })
+  @IsString()
   message: string;
 }
 
 // Simple Keyword Autoreply
 export class CreateAutoreplyDto {
   @ApiProperty({ example: 'profile-uuid' })
+  @IsString()
   profileId: string;
 
-  @ApiProperty({ 
+  @ApiProperty({
     example: ['halo', 'hello', 'hi'],
-    description: 'Keywords that trigger this reply'
+    description: 'Keywords that trigger this reply',
   })
+  @IsArray()
+  @IsString({ each: true })
   keywords: string[];
 
-  @ApiPropertyOptional({ 
+  @ApiPropertyOptional({
     example: 'contains',
-    enum: ['exact', 'contains', 'startsWith']
+    enum: ['exact', 'contains', 'startsWith'],
   })
+  @IsOptional()
+  @IsIn(['exact', 'contains', 'startsWith'])
   matchMode?: string;
 
-  @ApiProperty({ 
+  @ApiProperty({
     example: 'Hello {{name}}! Welcome to our store. How can I help you?',
-    description: 'Response message (supports {{name}}, {{phone}}, {{time}} variables)'
+    description: 'Response message (supports {{name}}, {{phone}}, {{time}} variables)',
   })
+  @IsString()
   response: string;
 
   @ApiPropertyOptional({ example: true })
+  @IsOptional()
+  @IsBoolean()
   isActive?: boolean;
 
-  @ApiPropertyOptional({ 
+  @ApiPropertyOptional({
     example: true,
-    description: 'Only trigger in private chats (not groups)'
+    description: 'Only trigger in private chats (not groups)',
   })
+  @IsOptional()
+  @IsBoolean()
   privateOnly?: boolean;
 
-  @ApiPropertyOptional({ 
+  @ApiPropertyOptional({
     example: 60,
-    description: 'Cooldown in seconds per contact'
+    description: 'Cooldown in seconds per contact',
   })
+  @IsOptional()
+  @IsInt()
   cooldownSecs?: number;
 }
 
 export class UpdateAutoreplyDto {
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
   keywords?: string[];
 
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsIn(['exact', 'contains', 'startsWith'])
   matchMode?: string;
 
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
   response?: string;
 
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
   isActive?: boolean;
 
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
   privateOnly?: boolean;
 
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsInt()
   cooldownSecs?: number;
 }

--- a/apps/api/src/modules/messages/dto/index.ts
+++ b/apps/api/src/modules/messages/dto/index.ts
@@ -2,7 +2,7 @@
 // apps/api/src/modules/messages/dto/index.ts
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, IsNumber, IsBoolean, ValidateNested, IsArray } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsNumber, IsBoolean, ValidateNested, IsArray, Allow } from 'class-validator';
 import { Type } from 'class-transformer';
 import { IsWhatsAppRecipient } from '../../../common/validators/is-whatsapp-recipient.validator';
 
@@ -381,6 +381,7 @@ export class ScheduleMessageDto extends BaseMessageDto {
   type: string;
 
   @ApiProperty({ description: 'Message content (text, media options, etc.)' })
+  @Allow() // free-form Json payload — kept as-is under whitelist, not stripped
   content: any;
 
   @ApiProperty({ example: '2026-03-01T10:00:00Z', description: 'ISO 8601 datetime to send' })

--- a/apps/api/src/modules/rbac/dto/index.ts
+++ b/apps/api/src/modules/rbac/dto/index.ts
@@ -2,39 +2,58 @@
 // apps/api/src/modules/rbac/dto/index.ts
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsString } from 'class-validator';
 
 export class CreateRoleDto {
-  @ApiProperty({ example: 'org-uuid' })
+  // Always overwritten from the authenticated principal in the controller — never
+  // trusted from the client, so validation is optional (the controller sets it before use).
+  @ApiPropertyOptional({ example: 'org-uuid' })
+  @IsOptional()
+  @IsString()
   organizationId: string;
 
   @ApiProperty({ example: 'Support Agent' })
+  @IsString()
   name: string;
 
   @ApiPropertyOptional({ example: 'Can view and send messages only' })
+  @IsOptional()
+  @IsString()
   description?: string;
 
-  @ApiProperty({ 
+  @ApiProperty({
     example: ['message:send', 'message:read', 'contact:read'],
-    description: 'List of permission keys'
+    description: 'List of permission keys',
   })
+  @IsArray()
+  @IsString({ each: true })
   permissions: string[];
 }
 
 export class UpdateRoleDto {
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
   name?: string;
 
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
   description?: string;
 
   @ApiPropertyOptional()
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
   permissions?: string[];
 }
 
 export class AssignRoleDto {
   @ApiProperty({ example: 'user-uuid' })
+  @IsString()
   userId: string;
 
   @ApiProperty({ example: 'role-uuid' })
+  @IsString()
   roleId: string;
 }


### PR DESCRIPTION
## What

Turn on the global `ValidationPipe` **`whitelist: true`** so any request-body property that isn't a declared, validated DTO field is **stripped** before it reaches a service. API-wide mass-assignment defense — the systemic version of the pointwise fix in [#42's broadcast `update()`](https://github.com/ribato22/MultiWA/pull/42).

Without it, a body like `{"status":"draft"}` or `{"cursor":0}` flows through `data: dto as any` writes into columns the client must never control.

`forbidNonWhitelisted` is deliberately **OFF** (strip, don't reject) so existing clients sending extra fields keep working.

## The audit (why this isn't a one-liner)

`whitelist` strips any property with **no class-validator decorator** — so DTOs declared with only `@ApiProperty` (Swagger) and no `@IsString`/`@IsOptional`/etc. would have their fields silently dropped, breaking endpoints. A multi-agent audit of **all 12 DTO modules** found **26 consumed-but-undecorated fields** in three modules. The other 9 modules were already fully decorated.

Fixed by adding the missing class-validator decorators — which both keeps the fields under whitelist **and** gives these endpoints the input validation they never had:

- **autoreply** — `CreateAutoreplyDto` / `UpdateAutoreplyDto` / `QuickReplyDto`: every field was undecorated. E.g. `keywords` stripped → `dto.keywords.slice(...)` throws → **500 on every create**.
- **rbac** — `CreateRoleDto` / `UpdateRoleDto` / `AssignRoleDto`: `name` / `permissions` / `userId` / `roleId` undecorated. `organizationId` is validated-optional (the controller always overwrites it from the authenticated principal — never trusted from the client).
- **messages** — `ScheduleMessageDto.content` → `@Allow()` (free-form Json, kept as-is).

## Test

New `validation-whitelist.spec.ts` drives the **real ValidationPipe** (no e2e harness exists) to lock the contract: unknown/execution-state fields (`status`, `cursor`, `id`) are stripped, decorated fields survive, and a body missing now-required fields is rejected. Full API suite green (172 local; `auth.service.spec` skipped locally for an unrelated bcrypt native-binding issue — CI builds it).

## ⚠️ Out of scope (separate follow-up)

Endpoints typed `@Body() dto: any` / inline object / `Record<string,any>` (**accounts**, **workspaces**, **organizations**, a few auth/settings) have **no DTO class**, so the pipe skips them entirely (`metatype` is `Object`). Whitelist neither breaks nor protects them — they remain mass-assignment-exposed and need real DTOs written. Tracked as a follow-up; the notable DB-writing ones are `accounts.create/update`, `workspaces.create/update`, `organizations.update`.