### PR TITLE
test(api): e2e API-key authentication flow

### DIFF
--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -9,6 +9,7 @@
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { Test } from '@nestjs/testing';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { ThrottlerGuard } from '@nestjs/throttler';
 import { AppModule } from '../src/app.module';
 import { configureApp } from '../src/app.factory';
 import { EngineManagerService } from '../src/modules/profiles/engine-manager.service';
@@ -40,6 +41,10 @@ describe('API (e2e)', () => {
     const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
       .overrideProvider(EngineManagerService)
       .useValue(engineStub)
+      // e2e drives many auth requests; the per-route @Throttle (register/login 5/min)
+      // would rate-limit the suite itself, so disable rate limiting for tests.
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
       .compile();
 
     app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
@@ -170,9 +175,7 @@ describe('API (e2e)', () => {
         headers: { authorization: `Bearer ${token}` },
         payload: { name: 'e2e-integration' },
       });
-      if (![200, 201].includes(created.statusCode)) {
-        throw new Error(`create api-key failed: ${created.statusCode} — ${created.body}`);
-      }
+      expect([200, 201]).toContain(created.statusCode);
       const apiKey: string = created.json().key;
       expect(apiKey).toMatch(/^mwa_/); // raw key returned only on creation
 

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -150,4 +150,39 @@ describe('API (e2e)', () => {
       expect((listB.json() as any[]).map((a) => a.id)).not.toContain(accountIdA);
     });
   });
+
+  // API-key auth is how bots/integrations authenticate (not JWT). Exercises the
+  // JwtOrApiKeyGuard + api-key passport strategy end-to-end.
+  describe('API-key authentication', () => {
+    it('creates a key and authenticates a request with x-api-key', async () => {
+      const token = await register(app, `apikey_${Date.now()}@test.local`);
+
+      // Create an API key (JWT-authed).
+      const created = await app.inject({
+        method: 'POST',
+        url: '/api/v1/api-keys',
+        headers: { authorization: `Bearer ${token}` },
+        payload: { name: 'e2e-integration' },
+      });
+      expect([200, 201]).toContain(created.statusCode);
+      const apiKey: string = created.json().key;
+      expect(apiKey).toMatch(/^mwa_/); // raw key returned only on creation
+
+      // The key authenticates a JwtOrApiKey-guarded endpoint.
+      const withKey = await app.inject({
+        method: 'GET',
+        url: '/api/v1/accounts',
+        headers: { 'x-api-key': apiKey },
+      });
+      expect(withKey.statusCode).toBe(200);
+
+      // A bogus key is rejected.
+      const bogus = await app.inject({
+        method: 'GET',
+        url: '/api/v1/accounts',
+        headers: { 'x-api-key': 'mwa_not_a_real_key' },
+      });
+      expect(bogus.statusCode).toBe(401);
+    });
+  });
 });

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -28,7 +28,11 @@ async function register(app: NestFastifyApplication, email: string): Promise<str
     url: '/api/v1/auth/register',
     payload: { email, password: 'password123', name: 'U', organizationName: `Org-${email}` },
   });
-  return res.json().accessToken as string;
+  const token = res.json()?.accessToken;
+  if (typeof token !== 'string') {
+    throw new Error(`register failed: ${res.statusCode} — ${res.body}`);
+  }
+  return token;
 }
 
 const authGet = (app: NestFastifyApplication, url: string, token: string) =>

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -156,6 +156,12 @@ describe('API (e2e)', () => {
   describe('API-key authentication', () => {
     it('creates a key and authenticates a request with x-api-key', async () => {
       const token = await register(app, `apikey_${Date.now()}@test.local`);
+      expect(typeof token).toBe('string');
+
+      // Sanity: the same token authenticates a known-good endpoint (isolates any
+      // failure below to the api-keys route rather than the token).
+      const sanity = await authGet(app, '/api/v1/accounts', token);
+      expect(sanity.statusCode).toBe(200);
 
       // Create an API key (JWT-authed).
       const created = await app.inject({
@@ -164,7 +170,9 @@ describe('API (e2e)', () => {
         headers: { authorization: `Bearer ${token}` },
         payload: { name: 'e2e-integration' },
       });
-      expect([200, 201]).toContain(created.statusCode);
+      if (![200, 201].includes(created.statusCode)) {
+        throw new Error(`create api-key failed: ${created.statusCode} — ${created.body}`);
+      }
       const apiKey: string = created.json().key;
       expect(apiKey).toMatch(/^mwa_/); // raw key returned only on creation
 

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -9,7 +9,6 @@
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { Test } from '@nestjs/testing';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
-import { ThrottlerGuard } from '@nestjs/throttler';
 import { AppModule } from '../src/app.module';
 import { configureApp } from '../src/app.factory';
 import { EngineManagerService } from '../src/modules/profiles/engine-manager.service';
@@ -22,10 +21,16 @@ const engineStub = {
 };
 
 // register() creates a fresh org + default workspace + "Default Account" + owner user.
+let clientSeq = 0;
 async function register(app: NestFastifyApplication, email: string): Promise<string> {
+  clientSeq += 1;
   const res = await app.inject({
     method: 'POST',
     url: '/api/v1/auth/register',
+    // Unique client IP per call: /auth/register carries @Throttle(5/min), which is
+    // per-IP — a growing e2e suite from one IP would rate-limit itself (429). Each
+    // registration is treated as a distinct client. (req.ip = socket addr; no trustProxy.)
+    remoteAddress: `10.9.${Math.floor(clientSeq / 254) % 254}.${(clientSeq % 254) + 1}`,
     payload: { email, password: 'password123', name: 'U', organizationName: `Org-${email}` },
   });
   const token = res.json()?.accessToken;
@@ -45,10 +50,6 @@ describe('API (e2e)', () => {
     const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
       .overrideProvider(EngineManagerService)
       .useValue(engineStub)
-      // e2e drives many auth requests; the per-route @Throttle (register/login 5/min)
-      // would rate-limit the suite itself, so disable rate limiting for tests.
-      .overrideGuard(ThrottlerGuard)
-      .useValue({ canActivate: () => true })
       .compile();
 
     app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());


### PR DESCRIPTION
Extends the e2e harness (#46/#47) to cover **API-key auth** — the path bots/integrations use (the one behind the recent bot outage), which JWT-based tests don't touch.

- create an API key (JWT-authed) → returns `mwa_…`
- authenticate a `JwtOrApiKey`-guarded request with `x-api-key` → **200**
- bogus key → **401**

Runs in the existing e2e job (reused app boot). No src changes.