### PR TITLE
fix(ops,auth): stop silent BullMQ job loss + graceful shutdown + real refresh-token secret (audit Tier-1)

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -122,6 +122,12 @@ async function bootstrap() {
     });
     console.log('✅ [6/7] Validation & Swagger configured');
 
+    // Enable graceful shutdown: on SIGTERM/SIGINT Nest fires OnModuleDestroy /
+    // OnApplicationShutdown so in-flight work drains (BullMQ workers/queues close,
+    // engine sessions detach, DB/Redis connections release) instead of being
+    // killed mid-flight. Must be enabled before listen() to register the hooks.
+    app.enableShutdownHooks();
+
     // Start server
     const port = process.env.API_PORT || 3000;
     const host = process.env.API_HOST || '0.0.0.0';

--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -43,6 +43,13 @@ describe('AuthService', () => {
     createSession: vi.fn(),
     removeSessionByToken: vi.fn(),
   };
+  const mockConfigService = {
+    // refresh-token secret + ttl (defaults mirror ConfigService.get(key, default))
+    get: vi.fn((key: string, def?: unknown) => {
+      if (key === 'JWT_REFRESH_SECRET') return 'test-refresh-secret';
+      return def;
+    }),
+  };
 
   beforeEach(() => {
     // Reset all mocks — clears call history AND resets implementations
@@ -61,10 +68,13 @@ describe('AuthService', () => {
     mockSessionsService.removeSessionByToken.mockReset();
     mockTwoFactorService.verifyTwoFactor.mockReset();
 
+    mockConfigService.get.mockClear();
+
     authService = new AuthService(
       mockJwtService as any,
       mockTwoFactorService as any,
       mockSessionsService as any,
+      mockConfigService as any,
     );
   });
 

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -3,6 +3,7 @@
 
 import { Injectable, UnauthorizedException, ConflictException, BadRequestException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { prisma } from '@multiwa/database';
 import { LoginDto, RegisterDto, TokenResponseDto } from './dto';
 import { TwoFactorService } from './two-factor.service';
@@ -16,7 +17,17 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly twoFactorService: TwoFactorService,
     private readonly sessionsService: SessionsService,
+    private readonly config: ConfigService,
   ) {}
+
+  // Refresh tokens are signed/verified with a SEPARATE secret from access tokens
+  // (JWT_REFRESH_SECRET, validated at boot in main.ts). This cryptographically
+  // isolates the two token classes: a leaked access-token secret cannot forge a
+  // refresh token (and vice versa), and a refresh token cannot be replayed as an
+  // access token — JwtStrategy verifies access tokens with JWT_SECRET only.
+  private get refreshSecret(): string {
+    return this.config.get<string>('JWT_REFRESH_SECRET') as string;
+  }
 
   async register(dto: RegisterDto): Promise<TokenResponseDto> {
     // Check if user exists
@@ -125,7 +136,7 @@ export class AuthService {
 
   async refreshToken(refreshToken: string): Promise<TokenResponseDto> {
     try {
-      const payload = this.jwtService.verify(refreshToken);
+      const payload = this.jwtService.verify(refreshToken, { secret: this.refreshSecret });
       const user = await prisma.user.findUnique({
         where: { id: payload.sub },
       });
@@ -234,7 +245,10 @@ export class AuthService {
     };
 
     const accessToken = this.jwtService.sign(payload);
-    const refreshToken = this.jwtService.sign(payload, { expiresIn: '30d' });
+    const refreshToken = this.jwtService.sign(payload, {
+      secret: this.refreshSecret,
+      expiresIn: this.config.get('JWT_REFRESH_EXPIRES_IN', '30d'),
+    });
 
     // Every issued access token is bound to a server-side session so logout and
     // session revocation actually invalidate it (JwtStrategy checks the session

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -4,11 +4,21 @@ version: "3.8"
 # Usage: docker compose -f docker-compose.production.yml up -d
 # Ensure .env.production exists alongside this file
 
+# Shared log-rotation policy. Without a cap, container json-file logs grow
+# unbounded and can fill the host disk (this has caused a real production
+# outage: full disk -> Postgres crash-loop). Applied to every service below.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   # ─── Database ───────────────────────────────────
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: ${DB_USER:-multiwa}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -24,10 +34,16 @@ services:
       - internal
 
   # ─── Cache / Queue ──────────────────────────────
+  # This Redis backs BullMQ (durable webhook + message delivery). BullMQ REQUIRES
+  # an eviction policy of `noeviction` — under memory pressure any other policy
+  # silently evicts queued jobs, dropping webhooks/messages with no error. AOF is
+  # enabled so queued jobs survive a restart. maxmemory sized with headroom so the
+  # queue does not hit the limit under normal load; alert before it does.
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    command: redis-server --requirepass ${REDIS_PASSWORD} --maxmemory 256mb --maxmemory-policy allkeys-lru
+    logging: *default-logging
+    command: redis-server --requirepass ${REDIS_PASSWORD} --maxmemory ${REDIS_MAXMEMORY:-512mb} --maxmemory-policy noeviction --appendonly yes
     volumes:
       - redis_data:/data
     healthcheck:
@@ -42,6 +58,7 @@ services:
   minio:
     image: minio/minio:latest
     restart: unless-stopped
+    logging: *default-logging
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${S3_ACCESS_KEY}
@@ -62,6 +79,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.api
     restart: unless-stopped
+    logging: *default-logging
     depends_on:
       postgres:
         condition: service_healthy
@@ -113,6 +131,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.worker
     restart: unless-stopped
+    logging: *default-logging
     depends_on:
       postgres:
         condition: service_healthy
@@ -151,6 +170,7 @@ services:
       args:
         NEXT_PUBLIC_API_URL: ${API_URL:-https://api.yourdomain.com}
     restart: unless-stopped
+    logging: *default-logging
     depends_on:
       api:
         condition: service_started
@@ -169,6 +189,7 @@ services:
   nginx:
     image: nginx:alpine
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "${HTTP_PORT:-80}:80"
       - "${HTTPS_PORT:-443}:443"


### PR DESCRIPTION
## Why

The world-class readiness audit (2026-07-19) surfaced three **verified** correctness defects in the highest-severity tier. All three were grep-confirmed against the tree. These are the "days, highest-ROI" ops/correctness fixes — cheap, low-risk, release-blocking.

## What

### 1. Redis silently drops durable jobs → `noeviction` + AOF
`docker-compose.production.yml` ran BullMQ's Redis with `--maxmemory-policy allkeys-lru` at 256mb. BullMQ **requires** `noeviction`; under memory pressure any other policy silently evicts queued jobs — dropping webhooks/messages with **no error**. Now `noeviction`, `--appendonly yes` (restart durability), `maxmemory` via `REDIS_MAXMEMORY` (default 512mb, headroom).

### 2. Unbounded container logs filled the disk → log rotation
Added a shared `x-logging` anchor (`json-file`, `max-size 10m`, `max-file 3`) to **every** service. Unbounded logs previously filled the host disk and crash-looped Postgres (a real production outage).

### 3. API killed mid-flight on deploy → `enableShutdownHooks()`
`main.ts` never enabled Nest shutdown hooks, so `OnModuleDestroy`/`OnApplicationShutdown` never fired on SIGTERM — BullMQ workers/queues, engine sessions, and DB/Redis connections were killed mid-flight. Now enabled before `listen()`.

### 4. `JWT_REFRESH_SECRET` validated but unused → wire it in
`JWT_REFRESH_SECRET` is validated at boot (`main.ts:22`) but refresh tokens were signed/verified with the single `JWT_SECRET`. Now signed + verified with `JWT_REFRESH_SECRET` (+ `JWT_REFRESH_EXPIRES_IN`), cryptographically isolating the two token classes: a leaked access-token secret can't forge a refresh token, and a refresh token can't be replayed as an access token.

## Compatibility
- Existing refresh tokens (signed with `JWT_SECRET`) stop verifying after deploy → affected users re-login once. Both env vars already exist in `.env.example`.
- Redis `noeviction`: the queue now rejects **writes** if it ever hits `maxmemory` (loud failure) instead of silently evicting — alert on Redis memory. AOF adds the `redis_data` volume as the durability store (already mounted).

## Out of scope (tracked follow-ups)
Full refresh-token revocation/rotation + reuse detection (audit Tier-5), per-service CPU/mem limits (needs the server's real headroom to set safely), and horizontal-safe send-gate/broadcast primitives (Tier-4).

## Validation
- `tsc --noEmit` clean (caught + fixed the `AuthService` constructor-arity break in the unit spec).
- `docker compose -f docker-compose.production.yml config` valid (anchors + `noeviction` resolve).
- Auth unit specs run in CI (local bcrypt native binding won't build against Node 26).