### PR TITLE
feat(observability): HTTP RED metrics + Prometheus/Grafana starter (audit Tier-6)

### DIFF
--- a/apps/api/src/metrics/http-metrics.interceptor.spec.ts
+++ b/apps/api/src/metrics/http-metrics.interceptor.spec.ts
@@ -1,0 +1,59 @@
+// Unit tests for HttpMetricsInterceptor — proves route-pattern labelling,
+// endpoint exclusion, and error-status capture against a real MetricsService.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { of, throwError, lastValueFrom } from 'rxjs';
+import { NotFoundException } from '@nestjs/common';
+import { MetricsService } from './metrics.service';
+import { HttpMetricsInterceptor } from './http-metrics.interceptor';
+
+function ctx(route: string, method = 'GET', statusCode = 200) {
+  return {
+    getType: () => 'http',
+    switchToHttp: () => ({
+      getRequest: () => ({ method, routeOptions: { url: route } }),
+      getResponse: () => ({ statusCode }),
+    }),
+  } as any;
+}
+
+describe('HttpMetricsInterceptor', () => {
+  let svc: MetricsService;
+  let interceptor: HttpMetricsInterceptor;
+
+  beforeEach(() => {
+    svc = new MetricsService();
+    interceptor = new HttpMetricsInterceptor(svc);
+  });
+
+  it('records a matched route by its pattern (not the raw URL)', async () => {
+    const handler = { handle: () => of('ok') } as any;
+    await lastValueFrom(interceptor.intercept(ctx('/api/v1/messages/:id'), handler));
+
+    const out = await svc.metrics();
+    expect(out).toContain('http_requests_total');
+    expect(out).toContain('route="/api/v1/messages/:id"');
+    expect(out).toContain('status="200"');
+    expect(out).toContain('http_request_duration_seconds');
+  });
+
+  it('excludes the /metrics and /health endpoints', async () => {
+    const handler = { handle: () => of('ok') } as any;
+    await lastValueFrom(interceptor.intercept(ctx('/metrics'), handler));
+    await lastValueFrom(interceptor.intercept(ctx('/api/v1/health'), handler));
+
+    const out = await svc.metrics();
+    expect(out).not.toContain('route="/metrics"');
+    expect(out).not.toContain('route="/api/v1/health"');
+  });
+
+  it('captures the HttpException status on error', async () => {
+    const handler = { handle: () => throwError(() => new NotFoundException()) } as any;
+    await expect(
+      lastValueFrom(interceptor.intercept(ctx('/api/v1/messages/:id'), handler)),
+    ).rejects.toThrow(NotFoundException);
+
+    const out = await svc.metrics();
+    expect(out).toContain('status="404"');
+  });
+});

--- a/apps/api/src/metrics/http-metrics.interceptor.ts
+++ b/apps/api/src/metrics/http-metrics.interceptor.ts
@@ -1,0 +1,64 @@
+// MultiWA Gateway API - HTTP RED metrics interceptor
+// apps/api/src/metrics/http-metrics.interceptor.ts
+//
+// Records http_requests_total + http_request_duration_seconds for every matched
+// HTTP route, labelled by the ROUTE PATTERN (bounded cardinality). Additive and
+// fully guarded: a metrics bug can never break a response.
+
+import { CallHandler, ExecutionContext, HttpException, Injectable, Logger, NestInterceptor } from '@nestjs/common';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { Observable, tap, catchError, throwError } from 'rxjs';
+import { MetricsService } from './metrics.service';
+
+// Prefix-agnostic: matches /metrics, /api/v1/health, /api/v1/health/ready.
+// These are scrape/probe endpoints and would only add noise to the RED series.
+const EXCLUDED = /\/(metrics|health)(\/.*)?$/;
+
+@Injectable()
+export class HttpMetricsInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(HttpMetricsInterceptor.name);
+
+  constructor(private readonly metrics: MetricsService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') {
+      return next.handle(); // skip WS / socket.io gateways
+    }
+
+    const http = context.switchToHttp();
+    const req = http.getRequest<FastifyRequest>();
+    const reply = http.getResponse<FastifyReply>();
+
+    // The matched template (e.g. /api/v1/messages/:id), NOT the raw URL.
+    const route = req.routeOptions?.url ?? 'unknown';
+    if (EXCLUDED.test(route)) {
+      return next.handle();
+    }
+
+    const method = req.method;
+    const start = process.hrtime.bigint();
+
+    const record = (status: number) => {
+      try {
+        const seconds = Number(process.hrtime.bigint() - start) / 1e9;
+        const labels = { method, route, status: String(status) };
+        this.metrics.httpRequestsTotal.inc(labels);
+        this.metrics.httpRequestDuration.observe(labels, seconds);
+      } catch (err) {
+        // Never let a metrics failure affect the response.
+        this.logger.debug(`metrics record failed: ${(err as Error).message}`);
+      }
+    };
+
+    return next.handle().pipe(
+      // Nest sets the final status BEFORE interceptors run on success, so
+      // reply.statusCode is correct here. On error the exception filter sets the
+      // status later, so read it from the thrown HttpException instead.
+      tap(() => record(reply.statusCode)),
+      catchError((err) => {
+        record(err instanceof HttpException ? err.getStatus() : 500);
+        return throwError(() => err);
+      }),
+    );
+  }
+}

