### PR TITLE
fix(admin): enforce TypeScript in next build (drop ignoreBuildErrors)

### DIFF
--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -3,13 +3,15 @@ const nextConfig = {
   output: "standalone",
   reactStrictMode: true,
   transpilePackages: ["@multiwa/core", "@multiwa/database"],
-  // Ignore ESLint and TypeScript errors during production build
-  // This prevents version mismatch issues on different servers
+  // TypeScript IS enforced during `next build`: the admin `tsc --noEmit` CI gate keeps
+  // the app type-clean, and builds now run in CI (consistent env), so there is no
+  // silent-type-error footgun. ESLint stays off during build for now (the admin's
+  // Next-lint isn't gated yet — a separate follow-up).
   eslint: {
     ignoreDuringBuilds: true,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   experimental: {
     serverActions: {


### PR DESCRIPTION
The admin already passes a standalone `tsc --noEmit` CI gate (#30) and its image is built in CI (consistent env), so `next build` silently ignoring type errors was a footgun. Flip `typescript.ignoreBuildErrors` → `false` so the production build enforces types too.

Validated by the CI admin image build (Dockerfile.admin → `next build`). ESLint-during-build stays off pending a separate Next-lint audit.