### PR TITLE
feat(security): enforce API-key scopes + password floor 12 + CI security scanning (audit Tier-5 pt.1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+# Automated dependency updates. Grouped to avoid PR spam; security updates are
+# opened by Dependabot regardless of schedule. This is the mechanism that
+# actually burns down the `pnpm audit` high/critical backlog over time.
+updates:
+  - package-ecosystem: npm # covers the pnpm workspace (pnpm-lock.yaml)
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+# Static analysis (SAST). Findings surface in the repo Security tab; the check
+# itself passes even when issues are found, so it never spuriously blocks a PR.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '31 4 * * 1' # Mondays 04:31 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      # JS/TS is interpreted — no build step needed for CodeQL extraction.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,46 @@
+name: Security
+
+# Dependency audit + secret scanning.
+#
+# The dependency audit is ADVISORY (non-blocking) for now: the tree currently
+# carries a backlog of high/critical advisories (mostly dev tooling + a NestJS 11
+# fastify fix that needs a major bump). Dependabot opens the remediation PRs; once
+# the backlog is burned down, drop `continue-on-error` to turn this into a hard gate.
+# Secret scanning IS a hard gate — a leaked credential must fail the build.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '17 3 * * 1' # Mondays 03:17 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Dependency audit (pnpm) — advisory
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: pnpm audit (high/critical)
+        run: pnpm audit --audit-level high
+
+  secrets:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,6 @@ jobs:
   audit:
     name: Dependency audit (pnpm) — advisory
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -31,8 +30,11 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # Advisory only: print the high/critical report but never fail the check
+      # (the tree has a known backlog). `|| true` keeps it green; the report is in
+      # the log and Dependabot opens the fixes. Drop `|| true` to make it a gate.
       - name: pnpm audit (high/critical)
-        run: pnpm audit --audit-level high
+        run: pnpm audit --audit-level high || true
 
   secrets:
     name: Secret scan (gitleaks)

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -200,8 +200,8 @@ export class AuthService {
     const isValid = await this.verifyPassword(currentPassword, user.passwordHash);
     if (!isValid) throw new BadRequestException('Current password is incorrect');
 
-    if (newPassword.length < 8) {
-      throw new BadRequestException('New password must be at least 8 characters');
+    if (newPassword.length < 12) {
+      throw new BadRequestException('New password must be at least 12 characters');
     }
 
     const newHash = await this.hashPassword(newPassword);

--- a/apps/api/src/modules/auth/decorators/require-scope.decorator.ts
+++ b/apps/api/src/modules/auth/decorators/require-scope.decorator.ts
@@ -1,0 +1,24 @@
+// MultiWA Gateway API - API-key Scope Decorator
+// apps/api/src/modules/auth/decorators/require-scope.decorator.ts
+
+import { SetMetadata } from '@nestjs/common';
+
+// Distinct from the RBAC RequirePermissions/'permissions' metadata (rbac.guard.ts)
+// so the two guards never cross-read each other's metadata.
+export const API_KEY_SCOPE = 'multiwa_api_key_scope';
+
+/**
+ * Declare the API-key scope(s) a route requires. Enforced by ApiKeyScopeGuard,
+ * which reads `req.user.apiKeyScopes` (present only for API-key auth).
+ *
+ * Semantics: the guard passes when the key carries ANY of the listed scopes.
+ * Backward-compat escape hatches: a key with NO scopes (`[]`) or a wildcard `*`
+ * is full-access, and JWT-authenticated requests are unaffected (no apiKeyScopes).
+ *
+ * Scope vocabulary = the PERMISSIONS keys in rbac.service.ts (e.g. `message:send`,
+ * `message:read`, `contact:read`, …) plus `*`.
+ *
+ * @example
+ * @RequireScope('message:send')
+ */
+export const RequireScope = (...scopes: string[]) => SetMetadata(API_KEY_SCOPE, scopes);

--- a/apps/api/src/modules/auth/dto/index.ts
+++ b/apps/api/src/modules/auth/dto/index.ts
@@ -20,9 +20,9 @@ export class RegisterDto {
   @IsEmail()
   email: string;
 
-  @ApiProperty({ example: 'password123' })
+  @ApiProperty({ example: 'ChangeMe1234!' })
   @IsString()
-  @MinLength(6)
+  @MinLength(12, { message: 'Password must be at least 12 characters' })
   password: string;
 
   @ApiProperty({ example: 'John Doe' })

--- a/apps/api/src/modules/auth/guards/api-key-scope.guard.spec.ts
+++ b/apps/api/src/modules/auth/guards/api-key-scope.guard.spec.ts
@@ -1,0 +1,52 @@
+// Unit tests for ApiKeyScopeGuard — proves the backward-compat decision matrix
+// without HTTP. Mirrors roles.guard.spec.ts (Reflector-stubbed).
+
+import { describe, it, expect, vi } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+import { ApiKeyScopeGuard } from './api-key-scope.guard';
+
+function ctx(user: any) {
+  return {
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    switchToHttp: () => ({ getRequest: () => ({ user }) }),
+  } as any;
+}
+
+function guardWith(required: string[] | undefined) {
+  const reflector = { getAllAndOverride: vi.fn().mockReturnValue(required) } as any;
+  return new ApiKeyScopeGuard(reflector);
+}
+
+describe('ApiKeyScopeGuard', () => {
+  it('passes when the route declares no scope', () => {
+    expect(guardWith(undefined).canActivate(ctx({ apiKeyScopes: ['message:read'] }))).toBe(true);
+    expect(guardWith([]).canActivate(ctx({ apiKeyScopes: ['message:read'] }))).toBe(true);
+  });
+
+  it('legacy unscoped key ([]) stays full-access', () => {
+    expect(guardWith(['message:send']).canActivate(ctx({ apiKeyScopes: [] }))).toBe(true);
+  });
+
+  it('wildcard key (*) is full-access', () => {
+    expect(guardWith(['message:send']).canActivate(ctx({ apiKeyScopes: ['*'] }))).toBe(true);
+  });
+
+  it('passes when the key carries the required scope', () => {
+    expect(guardWith(['message:send']).canActivate(ctx({ apiKeyScopes: ['message:send'] }))).toBe(true);
+  });
+
+  it('passes on ANY-of when the key has one of several required scopes', () => {
+    expect(guardWith(['message:send', 'message:read']).canActivate(ctx({ apiKeyScopes: ['message:read'] }))).toBe(true);
+  });
+
+  it('throws Forbidden when the key lacks the required scope', () => {
+    expect(() =>
+      guardWith(['message:send']).canActivate(ctx({ apiKeyScopes: ['message:read'] })),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('JWT principal (no apiKeyScopes) is never blocked by the scope guard', () => {
+    expect(guardWith(['message:send']).canActivate(ctx({ role: 'owner' }))).toBe(true);
+  });
+});

--- a/apps/api/src/modules/auth/guards/api-key-scope.guard.ts
+++ b/apps/api/src/modules/auth/guards/api-key-scope.guard.ts
@@ -1,0 +1,49 @@
+// MultiWA Gateway API - API-key Scope Guard
+// apps/api/src/modules/auth/guards/api-key-scope.guard.ts
+
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { API_KEY_SCOPE } from '../decorators/require-scope.decorator';
+
+/**
+ * Enforces `@RequireScope(...)` for API-key-authenticated requests. Must run AFTER
+ * an auth guard that populates `req.user` (e.g. JwtOrApiKeyGuard).
+ *
+ * No-op unless BOTH: (a) the route declares `@RequireScope`, AND (b) the caller is
+ * an API key with an explicit, non-wildcard scope list. This keeps every existing
+ * key (`[]` -> full access) and every JWT login (no apiKeyScopes) working unchanged.
+ * Mirrors RolesGuard — Reflector-only, so no provider/module registration is needed.
+ */
+@Injectable()
+export class ApiKeyScopeGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const required = this.reflector.getAllAndOverride<string[] | undefined>(API_KEY_SCOPE, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!required || required.length === 0) {
+      return true; // route declares no scope
+    }
+
+    const req = context.switchToHttp().getRequest();
+    const scopes: string[] | undefined = req.user?.apiKeyScopes;
+
+    // JWT auth (or no principal): API-key scopes don't apply. JWT authorization is
+    // handled by RolesGuard/RbacGuard/TenantGuard, not here.
+    if (scopes === undefined) {
+      return true;
+    }
+
+    // Backward-compat: an unscoped or wildcard key is full-access.
+    if (scopes.length === 0 || scopes.includes('*')) {
+      return true;
+    }
+
+    if (!required.some((s) => scopes.includes(s))) {
+      throw new ForbiddenException(`API key missing required scope(s): ${required.join(', ')}`);
+    }
+    return true;
+  }
+}

--- a/apps/api/src/modules/auth/strategies/api-key.strategy.ts
+++ b/apps/api/src/modules/auth/strategies/api-key.strategy.ts
@@ -55,6 +55,7 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') {
       organizationId: key.user.organizationId,
       organization: key.user.organization,
       apiKeyId: key.id,
+      apiKeyScopes: key.permissions, // string[]; [] or ['*'] == full access (enforced by ApiKeyScopeGuard)
     };
   }
 }

--- a/apps/api/src/modules/messages/messages.controller.ts
+++ b/apps/api/src/modules/messages/messages.controller.ts
@@ -6,6 +6,8 @@ import { ApiTags, ApiOperation, ApiBearerAuth, ApiSecurity, ApiQuery, ApiCreated
 import { ApiAuthErrors, ApiValidationError, ApiRateLimited, ApiNotFound } from '../../common/decorators/api-responses';
 import { MessagesService } from './messages.service';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-auth.guard';
+import { ApiKeyScopeGuard } from '../auth/guards/api-key-scope.guard';
+import { RequireScope } from '../auth/decorators/require-scope.decorator';
 import { TenantGuard } from '../../common/tenant/tenant.guard';
 import { RequireTenant } from '../../common/tenant/require-tenant.decorator';
 import {
@@ -41,7 +43,12 @@ const ApiSend = (summary: string, description?: string) =>
 
 @ApiTags('Messages')
 @Controller('messages')
-@UseGuards(JwtOrApiKeyGuard, TenantGuard)
+// ApiKeyScopeGuard runs between auth and tenant: a cheap in-memory capability
+// check before the per-resource tenant DB lookup. Class default requires the
+// `message:send` scope; the read (GET) routes below override it to `message:read`.
+// No-op for JWT logins and for API keys with no scopes / a `*` wildcard.
+@UseGuards(JwtOrApiKeyGuard, ApiKeyScopeGuard, TenantGuard)
+@RequireScope('message:send')
 @ApiBearerAuth()
 @ApiSecurity('api-key')
 @ApiAuthErrors()
@@ -204,6 +211,7 @@ export class MessagesController {
   }
 
   @Get('schedule/:profileId')
+  @RequireScope('message:read')
   @RequireTenant({ from: 'param', key: 'profileId', resource: 'profile' })
   @ApiOperation({ summary: 'Get scheduled messages by profile' })
   @ApiQuery({ name: 'status', required: false, enum: ['pending', 'sent', 'failed', 'cancelled'] })
@@ -223,6 +231,7 @@ export class MessagesController {
 
   // Get messages by profile
   @Get('profile/:profileId')
+  @RequireScope('message:read')
   @RequireTenant({ from: 'param', key: 'profileId', resource: 'profile' })
   @ApiOperation({ summary: 'Get messages by profile' })
   @ApiQuery({ name: 'limit', required: false })
@@ -241,6 +250,7 @@ export class MessagesController {
 
   // Get messages by conversation
   @Get('conversation/:conversationId')
+  @RequireScope('message:read')
   @RequireTenant({ from: 'param', key: 'conversationId', resource: 'conversation' })
   @ApiOperation({ summary: 'Get messages by conversation' })
   @ApiQuery({ name: 'limit', required: false })
@@ -256,6 +266,7 @@ export class MessagesController {
   // Load older messages on-demand: pulls deeper history from WhatsApp, persists it,
   // and returns the refreshed page. Profile must be connected.
   @Get('conversation/:conversationId/load-older')
+  @RequireScope('message:read')
   @RequireTenant({ from: 'param', key: 'conversationId', resource: 'conversation' })
   @ApiOperation({ summary: 'Fetch older messages for a conversation from WhatsApp and persist them' })
   @ApiQuery({ name: 'limit', required: false, description: 'Total most-recent messages to pull (default 100, max 500)' })
@@ -268,6 +279,7 @@ export class MessagesController {
 
   // Get single message
   @Get(':id')
+  @RequireScope('message:read')
   @RequireTenant({ from: 'param', key: 'id', resource: 'message' })
   @ApiOperation({ summary: 'Get message by ID' })
   @ApiNotFound('Message')

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -31,7 +31,7 @@ async function register(app: NestFastifyApplication, email: string): Promise<str
     // per-IP — a growing e2e suite from one IP would rate-limit itself (429). Each
     // registration is treated as a distinct client. (req.ip = socket addr; no trustProxy.)
     remoteAddress: `10.9.${Math.floor(clientSeq / 254) % 254}.${(clientSeq % 254) + 1}`,
-    payload: { email, password: 'password123', name: 'U', organizationName: `Org-${email}` },
+    payload: { email, password: 'password1234!', name: 'U', organizationName: `Org-${email}` },
   });
   const token = res.json()?.accessToken;
   if (typeof token !== 'string') {
@@ -75,7 +75,7 @@ describe('API (e2e)', () => {
       url: '/api/v1/auth/register',
       payload: {
         email,
-        password: 'password123',
+        password: 'password1234!',
         name: 'E2E User',
         organizationName: 'E2E Org',
         // hostile extra: RegisterDto has no `role` — whitelist must strip it so the
@@ -91,7 +91,7 @@ describe('API (e2e)', () => {
     const login = await app.inject({
       method: 'POST',
       url: '/api/v1/auth/login',
-      payload: { email, password: 'password123' },
+      payload: { email, password: 'password1234!' },
     });
     expect([200, 201]).toContain(login.statusCode);
     expect(login.json().accessToken).toBeTruthy();
@@ -102,7 +102,7 @@ describe('API (e2e)', () => {
     await app.inject({
       method: 'POST',
       url: '/api/v1/auth/register',
-      payload: { email, password: 'password123', name: 'B', organizationName: 'B Org' },
+      payload: { email, password: 'password1234!', name: 'B', organizationName: 'B Org' },
     });
 
     const bad = await app.inject({
@@ -117,7 +117,7 @@ describe('API (e2e)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/auth/register',
-      payload: { email: 'x@test.local', password: 'password123' }, // no name / organizationName
+      payload: { email: 'x@test.local', password: 'password1234!' }, // no name / organizationName
     });
     expect(res.statusCode).toBe(400);
   });
@@ -125,6 +125,22 @@ describe('API (e2e)', () => {
   it('requires auth on a protected route (401 without a token)', async () => {
     const res = await app.inject({ method: 'GET', url: '/api/v1/auth/me' });
     expect(res.statusCode).toBe(401);
+  });
+
+  it('enforces the 12-char register password floor (400 under, 201 at)', async () => {
+    const short = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/register',
+      payload: { email: `pw_${Date.now()}@test.local`, password: 'elevenchar1', name: 'P', organizationName: 'P Org' },
+    });
+    expect(short.statusCode).toBe(400); // 11 chars < 12
+
+    const ok = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/register',
+      payload: { email: `pw_ok_${Date.now()}@test.local`, password: 'twelvechars1', name: 'P', organizationName: 'P Org' },
+    });
+    expect(ok.statusCode).toBe(201); // exactly 12 chars
   });
 
   // Tenant isolation / IDOR: the TenantGuard must stop one org from reaching another
@@ -229,6 +245,38 @@ describe('API (e2e)', () => {
         headers: { 'x-api-key': 'mwa_not_a_real_key' },
       });
       expect(bogus.statusCode).toBe(401);
+    });
+
+    it('enforces API-key scopes: a message:read key is blocked from send but not from unscoped routes', async () => {
+      const token = await register(app, `scope_${Date.now()}@test.local`);
+
+      // A restricted, read-only messaging key.
+      const created = await app.inject({
+        method: 'POST',
+        url: '/api/v1/api-keys',
+        headers: { authorization: `Bearer ${token}` },
+        payload: { name: 'read-only', permissions: ['message:read'] },
+      });
+      expect([200, 201]).toContain(created.statusCode);
+      const readKey: string = created.json().key;
+
+      // The scope gate runs before tenant/validation, so sending is a clean 403
+      // (missing message:send) — not a 400/404 from the body/tenant.
+      const send = await app.inject({
+        method: 'POST',
+        url: '/api/v1/messages/text',
+        headers: { 'x-api-key': readKey },
+        payload: { profileId: 'nonexistent', to: '628123', text: 'hi' },
+      });
+      expect(send.statusCode).toBe(403);
+
+      // A route with no @RequireScope is unaffected by the key's scopes.
+      const list = await app.inject({
+        method: 'GET',
+        url: '/api/v1/accounts',
+        headers: { 'x-api-key': readKey },
+      });
+      expect(list.statusCode).toBe(200);
     });
   });
 


### PR DESCRIPTION
## Why

Tier-5 of the world-class roadmap: **close the security gaps** the audit flagged as *false assurance*. This is **part 1** — the backward-compatible, no-schema, no-deploy-risk subset. Designed via a grounded per-item design pass (each change verified against the actual code).

The two delicate items are **deferred to their own PRs** (called out below): refresh-token rotation (schema change + forces re-login) and non-root containers (a production volume-permission migration on the live wagw server).

## What

### 1. API-key scope enforcement — "every key is full-access" (audit high)
`ApiKey.permissions` was stored but never read for authZ. Now:
- the api-key strategy attaches the key's `permissions` to the principal as `apiKeyScopes`;
- a new `@RequireScope` decorator + `ApiKeyScopeGuard` (Reflector-only, mirrors `RolesGuard` — no module wiring; distinct metadata key from the RBAC guard);
- wired onto the messages controller: class default `message:send`, the 5 GET routes override to `message:read`.

**Backward-compatible by construction** — three escape hatches mean nothing existing breaks:
| Caller | Result |
|---|---|
| Existing key (`permissions: []`) | full access (guard returns true on empty) |
| Key with `['*']` | full access (wildcard) |
| JWT login (no `apiKeyScopes`) | unaffected (authZ stays with Roles/RBAC/Tenant) |
| Key with `['message:read']` → `POST /messages/text` | **403** (enforced) |

### 2. Password floor 6/8 → 12
`RegisterDto` 6→12; `changePassword` 8→12. **`LoginDto` left at 6 on purpose** so existing users can still log in — only new registrations / new password changes are gated. No stored hash is re-checked, so zero lockouts.

### 3. CI security scanning
- **CodeQL** (javascript-typescript, security-and-quality) — findings → Security tab; the check never spuriously fails a PR.
- **Dependabot** (npm/pnpm + github-actions, grouped) — the mechanism that actually burns down the audit backlog.
- **gitleaks** secret scan (hard gate) + an **advisory** `pnpm audit` job. The audit is non-blocking today because the tree carries **82 high / 8 critical** existing advisories (mostly dev tooling + a NestJS-11 fastify fix needing a major bump) — flip it to a hard gate once Dependabot burns it down. (No silent cap — this is stated in the workflow + here.)

## Tests
- New `ApiKeyScopeGuard` unit spec — 7 cases, the full backward-compat matrix (green locally).
- e2e extended: a `message:read` key gets **403 on send** but **200 on an unscoped route**; the 12-char register-floor boundary (11→400, 12→201). All e2e register/login passwords bumped to ≥12 so the suite stays green.
- api typecheck clean.

## Deferred (own PRs, with runbooks) — tracked
- **Refresh-token rotation + reuse detection** (audit high): revocable, rotated refresh tokens (schema delta for a token store; forces a one-time re-login). #54 already split the refresh secret; this makes the tokens actually revocable.
- **Non-root containers** (`USER node`): repo change is trivial, but existing deployments have a **root-owned `wa_sessions` volume** — the non-root image would crash-loop + regenerate secrets (mass logout + undecryptable settings) unless the volume is `chown -R 1000:1000`'d during cutover. Ships with that runbook, separately.
- **`ws-api-key.guard.ts`**: a stub that accepts any non-empty key without DB validation (WS auth bypass) — its own fix.