--- a/apps/api/src/metrics/metrics.module.ts
+++ b/apps/api/src/metrics/metrics.module.ts
@@ -2,12 +2,19 @@
 // apps/api/src/metrics/metrics.module.ts
 
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { MetricsController } from './metrics.controller';
 import { MetricsService } from './metrics.service';
+import { HttpMetricsInterceptor } from './http-metrics.interceptor';
 
 @Module({
   controllers: [MetricsController],
-  providers: [MetricsService],
+  providers: [
+    MetricsService,
+    // Global HTTP RED interceptor. MetricsModule is imported first in AppModule,
+    // so this is the outermost interceptor and measures total handler time.
+    { provide: APP_INTERCEPTOR, useClass: HttpMetricsInterceptor },
+  ],
   exports: [MetricsService],
 })
 export class MetricsModule {}

--- a/apps/api/src/metrics/metrics.service.ts
+++ b/apps/api/src/metrics/metrics.service.ts
@@ -3,22 +3,57 @@
 //
 // Owns a dedicated prom-client Registry (not the global one) so tests and
 // multiple instantiations stay isolated. Collects default Node/process metrics
-// (CPU, memory, event-loop lag, GC, handles). Domain metrics can be added by
-// injecting this service and registering on `registry`.
+// (CPU, memory, event-loop lag, GC, handles) plus the HTTP RED series
+// (requests + latency) recorded by HttpMetricsInterceptor. Domain metrics can be
+// added by injecting this service and registering on `registry` via getOrCreate.
 
 import { Injectable } from '@nestjs/common';
-import { collectDefaultMetrics, Registry } from 'prom-client';
+import { collectDefaultMetrics, Registry, Counter, Histogram, Metric } from 'prom-client';
 
 @Injectable()
 export class MetricsService {
   readonly registry = new Registry();
 
+  // HTTP RED (Rate / Errors / Duration). Labelled by the matched ROUTE PATTERN
+  // (e.g. /api/v1/messages/:id), never the raw URL, so cardinality stays bounded.
+  readonly httpRequestsTotal: Counter<'method' | 'route' | 'status'>;
+  readonly httpRequestDuration: Histogram<'method' | 'route' | 'status'>;
+
   constructor() {
     this.registry.setDefaultLabels({ app: 'multiwa-api' });
     collectDefaultMetrics({ register: this.registry });
+
+    this.httpRequestsTotal = this.getOrCreate(
+      'http_requests_total',
+      () =>
+        new Counter({
+          name: 'http_requests_total',
+          help: 'Total HTTP requests by method, matched route pattern, and status code',
+          labelNames: ['method', 'route', 'status'] as const,
+          registers: [this.registry],
+        }),
+    );
+
+    this.httpRequestDuration = this.getOrCreate(
+      'http_request_duration_seconds',
+      () =>
+        new Histogram({
+          name: 'http_request_duration_seconds',
+          help: 'HTTP request latency (seconds) by method, matched route pattern, and status code',
+          labelNames: ['method', 'route', 'status'] as const,
+          buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+          registers: [this.registry],
+        }),
+    );
   }
 
   metrics(): Promise<string> {
     return this.registry.metrics();
+  }
+
+  // Reuse an existing series on re-instantiation (Vitest re-import, Nest HMR)
+  // instead of throwing "A metric with the name ... has already been registered".
+  private getOrCreate<T extends Metric>(name: string, factory: () => T): T {
+    return (this.registry.getSingleMetric(name) as T | undefined) ?? factory();
   }
 }

