### PR TITLE
docs: reconcile overclaims + doc-drift with the actual code (audit Tier-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Multi-engine architecture** — Pluggable WhatsApp engine adapters (whatsapp-web.js, Baileys)
 - **Admin Dashboard** — Full-featured Next.js dashboard with real-time session monitoring
 - **Visual Automation Builder** — Drag & drop flow builder for message automation
-- **Knowledge Base** — AI-powered auto-reply using document context (OpenAI, Google AI)
+- **Knowledge Base** — AI-powered auto-reply using document context (OpenAI-compatible API)
 - **Broadcast System** — Bulk messaging with template support and delivery tracking
 - **Contact Management** — Import/export contacts, tagging, and segmentation
 - **Template System** — Reusable message templates with variable substitution

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you want to send and receive WhatsApp messages from your own backend without 
 | **Multi-engine** | ✅ whatsapp-web.js (Baileys adapter experimental) | ❌ Single | ❌ Fixed |
 | **Admin Dashboard** | ✅ Full-featured | ❌ None | ⚠️ Basic |
 | **Visual Automation** | ✅ Drag & drop builder | ❌ | ❌ |
-| **Knowledge Base AI** | ✅ OpenAI / Google AI | ❌ | ❌ |
+| **Knowledge Base AI** | ✅ OpenAI-compatible | ❌ | ❌ |
 | **Plugin System** | ✅ Extensible | ❌ | ❌ |
 | **Free** | ✅ MIT License | ⚠️ Per-message pricing | ✅ |
 | **Official SDKs** | ✅ TS, Python, PHP | ✅ Multiple | ⚠️ Community |
@@ -113,7 +113,7 @@ pnpm --filter admin dev   # Admin on http://localhost:3001
 
 ### Core
 - 📱 **Multi-Session Management** — Connect unlimited WhatsApp accounts
-- 🔌 **Pluggable Engine Adapters** — Clean engine interface with per-profile engine selection: whatsapp-web.js (default, production) or a Baileys adapter (experimental)
+- 🔌 **Pluggable Engine Adapters** — Clean engine interface with per-profile engine selection: whatsapp-web.js (default, production) or a Baileys adapter (experimental — not production-validated; `sendReaction` and `resolveIdentity` are stubs and history sync / WhatsApp-addressbook contact save are whatsapp-web.js-only; see [Engine Abstraction](docs/06-engine-abstraction.md))
 - 📨 **Unified Messaging API** — Send text, media, documents, contacts, locations
 - 📡 **Real-time WebSocket** — Live session status, QR codes, and events via Socket.IO
 - 🔐 **JWT Authentication** — Secure API access with refresh tokens
@@ -126,7 +126,7 @@ pnpm --filter admin dev   # Admin on http://localhost:3001
 
 ### Automation & AI
 - 🤖 **Visual Flow Builder** — Drag & drop automation design
-- 🧠 **Knowledge Base** — AI-powered replies using OpenAI or Google AI
+- 🧠 **Knowledge Base** — AI-powered replies using OpenAI (or any OpenAI-compatible API) with keyword (TF-IDF) retrieval
 - 📅 **Scheduled Messages** — Queue messages for future delivery
 - 📢 **Broadcast** — Bulk messaging with templates and tracking
 
@@ -178,7 +178,7 @@ pnpm --filter admin dev   # Admin on http://localhost:3001
 │                      ├───────────────────────────────────┤
 │                      │  WhatsApp Engine Adapters         │
 │                      │  ├─ whatsapp-web.js               │
-│                      │  └─ Baileys                       │
+│                      │  └─ Baileys (experimental)        │
 ├──────────────────────┴───────────────────────────────────┤
 │  Worker (BullMQ)  │  PostgreSQL 16  │  Redis 7           │
 └──────────────────────────────────────────────────────────┘
@@ -192,7 +192,7 @@ pnpm --filter admin dev   # Admin on http://localhost:3001
 | **Admin** | Next.js 14 + Tailwind CSS |
 | **Database** | PostgreSQL 16 + Prisma ORM |
 | **Cache/Queue** | Redis 7 + BullMQ |
-| **WhatsApp** | whatsapp-web.js / Baileys |
+| **WhatsApp** | whatsapp-web.js (production) / Baileys (experimental) |
 | **Auth** | JWT (access + refresh tokens) |
 | **Realtime** | Socket.IO |
 | **Container** | Docker + Docker Compose |

--- a/docs/09-webhook-events.md
+++ b/docs/09-webhook-events.md
@@ -16,7 +16,7 @@ POST /api/v1/profiles/:id/webhook
 {
   "url": "https://yourserver.com/webhook",
   "secret": "optional-hmac-secret",
-  "events": ["message.received", "session.status"]
+  "events": ["message.received", "connection.ready"]
 }
 ```
 
@@ -40,9 +40,10 @@ POST /api/v1/webhooks
 | `message.sent` | Outgoing message confirmed |
 | `message.delivered` | Message delivered (✓✓) |
 | `message.read` | Message read (blue ✓✓) |
-| `session.connected` | WhatsApp connected |
-| `session.disconnected` | WhatsApp disconnected |
-| `session.qr` | New QR code generated |
+| `message.failed` | Message delivery failed |
+| `connection.qr` | New QR code generated |
+| `connection.ready` | WhatsApp connected |
+| `connection.disconnected` | WhatsApp disconnected |
 
 ---
 
@@ -67,23 +68,28 @@ POST /api/v1/webhooks
 
 ## HMAC Verification
 
-If you set a `secret`, verify the signature:
+If you set a `secret`, verify the signature over the **raw request body** (the exact bytes MultiWA sent), not a re-serialized object:
 
 ```javascript
 const crypto = require('crypto');
 
-function verifyWebhook(body, signature, secret) {
-  const expected = crypto
-    .createHmac('sha256', secret)
-    .update(JSON.stringify(body))
-    .digest('hex');
-  return `sha256=${expected}` === signature;
+// Capture the RAW request body so the HMAC matches byte-for-byte. MultiWA signs
+// the exact bytes it sends, so verify against the raw body — a re-serialized
+// object (JSON.stringify(req.body)) is NOT guaranteed to match.
+app.use(express.json({ verify: (req, _res, buf) => { req.rawBody = buf; } }));
+
+function verifyWebhook(rawBody, signature, secret) {
+  const expected =
+    'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  const got = signature || '';
+  return expected.length === got.length &&
+    crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(got));
 }
 
 // In your handler
 app.post('/webhook', (req, res) => {
   const signature = req.headers['x-multiwa-signature'];
-  if (!verifyWebhook(req.body, signature, 'your-secret')) {
+  if (!verifyWebhook(req.rawBody, signature, 'your-secret')) {
     return res.status(401).send('Invalid signature');
   }
   // Process event...

--- a/docs/11-groups.md
+++ b/docs/11-groups.md
@@ -175,7 +175,7 @@ Returns new invite link after revoking the old one.
 ```python
 from multiwa import MultiWA
 
-client = MultiWA("http://localhost:3001/api", "YOUR_API_KEY")
+client = MultiWA("http://localhost:3333/api/v1", "YOUR_API_KEY")
 
 # List all groups
 groups = client.groups.get_all("profile-123")

--- a/docs/13-sdk-python.md
+++ b/docs/13-sdk-python.md
@@ -19,7 +19,7 @@ from multiwa import MultiWA
 
 # Initialize client
 client = MultiWA(
-    base_url="http://localhost:3001/api",
+    base_url="http://localhost:3333/api/v1",
     api_key="YOUR_API_KEY"
 )
 
@@ -43,7 +43,7 @@ import asyncio
 
 async def main():
     client = AsyncMultiWA(
-        base_url="http://localhost:3001/api",
+        base_url="http://localhost:3333/api/v1",
         api_key="YOUR_API_KEY"
     )
 

--- a/docs/14-sdk-php.md
+++ b/docs/14-sdk-php.md
@@ -7,7 +7,7 @@ Official PHP SDK for MultiWA.
 ## Installation
 
 ```bash
-composer require multiwa/multiwa
+composer require multiwa/multiwa-php
 ```
 
 ---
@@ -29,7 +29,7 @@ require_once 'vendor/autoload.php';
 use MultiWA\MultiWA;
 
 $client = new MultiWA(
-    baseUrl: 'http://localhost:3001/api',
+    baseUrl: 'http://localhost:3333/api/v1',
     apiKey: 'YOUR_API_KEY'
 );
 
@@ -149,7 +149,7 @@ try {
 ```php
 // config/services.php
 'multiwa' => [
-    'base_url' => env('MULTIWA_BASE_URL', 'http://localhost:3001/api'),
+    'base_url' => env('MULTIWA_BASE_URL', 'http://localhost:3333/api/v1'),
     'api_key' => env('MULTIWA_API_KEY'),
 ],
 

--- a/docs/15-n8n-integration.md
+++ b/docs/15-n8n-integration.md
@@ -25,7 +25,7 @@ Or install via n8n UI:
 1. In n8n, go to **Credentials** → **Add Credential**
 2. Search for **MultiWA API**
 3. Enter:
-   - **API Base URL**: `http://localhost:3001/api`
+   - **API Base URL**: `http://localhost:3333/api/v1`
    - **API Key**: Your MultiWA API key
 
 ---

--- a/docs/20-examples.md
+++ b/docs/20-examples.md
@@ -16,7 +16,7 @@ X-API-Key: <your-api-key>
 
 ## 1. Webhook integration
 
-MultiWA delivers events (`message.received`, `session.status`, …) as `POST`
+MultiWA delivers events (`message.received`, `message.sent`, …) as `POST`
 requests to your endpoint. When the webhook has a `secret`, each request carries
 an HMAC-SHA256 signature header so you can verify it came from MultiWA:
 
@@ -121,7 +121,7 @@ curl -X POST https://your-multiwa-host/api/v1/webhooks \
   -d '{
     "url": "https://yourserver.com/webhook",
     "secret": "a-long-random-string",
-    "events": ["message.received", "session.status"]
+    "events": ["message.received", "connection.ready"]
   }'
 ```
 

--- a/docs/PROMOTION_DRAFTS.md
+++ b/docs/PROMOTION_DRAFTS.md
@@ -21,7 +21,7 @@ docker compose up -d
 ### Key features:
 - 📱 **Multi-Session** — Connect unlimited WhatsApp numbers via single API
 - 🔌 **Pluggable engines** — pick whatsapp-web.js (production) or Baileys (experimental) per profile
-- 🤖 **AI Auto-Reply** — Knowledge base powered by OpenAI or Google AI
+- 🤖 **AI Auto-Reply** — Knowledge base powered by OpenAI (or any OpenAI-compatible API)
 - ⚡ **Visual Flow Builder** — Drag & drop automation (no code needed)
 - 📢 **Broadcast** — Bulk messaging with templates, variables, tracking
 - 🖥️ **Admin Dashboard** — Full-featured Next.js dashboard with dark mode
@@ -56,7 +56,7 @@ I'm sharing my open-source project **MultiWA** — a self-hosted WhatsApp Busine
 **What makes it different from other WhatsApp tools:**
 - Pluggable engines: whatsapp-web.js (production) or Baileys (experimental), selectable per profile
 - Visual automation builder: drag & drop, no coding required
-- AI-powered knowledge base: plug in OpenAI or Google AI for smart auto-replies
+- AI-powered knowledge base: plug in OpenAI (or any OpenAI-compatible API) for smart auto-replies
 - Full admin dashboard with real-time chat, analytics, broadcast
 - Official SDKs for TypeScript, Python, and PHP
 
@@ -87,7 +87,7 @@ Adds MultiWA to the Communication - Custom section.
 MultiWA is a self-hosted WhatsApp Business API gateway featuring:
 - Multi-engine support (whatsapp-web.js + Baileys)
 - Visual drag-and-drop automation builder
-- AI-powered auto-reply (OpenAI, Google AI)
+- AI-powered auto-reply (OpenAI-compatible API)
 - Full admin dashboard (Next.js 14)
 - Official SDKs (TypeScript, Python, PHP)
 - One-command Docker setup
@@ -108,7 +108,7 @@ Source: https://github.com/ribato22/MultiWA
 ```
 I built MultiWA, a self-hosted WhatsApp Business API gateway.
 
-It supports multiple WhatsApp engines (whatsapp-web.js, Baileys), has a visual drag-and-drop automation builder, AI-powered knowledge base (OpenAI/Google AI), and a full admin dashboard.
+It supports multiple WhatsApp engines (whatsapp-web.js production, Baileys experimental), has a visual drag-and-drop automation builder, AI-powered knowledge base (OpenAI-compatible), and a full admin dashboard.
 
 Docker one-click setup:
   git clone ... && docker compose up -d


### PR DESCRIPTION
## Why

Tier-2 of the world-class readiness audit: **make the claims true or correct them.** The audit found docs advertising capabilities the code doesn't have + examples that fail on the first copy-paste — the exact things that erode trust with the developers evaluating an OSS gateway. Each item was **verified against the tree** (via a 5-agent grounded verification pass) before editing. **Docs-only; no behavior change.**

## What (all verified TRUE, then corrected)

| Overclaim / drift | Reality | Fix |
|---|---|---|
| "OpenAI / **Google AI**" KB | `ai.service.ts` is OpenAI-only; no Gemini/Google path anywhere; retrieval is keyword/TF-IDF | README + CHANGELOG + PROMOTION_DRAFTS → "OpenAI (or any OpenAI-compatible API)" + keyword retrieval |
| **Multi-engine** lists Baileys as a peer | Abstraction is real, but Baileys `sendReaction` is a no-op + `resolveIdentity` returns null + history/contact-save unimplemented | README diagram/table/bullet mark it **experimental** + disclose stubs |
| Webhook events `session.connected/disconnected/qr/status` | Not in `ALL_APP_EVENTS`; dispatcher's `APP_EVENT_SET` gate drops them → never delivered | docs/09 + docs/20 → real emitted events (`message.failed`, `connection.qr/ready/disconnected`) |
| Webhook HMAC example verifies over `JSON.stringify(req.body)` | Server signs the **raw** bytes; re-serialized ≠ byte-identical → silently fails | docs/09 → capture `req.rawBody` + `timingSafeEqual` (matches server + SDKs) |
| SDK base URL `http://localhost:3001/api` | 3001 is the **admin** port; prefix is wrong | docs/13,14,11,15 → `http://localhost:3333/api/v1` |
| `composer require multiwa/multiwa` | package is `multiwa/multiwa-php` | docs/14 fixed (pip `multiwa` was already correct) |

## Deliberately NOT changed
- `docs/08-websocket-api.md` keeps `session.status` — that IS a real Socket.IO **channel** event (`realtime.gateway.ts:223`), just not a webhook event.
- Pre-existing markdownlint (MD022/031/032/060) noise in touched files — out of scope, would balloon the diff.

## Follow-ups (roadmap)
Tier-2 also recommended a CI doc-drift check (fail on webhook-event / API-route drift vs a snapshot) — deferred to a separate PR. Implementing Gemini + pgvector embeddings (to make the *original* claim true instead of correcting it) remains a product decision.