### PR TITLE
chore(lint): clear no-unused-vars + no-case-declarations, ratchet rules to error

### DIFF
--- a/apps/api/src/modules/accounts/accounts.service.ts
+++ b/apps/api/src/modules/accounts/accounts.service.ts
@@ -224,7 +224,7 @@ export class AccountsService {
     };
   }
 
-  async getQr(accountId: string, profileId: string) {
+  async getQr(_accountId: string, _profileId: string) {
     // This would integrate with the WhatsApp engine to get QR code
     // For now return a placeholder
     return {

--- a/apps/api/src/modules/ai/ai.service.ts
+++ b/apps/api/src/modules/ai/ai.service.ts
@@ -179,7 +179,7 @@ export class AIService {
       knowledgeContext?: string; // Pre-fetched KB context
     }
   ): Promise<AICompletionResult> {
-    let kbContext = context?.knowledgeContext || '';
+    const kbContext = context?.knowledgeContext || '';
 
     const systemPrompt = context?.customPrompt || `
 You are a helpful customer service assistant for ${context?.businessName || 'our business'}.

--- a/apps/api/src/modules/audit/audit.interceptor.ts
+++ b/apps/api/src/modules/audit/audit.interceptor.ts
@@ -149,7 +149,7 @@ export class AuditInterceptor implements NestInterceptor {
     const userAgent = req.headers?.['user-agent'];
     
     return next.handle().pipe(
-      tap((response) => {
+      tap((_response) => {
         // Log successful action (fire-and-forget)
         this.auditService.log({
           action,

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -157,7 +157,7 @@ export class AuthService {
       throw new UnauthorizedException('User not found');
     }
 
-    const { passwordHash, twoFactorSecret, backupCodes, ...profile } = user;
+    const { passwordHash: _passwordHash, twoFactorSecret: _twoFactorSecret, backupCodes, ...profile } = user;
     return {
       ...profile,
       twoFactorEnabled: user.twoFactorEnabled,

--- a/apps/api/src/modules/auth/dto/index.ts
+++ b/apps/api/src/modules/auth/dto/index.ts
@@ -2,7 +2,7 @@
 // apps/api/src/modules/auth/dto/index.ts
 
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength, IsOptional } from 'class-validator';
+import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
   @ApiProperty({ example: 'user@example.com' })

--- a/apps/api/src/modules/automation/automation.service.ts
+++ b/apps/api/src/modules/automation/automation.service.ts
@@ -1,7 +1,7 @@
 // MultiWA Gateway - Automation Service
 // apps/api/src/modules/automation/automation.service.ts
 
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { prisma } from '@multiwa/database';
 import { CreateAutomationDto, UpdateAutomationDto } from './dto';
 
@@ -86,19 +86,19 @@ export class AutomationService {
     const config = automation.triggerConfig as any;
     
     let matches = false;
-    let matchDetails: any = {};
+    const matchDetails: any = {};
 
     switch (automation.triggerType) {
-      case 'keyword':
+      case 'keyword': {
         const keywords = config.keywords || [];
         const matchMode = config.matchMode || 'contains';
         const caseSensitive = config.caseSensitive || false;
-        
+
         const testMsg = caseSensitive ? message : message.toLowerCase();
-        
+
         for (const keyword of keywords) {
           const testKeyword = caseSensitive ? keyword : keyword.toLowerCase();
-          
+
           if (matchMode === 'exact' && testMsg === testKeyword) {
             matches = true;
             matchDetails.matchedKeyword = keyword;
@@ -114,6 +114,7 @@ export class AutomationService {
           }
         }
         break;
+      }
 
       case 'regex':
         try {
@@ -211,7 +212,7 @@ export class AutomationService {
   }
 
   // Check cooldown
-  async checkCooldown(id: string, contactJid: string): Promise<boolean> {
+  async checkCooldown(id: string, _contactJid: string): Promise<boolean> {
     const automation = await this.findOne(id);
     if (!automation.cooldownSecs) return true;
 

--- a/apps/api/src/modules/automation/rule-engine.service.ts
+++ b/apps/api/src/modules/automation/rule-engine.service.ts
@@ -95,12 +95,13 @@ export class RuleEngineService {
     const config = automation.triggerConfig as any;
 
     switch (automation.triggerType) {
-      case 'keyword':
+      case 'keyword': {
         const keywordMatch = this.matchKeyword(message.content?.text || '', config);
         if (!keywordMatch) {
           // Log for debugging keyword matching
         }
         return keywordMatch;
+      }
 
       case 'regex':
         return this.matchRegex(message.content?.text || '', config);
@@ -213,16 +214,18 @@ export class RuleEngineService {
       case 'message_type':
         return condition.types?.includes(message.messageType);
 
-      case 'time_range':
+      case 'time_range': {
         const now = new Date();
         const hour = now.getHours();
         return hour >= condition.startHour && hour < condition.endHour;
+      }
 
-      case 'day_of_week':
+      case 'day_of_week': {
         const day = new Date().getDay();
         return condition.days?.includes(day);
+      }
 
-      case 'contact_tag':
+      case 'contact_tag': {
         const contact = await prisma.contact.findFirst({
           where: {
             profileId: message.profileId,
@@ -230,6 +233,7 @@ export class RuleEngineService {
           },
         });
         return contact?.tags?.some((t) => condition.tags?.includes(t)) || false;
+      }
 
       default:
         // Unknown condition types should NOT pass silently

--- a/apps/api/src/modules/autoreply/autoreply.service.ts
+++ b/apps/api/src/modules/autoreply/autoreply.service.ts
@@ -263,7 +263,7 @@ export class AutoreplyService {
   }
 
   // OpenAI integration
-  private async callOpenAI(cfg: any, message: string, context?: any): Promise<string | null> {
+  private async callOpenAI(cfg: any, message: string, _context?: any): Promise<string | null> {
     try {
       const response = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
@@ -289,7 +289,7 @@ export class AutoreplyService {
   }
 
   // Dialogflow integration (not yet implemented)
-  private async callDialogflow(cfg: any, message: string, context?: any): Promise<string | null> {
+  private async callDialogflow(_cfg: any, _message: string, _context?: any): Promise<string | null> {
     // Dialogflow CX/ES integration can be added here
     return null;
   }

--- a/apps/api/src/modules/broadcast/broadcast.service.ts
+++ b/apps/api/src/modules/broadcast/broadcast.service.ts
@@ -419,7 +419,7 @@ export class BroadcastService implements OnModuleInit {
 
     // Resume from persisted cursor; seed counters from persisted stats so a resumed
     // or recovered run keeps counting rather than resetting to zero.
-    let cursor = broadcast.cursor || 0;
+    const cursor = broadcast.cursor || 0;
     const persistedStats = (broadcast.stats as any) || {};
     let sentCount = persistedStats.sent || 0;
     let failedCount = persistedStats.failed || 0;
@@ -574,7 +574,7 @@ export class BroadcastService implements OnModuleInit {
   }
 
   // Resolve template variables in message
-  private resolveTemplate(message: any, phone: string): string {
+  private resolveTemplate(message: any, _phone: string): string {
     if (typeof message === 'string') return message;
     if (message?.text) return message.text;
     if (message?.type === 'text' && message?.text) return message.text;

--- a/apps/api/src/modules/bulk/bulk.service.ts
+++ b/apps/api/src/modules/bulk/bulk.service.ts
@@ -288,7 +288,7 @@ export class BulkService {
     
     for (const [batchId, batch] of this.batches.entries()) {
       if (this.batchProfiles.get(batchId) === profileId) {
-        const { results, ...batchSummary } = batch;
+        const { results: _results, ...batchSummary } = batch;
         batches.push(batchSummary);
       }
     }

--- a/apps/api/src/modules/contacts/dto/index.ts
+++ b/apps/api/src/modules/contacts/dto/index.ts
@@ -11,7 +11,6 @@ import {
   IsBoolean,
   ValidateNested,
   ArrayNotEmpty,
-  IsPhoneNumber,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 

--- a/apps/api/src/modules/conversations/conversations.controller.ts
+++ b/apps/api/src/modules/conversations/conversations.controller.ts
@@ -1,7 +1,7 @@
 // MultiWA Gateway - Conversations Controller
 // apps/api/src/modules/conversations/conversations.controller.ts
 
-import { Controller, Get, Put, Delete, Param, Query, Body, UseGuards, Request } from '@nestjs/common';
+import { Controller, Get, Put, Delete, Param, Query, UseGuards, Request } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiSecurity, ApiQuery } from '@nestjs/swagger';
 import { ConversationsService } from './conversations.service';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-auth.guard';

--- a/apps/api/src/modules/conversations/conversations.service.ts
+++ b/apps/api/src/modules/conversations/conversations.service.ts
@@ -67,7 +67,7 @@ export class ConversationsService {
 
     // For conversations without a contact, try to resolve names by JID phone number
     const unlinkedConvs = conversations.filter(c => !c.contact && c.jid?.includes('@s.whatsapp.net'));
-    let phoneToName: Record<string, string> = {};
+    const phoneToName: Record<string, string> = {};
     
     if (unlinkedConvs.length > 0) {
       const phones = unlinkedConvs.map(c => c.jid.split('@')[0]);
@@ -90,7 +90,7 @@ export class ConversationsService {
       (c.type === 'group' || c.jid?.includes('@g.us')) &&
       (!c.name || /^[0-9]+(@g\.us|@s\.whatsapp\.net)?$/.test(c.name) || c.name === c.jid)
     );
-    let groupJidToName: Record<string, string> = {};
+    const groupJidToName: Record<string, string> = {};
 
     if (groupConvs.length > 0) {
       // Resolve each group name individually (faster than loading all 270+ groups)

--- a/apps/api/src/modules/groups/groups.controller.ts
+++ b/apps/api/src/modules/groups/groups.controller.ts
@@ -6,7 +6,6 @@ import {
   Get,
   Post,
   Patch,
-  Delete,
   Param,
   Body,
   Query,

--- a/apps/api/src/modules/integrations/integrations.controller.ts
+++ b/apps/api/src/modules/integrations/integrations.controller.ts
@@ -66,7 +66,7 @@ export class IntegrationsController {
   @ApiOperation({ summary: 'Update integration configuration (env-based, restart required)' })
   @ApiResponse({ status: 200, description: 'Configuration noted, restart needed' })
   @ApiValidationError()
-  async updateConfig(@Body() config: IntegrationConfig) {
+  async updateConfig(@Body() _config: IntegrationConfig) {
     // Note: The services read from environment variables.
     // This endpoint acknowledges the config but env changes require a restart.
     this.logger.log('Integration config update requested — environment restart needed for changes to take effect');

--- a/apps/api/src/modules/integrations/typebot.service.ts
+++ b/apps/api/src/modules/integrations/typebot.service.ts
@@ -51,7 +51,7 @@ export class TypeBotService {
 
     try {
       const sessionKey = `${typebotId}:${contactJid}`;
-      let session = this.sessions.get(sessionKey);
+      const session = this.sessions.get(sessionKey);
 
       let url: string;
       let body: any;

--- a/apps/api/src/modules/messages/messages.controller.ts
+++ b/apps/api/src/modules/messages/messages.controller.ts
@@ -1,7 +1,7 @@
 // MultiWA Gateway - Enhanced Messages Controller
 // apps/api/src/modules/messages/messages.controller.ts
 
-import { Controller, Get, Post, Delete, Put, Body, Param, Query, UseGuards, Req, applyDecorators, HttpException, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Body, Param, Query, UseGuards, Req, applyDecorators, HttpException, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiSecurity, ApiQuery, ApiCreatedResponse } from '@nestjs/swagger';
 import { ApiAuthErrors, ApiValidationError, ApiRateLimited, ApiNotFound } from '../../common/decorators/api-responses';
 import { MessagesService } from './messages.service';

--- a/apps/api/src/modules/messages/messages.service.ts
+++ b/apps/api/src/modules/messages/messages.service.ts
@@ -672,7 +672,7 @@ export class MessagesService {
 
   // Delete message (from database only)
   async delete(id: string) {
-    const message = await this.findOne(id);
+    const _message = await this.findOne(id);
     await prisma.message.delete({ where: { id } });
     return { success: true };
   }
@@ -680,7 +680,7 @@ export class MessagesService {
   // ========== NEW FEATURES ==========
 
   // Send typing indicator
-  async sendTyping(profileId: string, to: string, state: 'composing' | 'recording' | 'available' = 'composing', duration?: number) {
+  async sendTyping(profileId: string, to: string, state: 'composing' | 'recording' | 'available' = 'composing', _duration?: number) {
     const jid = this.normalizeJid(to);
 
     if (isWorkerEngine()) {

--- a/apps/api/src/modules/notifications/push.service.spec.ts
+++ b/apps/api/src/modules/notifications/push.service.spec.ts
@@ -2,7 +2,6 @@
 // Tests push notification subscription management and delivery
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as webpush from 'web-push';
 
 // Mock web-push
 vi.mock('web-push', () => ({

--- a/apps/api/src/modules/rbac/rbac.service.ts
+++ b/apps/api/src/modules/rbac/rbac.service.ts
@@ -314,7 +314,7 @@ export class RbacService {
   // ============================================
 
   async seedDefaultRoles(organizationId: string) {
-    for (const [key, role] of Object.entries(DEFAULT_ROLES)) {
+    for (const [_key, role] of Object.entries(DEFAULT_ROLES)) {
       const existing = await prisma.role.findFirst({
         where: { organizationId, name: role.name },
       });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -7,7 +7,6 @@ import * as crypto from 'crypto';
 
 const ENCRYPTION_ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16;
-const AUTH_TAG_LENGTH = 16;
 
 /**
  * Get or generate encryption key for sensitive settings.

--- a/apps/api/src/modules/statistics/statistics.service.ts
+++ b/apps/api/src/modules/statistics/statistics.service.ts
@@ -273,7 +273,7 @@ export class StatisticsService {
   // Response Time Analytics
   // ============================================
 
-  async getResponseTimeStats(profileId: string, range: DateRange) {
+  async getResponseTimeStats(_profileId: string, _range: DateRange) {
     // This would require conversation-level tracking in production
     // For now, return mock structure
     return {

--- a/apps/api/src/modules/templates/dto/index.ts
+++ b/apps/api/src/modules/templates/dto/index.ts
@@ -2,7 +2,7 @@
 // apps/api/src/modules/templates/dto/index.ts
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsOptional, IsNotEmpty, IsObject, IsEnum } from 'class-validator';
+import { IsString, IsOptional, IsNotEmpty, IsObject } from 'class-validator';
 
 export class CreateTemplateDto {
   @ApiProperty({ example: 'profile-uuid' })

--- a/apps/api/src/modules/uploads/local-storage.adapter.ts
+++ b/apps/api/src/modules/uploads/local-storage.adapter.ts
@@ -24,7 +24,7 @@ export class LocalStorageAdapter implements IStorageAdapter {
     this.logger.log(`Local storage initialized: ${this.basePath}`);
   }
 
-  async upload(buffer: Buffer, key: string, mimeType: string): Promise<UploadResult> {
+  async upload(buffer: Buffer, key: string, _mimeType: string): Promise<UploadResult> {
     const filePath = join(this.basePath, key);
     const fileDir = dirname(filePath);
 

--- a/apps/api/src/modules/uploads/uploads.controller.ts
+++ b/apps/api/src/modules/uploads/uploads.controller.ts
@@ -1,11 +1,9 @@
 // MultiWA Gateway - Upload Controller
 // apps/api/src/modules/uploads/uploads.controller.ts
 
-import { Controller, Post, Get, Param, Res, UseGuards, Req, BadRequestException, NotFoundException } from '@nestjs/common';
+import { Controller, Post, UseGuards, Req, BadRequestException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiConsumes, ApiBearerAuth, ApiSecurity, ApiBody } from '@nestjs/swagger';
-import { FastifyRequest, FastifyReply } from 'fastify';
-import { existsSync, createReadStream } from 'fs';
-import { resolve, join } from 'path';
+import { FastifyRequest } from 'fastify';
 import { UploadsService } from './uploads.service';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-auth.guard';
 import { ApiAuthErrors, ApiValidationError } from '../../common/decorators/api-responses';
@@ -60,7 +58,7 @@ export class UploadsController {
   })
   @ApiValidationError()
   async uploadMedia(@Req() request: FastifyRequest) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     const data = await (request as any).file();
 
     if (!data) {

--- a/apps/api/src/modules/websocket/realtime.gateway.ts
+++ b/apps/api/src/modules/websocket/realtime.gateway.ts
@@ -11,8 +11,7 @@ import {
   ConnectedSocket,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { Logger, UseGuards } from '@nestjs/common';
-import { WsApiKeyGuard } from '../auth/guards/ws-api-key.guard';
+import { Logger } from '@nestjs/common';
 
 export interface SubscribePayload {
   sessionId?: string;

--- a/apps/worker/src/engine/ai.service.ts
+++ b/apps/worker/src/engine/ai.service.ts
@@ -181,7 +181,7 @@ export class AIService {
       knowledgeContext?: string; // Pre-fetched KB context
     }
   ): Promise<AICompletionResult> {
-    let kbContext = context?.knowledgeContext || '';
+    const kbContext = context?.knowledgeContext || '';
 
     const systemPrompt = context?.customPrompt || `
 You are a helpful customer service assistant for ${context?.businessName || 'our business'}.

--- a/apps/worker/src/engine/rule-engine.service.ts
+++ b/apps/worker/src/engine/rule-engine.service.ts
@@ -95,12 +95,13 @@ export class WorkerRuleEngineService {
     const config = automation.triggerConfig as any;
 
     switch (automation.triggerType) {
-      case 'keyword':
+      case 'keyword': {
         const keywordMatch = this.matchKeyword(message.content?.text || '', config);
         if (!keywordMatch) {
           // Log for debugging keyword matching
         }
         return keywordMatch;
+      }
 
       case 'regex':
         return this.matchRegex(message.content?.text || '', config);
@@ -213,16 +214,18 @@ export class WorkerRuleEngineService {
       case 'message_type':
         return condition.types?.includes(message.messageType);
 
-      case 'time_range':
+      case 'time_range': {
         const now = new Date();
         const hour = now.getHours();
         return hour >= condition.startHour && hour < condition.endHour;
+      }
 
-      case 'day_of_week':
+      case 'day_of_week': {
         const day = new Date().getDay();
         return condition.days?.includes(day);
+      }
 
-      case 'contact_tag':
+      case 'contact_tag': {
         const contact = await prisma.contact.findFirst({
           where: {
             profileId: message.profileId,
@@ -230,6 +233,7 @@ export class WorkerRuleEngineService {
           },
         });
         return contact?.tags?.some((t) => condition.tags?.includes(t)) || false;
+      }
 
       default:
         // Unknown condition types should NOT pass silently

--- a/apps/worker/src/processors/automation.processor.ts
+++ b/apps/worker/src/processors/automation.processor.ts
@@ -18,7 +18,7 @@ export interface AutomationJob {
 
 export class AutomationProcessor {
   async process(job: Job<AutomationJob>) {
-    const { profileId, event, messageId, messageBody, contactId } = job.data;
+    const { profileId, event, messageBody, contactId } = job.data;
 
     // Get contact
     const contact = await prisma.contact.findUnique({
@@ -46,7 +46,6 @@ export class AutomationProcessor {
     // Process each automation
     for (const automation of automations) {
       const startTime = Date.now();
-      const triggerConfig = automation.triggerConfig as any;
       const conditions = automation.conditions as any;
       const actions = automation.actions as any[];
 

--- a/apps/worker/src/processors/message.processor.ts
+++ b/apps/worker/src/processors/message.processor.ts
@@ -14,7 +14,7 @@ export interface MessageJob {
 
 export class MessageProcessor {
   async process(job: Job<MessageJob>) {
-    const { profileId, messageId, to, type, content } = job.data;
+    const { profileId, messageId, to, type, content: _content } = job.data;
 
     try {
       // Get profile

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,17 +35,18 @@ export default tseslint.config(
     rules: {
       // The codebase intentionally uses `any` at boundaries and dynamic payloads.
       '@typescript-eslint/no-explicit-any': 'off',
-      // Surface dead bindings without failing CI; ignore _-prefixed + caught errs.
+      // Dead bindings now fail CI; _-prefixed and caught errors are allowed.
       '@typescript-eslint/no-unused-vars': [
-        'warn',
+        'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrors: 'none' },
       ],
       'no-empty': ['warn', { allowEmptyCatch: true }],
-      // Downgraded to warnings for the initial green baseline — these are real
-      // cleanups, not new-bug guards, so they shouldn't block CI on day one.
-      // Ratchet each back to 'error' as the existing violations are cleared.
-      'prefer-const': 'warn',
-      'no-case-declarations': 'warn',
+      // Ratcheted to 'error' after clearing the existing violations (dead code removed,
+      // case bodies blocked). New violations now fail CI.
+      'prefer-const': 'error',
+      'no-case-declarations': 'error',
+      // Still 'warn': the remaining require()s are an intentional pattern (Fastify
+      // plugin registration in app.factory/main, lazy Baileys load) — not dead code.
       '@typescript-eslint/no-require-imports': 'warn',
     },
   },

--- a/packages/database/src/prisma-client.ts
+++ b/packages/database/src/prisma-client.ts
@@ -10,7 +10,7 @@ import { PrismaClient } from '@prisma/client';
 config({ path: resolve(process.cwd(), '.env') });
 
 declare global {
-  // eslint-disable-next-line no-var
+   
   var prisma: PrismaClient | undefined;
 }
 

--- a/packages/engines/src/adapters/baileys.adapter.ts
+++ b/packages/engines/src/adapters/baileys.adapter.ts
@@ -7,7 +7,6 @@ import makeWASocket, {
   fetchLatestBaileysVersion,
   makeCacheableSignalKeyStore,
   WAMessageContent,
-  proto,
 } from '@whiskeysockets/baileys';
 import { Boom } from '@hapi/boom';
 import * as qrcode from 'qrcode-terminal';
@@ -356,7 +355,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
   async sendText(
     to: string,
     text: string,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     try {
       if (!this.isReady() || !this.socket) {
@@ -413,7 +412,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
     to: string,
     media: MediaOptions,
     type: 'image' | 'video' | 'audio' | 'document',
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     try {
       if (!this.isReady() || !this.socket) {
@@ -462,7 +461,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
   async sendLocation(
     to: string,
     location: LocationOptions,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     try {
       if (!this.isReady() || !this.socket) {
@@ -493,7 +492,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
   async sendContact(
     to: string,
     contact: ContactOptions,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     try {
       if (!this.isReady() || !this.socket) {
@@ -521,7 +520,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
     }
   }
 
-  async sendReaction(messageId: string, emoji: string): Promise<MessageResult> {
+  async sendReaction(messageId: string, _emoji: string): Promise<MessageResult> {
     try {
       if (!this.isReady() || !this.socket) {
         return { success: false, error: 'Client not ready' };
@@ -539,7 +538,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
   async sendPoll(
     to: string,
     poll: PollOptions,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     try {
       if (!this.isReady() || !this.socket) {
@@ -643,7 +642,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
     return null; // Baileys uses file-based auth
   }
 
-  async restoreSession(data: any): Promise<boolean> {
+  async restoreSession(_data: any): Promise<boolean> {
     return true;
   }
 
@@ -753,7 +752,7 @@ export class BaileysAdapter implements IWhatsAppEngine {
 
       // If store is empty, try to get from chats
       if (contacts.length === 0) {
-        const chats = await this.socket.profilePictureUrl(this.status.phone + '@s.whatsapp.net', 'preview').catch(() => null);
+        const _chats = await this.socket.profilePictureUrl(this.status.phone + '@s.whatsapp.net', 'preview').catch(() => null);
         console.log('[Baileys] GetContacts: Store empty, contacts from chats not available yet');
       }
 

--- a/packages/engines/src/adapters/mock.adapter.ts
+++ b/packages/engines/src/adapters/mock.adapter.ts
@@ -80,7 +80,7 @@ export class MockAdapter implements IWhatsAppEngine {
   async sendText(
     to: string,
     text: string,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     console.log(`[Mock] Sending text to ${to}: ${text.substring(0, 50)}...`);
     return this.mockSend('text');
@@ -88,8 +88,8 @@ export class MockAdapter implements IWhatsAppEngine {
 
   async sendImage(
     to: string,
-    media: MediaOptions,
-    options?: SendMessageOptions
+    _media: MediaOptions,
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     console.log(`[Mock] Sending image to ${to}`);
     return this.mockSend('image');
@@ -97,8 +97,8 @@ export class MockAdapter implements IWhatsAppEngine {
 
   async sendVideo(
     to: string,
-    media: MediaOptions,
-    options?: SendMessageOptions
+    _media: MediaOptions,
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     console.log(`[Mock] Sending video to ${to}`);
     return this.mockSend('video');
@@ -106,8 +106,8 @@ export class MockAdapter implements IWhatsAppEngine {
 
   async sendAudio(
     to: string,
-    media: MediaOptions,
-    options?: SendMessageOptions
+    _media: MediaOptions,
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     console.log(`[Mock] Sending audio to ${to}`);
     return this.mockSend('audio');
@@ -115,8 +115,8 @@ export class MockAdapter implements IWhatsAppEngine {
 
   async sendDocument(
     to: string,
-    media: MediaOptions,
-    options?: SendMessageOptions
+    _media: MediaOptions,
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     console.log(`[Mock] Sending document to ${to}`);
     return this.mockSend('document');
@@ -125,7 +125,7 @@ export class MockAdapter implements IWhatsAppEngine {
   async sendLocation(
     to: string,
     location: LocationOptions,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     console.log(`[Mock] Sending location to ${to}: ${location.latitude}, ${location.longitude}`);
     return this.mockSend('location');
@@ -134,7 +134,7 @@ export class MockAdapter implements IWhatsAppEngine {
   async sendContact(
     to: string,
     contact: ContactOptions,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     console.log(`[Mock] Sending contact to ${to}: ${contact.name}`);
     return this.mockSend('contact');
@@ -148,7 +148,7 @@ export class MockAdapter implements IWhatsAppEngine {
   async sendPoll(
     to: string,
     poll: PollOptions,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     console.log(`[Mock] Sending poll to ${to}: ${poll.question} (${poll.options.length} options)`);
     return this.mockSend('poll');
@@ -213,7 +213,7 @@ export class MockAdapter implements IWhatsAppEngine {
     return { mock: true, profileId: this.config?.profileId };
   }
 
-  async restoreSession(data: any): Promise<boolean> {
+  async restoreSession(_data: any): Promise<boolean> {
     console.log(`[Mock] Restoring session for profile ${this.config?.profileId}`);
     return true;
   }

--- a/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
+++ b/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
@@ -1,7 +1,7 @@
 // MultiWA Gateway - WhatsApp Web.js Adapter (PRIMARY ENGINE)
 // packages/engines/src/adapters/whatsapp-webjs.adapter.ts
 
-import { Client, LocalAuth, MessageMedia, Location, Contact, Poll } from 'whatsapp-web.js';
+import { Client, LocalAuth, MessageMedia, Location, Poll } from 'whatsapp-web.js';
 import * as qrcode from 'qrcode-terminal';
 import type { 
   IWhatsAppEngine, 
@@ -273,7 +273,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
     to: string, 
     media: MediaOptions, 
     type: string,
-    options?: SendMessageOptions
+    _options?: SendMessageOptions
   ): Promise<MessageResult> {
     try {
       if (!this.isReady()) {
@@ -321,7 +321,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
     }
   }
 
-  async sendLocation(to: string, location: LocationOptions, options?: SendMessageOptions): Promise<MessageResult> {
+  async sendLocation(to: string, location: LocationOptions, _options?: SendMessageOptions): Promise<MessageResult> {
     try {
       if (!this.isReady()) {
         return { success: false, error: 'Client not ready' };
@@ -346,7 +346,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
     }
   }
 
-  async sendContact(to: string, contact: ContactOptions, options?: SendMessageOptions): Promise<MessageResult> {
+  async sendContact(to: string, contact: ContactOptions, _options?: SendMessageOptions): Promise<MessageResult> {
     try {
       if (!this.isReady()) {
         return { success: false, error: 'Client not ready' };
@@ -405,7 +405,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
     }
   }
 
-  async sendPoll(to: string, poll: PollOptions, options?: SendMessageOptions): Promise<MessageResult> {
+  async sendPoll(to: string, poll: PollOptions, _options?: SendMessageOptions): Promise<MessageResult> {
     try {
       if (!this.isReady()) {
         return { success: false, error: 'Client not ready' };
@@ -474,7 +474,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
   /**
    * Mark a chat or specific messages as read.
    */
-  async markAsRead(chatId: string, messageIds?: string[]): Promise<void> {
+  async markAsRead(chatId: string, _messageIds?: string[]): Promise<void> {
     try {
       if (!this.isReady() || !this.client) return;
 
@@ -609,7 +609,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
     return null;
   }
 
-  async restoreSession(data: any): Promise<boolean> {
+  async restoreSession(_data: any): Promise<boolean> {
     // whatsapp-web.js handles session restoration via LocalAuth
     return true;
   }

--- a/packages/engines/src/factory/engine-factory.ts
+++ b/packages/engines/src/factory/engine-factory.ts
@@ -84,7 +84,7 @@ export class EngineFactory {
    * Destroy all engine instances
    */
   static async destroyAll(): Promise<void> {
-    for (const [profileId, engine] of this.instances) {
+    for (const [_profileId, engine] of this.instances) {
       await engine.destroy();
     }
     this.instances.clear();

--- a/packages/n8n-nodes-multiwa/src/nodes/MultiWA/MultiWA.node.ts
+++ b/packages/n8n-nodes-multiwa/src/nodes/MultiWA/MultiWA.node.ts
@@ -298,7 +298,7 @@ export class MultiWA implements INodeType {
         const to = this.getNodeParameter('to', i) as string;
 
         let endpoint: string;
-        let body: Record<string, unknown> = { profileId, to };
+        const body: Record<string, unknown> = { profileId, to };
 
         switch (operation) {
           case 'sendText':

--- a/packages/sdk/src/clients/automation.ts
+++ b/packages/sdk/src/clients/automation.ts
@@ -2,7 +2,7 @@
 // packages/sdk/src/clients/automation.ts
 
 import type { MultiWAClient } from '../client';
-import type { Automation, CreateAutomationOptions, PaginatedResponse } from '../types';
+import type { Automation, CreateAutomationOptions } from '../types';
 
 export class AutomationClient {
   constructor(private client: MultiWAClient) {}


### PR DESCRIPTION
Clears the backend ESLint warning backlog and **ratchets the cleared rules from `warn` to `error`** so regressions fail CI.

- **`no-unused-vars`** (73) — removed dead imports; renamed unused params/vars with a leading `_` (never deleted a positional param); preserved destructure-omit idioms.
- **`no-case-declarations`** (14) — wrapped case bodies in blocks (no control-flow change).
- **`prefer-const`** — via `eslint --fix`.
- `no-require-imports` stays `warn`: the 6 remaining `require()`s are an intentional pattern (Fastify plugin registration, lazy Baileys load), not dead code.

Pure lint fixes, **no runtime behavior change**. Verified locally: api+worker `tsc` 0 errors, api 181 + sdk 17 tests pass, package build clean, `eslint` 0 errors (6 intentional require warnings). The bulk was done by a 9-agent parallel sweep over disjoint files, then verified centrally.