--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -1,0 +1,50 @@
+# Monitoring
+
+MultiWA exposes Prometheus metrics for scraping and includes a starter Grafana
+dashboard.
+
+## Endpoints
+
+| Process | Metrics endpoint | Notes |
+|---|---|---|
+| API | `http://<api>:3333/metrics` | Default Node/process metrics + HTTP RED series |
+| Worker | `http://<worker>:3002/metrics` | Default metrics + `multiwa_bullmq_jobs` queue gauge |
+
+Both are public like `/health` — **restrict `/metrics` at your proxy/firewall.**
+
+## HTTP RED metrics (API)
+
+Recorded by a global interceptor for every matched route, labelled by the
+**route pattern** (e.g. `/api/v1/messages/:id`) so cardinality stays bounded.
+The `/metrics` and `/health` endpoints are excluded.
+
+| Metric | Type | Labels |
+|---|---|---|
+| `http_requests_total` | counter | `method`, `route`, `status` |
+| `http_request_duration_seconds` | histogram | `method`, `route`, `status` |
+
+Useful queries:
+
+```promql
+# Request rate by route
+sum by (route) (rate(http_requests_total[5m]))
+
+# 5xx error rate
+sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))
+
+# p95 latency by route
+histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket[5m])))
+```
+
+## Setup
+
+1. Point Prometheus at the endpoints — see [`prometheus.yml`](./prometheus.yml)
+   (adjust the targets to your network/host:port).
+2. Import [`grafana-dashboard.json`](./grafana-dashboard.json) into Grafana
+   (Dashboards → New → Import) and select your Prometheus data source.
+
+## Roadmap
+
+Domain counters (messages sent/failed, send-gate 429 by lane, webhook
+delivery/failure, connected-profile gauge) and OpenTelemetry tracing are
+tracked as follow-ups — see the world-class roadmap.

--- a/docs/monitoring/grafana-dashboard.json
+++ b/docs/monitoring/grafana-dashboard.json
@@ -1,0 +1,112 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping MultiWA /metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "title": "MultiWA — HTTP RED",
+  "description": "Rate, Errors, Duration for the MultiWA API, by matched route pattern.",
+  "tags": ["multiwa", "red", "http"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request rate (req/s) by route",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (route) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{route}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Error rate (% of requests, 5xx)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_requests_total[5m])), 1e-9)",
+          "legendFormat": "5xx error rate"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(http_requests_total{status=~\"4..\"}[5m])) / clamp_min(sum(rate(http_requests_total[5m])), 1e-9)",
+          "legendFormat": "4xx rate"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Latency p95 (s) by route",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{route}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Latency percentiles (s, all routes)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/monitoring/prometheus.yml
+++ b/docs/monitoring/prometheus.yml
@@ -1,0 +1,26 @@
+# Sample Prometheus scrape config for MultiWA.
+# The API exposes /metrics on its HTTP port (default 3333); the worker exposes
+# /metrics on its health port (default 3002). Both serve prom-client text.
+#
+# Adjust the targets to your deployment (service names on the Docker network, or
+# host:port). Restrict access to /metrics at your proxy/firewall — it is public
+# like /health.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: multiwa-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['api:3333']
+        labels:
+          service: multiwa-api
+
+  - job_name: multiwa-worker
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['worker:3002']
+        labels:
+          service: multiwa-worker


### PR DESCRIPTION
## Why

The audit capped **production-readiness at 5/10** (the lowest dimension) because `/metrics` exposed only `collectDefaultMetrics()` — **no RED signal**, so an SRE couldn't build a latency SLO or alert on error rate for the multi-hop pipeline. This adds the HTTP RED series (Rate / Errors / Duration) with **zero hot-path risk**.

Grounded in a metrics-infra mapping pass (registry wiring, route-pattern source, status-timing, and double-registration all verified against the actual Fastify/Nest versions).

## What

- **MetricsService**: registers `http_requests_total` (counter) + `http_request_duration_seconds` (histogram) on the **same dedicated registry** `/metrics` already serves, labelled `method`/`route`/`status`. A `getOrCreate` guard reuses the series on re-instantiation (test re-import / HMR) instead of throwing prom-client's "already registered".
- **HttpMetricsInterceptor** (global via `APP_INTERCEPTOR` in `MetricsModule`): records each matched route by its **route pattern** (`req.routeOptions.url`, e.g. `/api/v1/messages/:id` — never the raw URL → bounded cardinality), excludes `/metrics` + `/health`, reads status from `reply.statusCode` on success and the thrown `HttpException` on error, and wraps recording in `try/catch` so **a metrics bug can never break a response**.
- **docs/monitoring/**: sample `prometheus.yml` (api :3333 + worker :3002), a starter **Grafana RED dashboard** (rate / 5xx+4xx error rate / p50-p95-p99 latency by route), and a README with endpoints + PromQL.

## Scope / deferred
This is the **HTTP RED slice only** — self-contained in the api process, low risk. Deferred to follow-ups (they span api/worker/engine-runtime hot paths): **domain counters** (messages sent/failed, send-gate 429 by lane, webhook delivery/failure, connected-profile gauge) and **OpenTelemetry tracing + error sink**.

## Tests
- New interceptor spec — route-pattern labelling, `/metrics` + `/health` exclusion, `HttpException` status capture (3 cases, green).
- Existing metrics-service spec still green. api typecheck clean.

## Example
```promql
histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket[5m])))
```