### PR TITLE
ci: export a service image as a .tar.gz artifact (air-gapped deploy)

### DIFF
--- a/.github/workflows/export-image.yml
+++ b/.github/workflows/export-image.yml
@@ -1,0 +1,49 @@
+name: Export image tarball (air-gapped deploy)
+
+# Builds a service image on a native amd64 runner and uploads it as a downloadable
+# .tar.gz artifact, so it can be transferred to an air-gapped host (docker load).
+# Used for the wagw deploy path: build here -> download -> scp -> /opt/multiwa/images/.
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: Which image to build + export
+        type: choice
+        options: [api, worker, admin]
+        default: api
+      tag:
+        description: Image tag (multiwa-<service>:<tag>)
+        default: wagw
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image (amd64)
+        env:
+          SERVICE: ${{ inputs.service }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          ARGS=""
+          if [ "$SERVICE" = "admin" ]; then
+            ARGS="--build-arg NEXT_PUBLIC_API_URL=https://wagw.plnbatam.com"
+          fi
+          docker build -f "docker/Dockerfile.$SERVICE" $ARGS -t "multiwa-$SERVICE:$TAG" .
+
+      - name: Save + gzip
+        env:
+          SERVICE: ${{ inputs.service }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          docker save "multiwa-$SERVICE:$TAG" | gzip > "multiwa-$SERVICE-$TAG.tar.gz"
+          ls -lh "multiwa-$SERVICE-$TAG.tar.gz"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: multiwa-image-${{ inputs.service }}-${{ inputs.tag }}
+          path: multiwa-*.tar.gz
+          retention-days: 5


### PR DESCRIPTION
Adds a `workflow_dispatch` workflow that builds `multiwa-<service>:<tag>` on a native amd64 runner and uploads it as a downloadable `.tar.gz` artifact.

Purpose: the wagw production host is **air-gapped** and its Docker images are built off-server. This gives a reliable, native-amd64 build path (the Mac is arm64 + its local Docker is broken) whose output can be downloaded and `scp`'d into `/opt/multiwa/images/` for `05-redeploy-api.sh`.

Inputs are read via `env:` (not interpolated into `run:`) to avoid workflow injection. No effect on existing CI.