### PR TITLE
fix(engine): coerce inbound WhatsApp message id to a string (group @lid messages)

### DIFF
--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import * as QRCode from 'qrcode';
 import { RuleEngineService, IncomingMessage } from '../automation/rule-engine.service';
 import { NotificationsService, NotificationType } from '../notifications/notifications.service';
+import { serializeWaMessageId } from './wa-message-id';
 
 
 interface EngineInstance {
@@ -1017,7 +1018,7 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
             data: {
               profileId,
               conversationId: conversation.id,
-              messageId: message.id?._serialized || message.id || `in_${Date.now()}`,
+              messageId: serializeWaMessageId(message),
               direction: 'incoming',
               senderJid,
               type: msgType === 'chat' ? 'text' : msgType,

--- a/apps/api/src/modules/profiles/wa-message-id.spec.ts
+++ b/apps/api/src/modules/profiles/wa-message-id.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { serializeWaMessageId } from './wa-message-id';
+
+describe('serializeWaMessageId', () => {
+  it('passes through a plain string id', () => {
+    expect(serializeWaMessageId({ id: 'false_628@c.us_ABC' })).toBe('false_628@c.us_ABC');
+  });
+
+  it('prefers the top-level _serialized', () => {
+    expect(serializeWaMessageId({ _serialized: 'TOP', id: { _serialized: 'NESTED' } })).toBe('TOP');
+  });
+
+  it('uses id._serialized when present', () => {
+    expect(serializeWaMessageId({ id: { _serialized: 'Y' } })).toBe('Y');
+  });
+
+  it('uses id.$1 when the serialized field was renamed', () => {
+    expect(serializeWaMessageId({ id: { fromMe: false, remote: 'g@g.us', id: 'ABC', $1: 'SER' } })).toBe('SER');
+  });
+
+  // The exact production crash: a group message from an @lid participant whose id
+  // object has no usable serialized field. It must reconstruct, never return the object.
+  it('reconstructs a group @lid id object (the production crash case)', () => {
+    const id = { fromMe: false, remote: '120363019234439872@g.us', id: '3EB0C72E79BD7F9D8444D1', participant: '38002055245963@lid' };
+    const out = serializeWaMessageId({ id });
+    expect(out).toBe('false_120363019234439872@g.us_3EB0C72E79BD7F9D8444D1_38002055245963@lid');
+    expect(typeof out).toBe('string');
+  });
+
+  it('reconstructs a 1:1 id object with no participant', () => {
+    expect(serializeWaMessageId({ id: { fromMe: true, remote: '628@c.us', id: 'ZZ' } })).toBe('true_628@c.us_ZZ');
+  });
+
+  it('never returns a non-string; falls back for null/garbage', () => {
+    expect(serializeWaMessageId(null)).toMatch(/^in_/);
+    expect(serializeWaMessageId({ id: {} })).toMatch(/^in_/);
+    expect(serializeWaMessageId({ id: 123 })).toMatch(/^in_/);
+  });
+});

--- a/apps/api/src/modules/profiles/wa-message-id.ts
+++ b/apps/api/src/modules/profiles/wa-message-id.ts
@@ -1,0 +1,35 @@
+// apps/api/src/modules/profiles/wa-message-id.ts
+//
+// The WhatsApp engine normally hands us a message whose id is the serialized string,
+// but for GROUP messages from @lid participants (and across some engine/serialization
+// boundaries) `message.id` arrives as the raw MessageId OBJECT — sometimes with
+// `_serialized` renamed to `$1`, sometimes missing it entirely. Passing that object
+// into prisma.message.create({ data: { messageId } }) (a String column) throws a
+// PrismaClientValidationError, which silently dropped every such inbound message → no
+// `message.received` webhook fired → downstream bots/integrations stopped responding.
+//
+// This coerces any of those shapes to the canonical serialized id string.
+
+export function serializeWaMessageId(message: any): string {
+  const fallback = () => `in_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  if (!message) return fallback();
+
+  // The adapter also copies the serialized id to the top level.
+  if (typeof message._serialized === 'string' && message._serialized) return message._serialized;
+
+  const id = message.id;
+  if (typeof id === 'string' && id) return id;
+
+  if (id && typeof id === 'object') {
+    if (typeof id._serialized === 'string' && id._serialized) return id._serialized;
+    // Some engine/serialization paths surface the serialized value under `$1`.
+    if (typeof id.$1 === 'string' && id.$1) return id.$1;
+    // Reconstruct the canonical form: fromMe_remote_id[_participant].
+    const parts = [id.fromMe, id.remote, id.id, id.participant].filter(
+      (v) => v !== undefined && v !== null && v !== '',
+    );
+    if (parts.length >= 3) return parts.join('_');
+  }
+
+  return fallback();
+}


### PR DESCRIPTION
## Incident
After the #42 cutover, the PLN bot stopped responding. Root cause found on the server: **inbound group messages from @lid participants were being dropped.**

`prisma.message.create()` received `messageId` as the raw **MessageId object** (`{fromMe, remote, id, participant, ...}`, with `_serialized` surfaced as `$1` or absent) instead of a string → **PrismaClientValidationError** on every such message → the message was never saved → **no `message.received` webhook** fired → the bot never saw incoming messages.

Confirmed on wagw: 645 incoming msgs/8h, recurring `ERROR [EngineManagerService] Error processing incoming message: PrismaClientValidationError`, and `message.received` absent from webhook_logs (only sent/delivered/read delivered).

## Fix
`serializeWaMessageId(message)` coerces any shape to the canonical serialized string (string id / top-level `_serialized` / `id._serialized` / `id.$1` / reconstruct `fromMe_remote_id[_participant]` / safe fallback). Never returns a non-string. 7 unit tests including the exact production crash object.

Api-only change. Hotfix — to be built + redeployed to wagw.