### PR TITLE
feat(security): revocable, rotating refresh tokens with reuse detection (audit Tier-5 pt.2)

### DIFF
--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -24,6 +24,12 @@ vi.mock('@multiwa/database', () => ({
     account: {
       create: vi.fn(),
     },
+    refreshToken: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
   },
 }));
 
@@ -35,6 +41,7 @@ describe('AuthService', () => {
   const mockJwtService = {
     sign: vi.fn().mockReturnValue('mock-token'),
     verify: vi.fn(),
+    decode: vi.fn(),
   };
   const mockTwoFactorService = {
     verifyTwoFactor: vi.fn(),
@@ -61,9 +68,14 @@ describe('AuthService', () => {
     vi.mocked(prisma.organization.delete).mockReset();
     vi.mocked(prisma.workspace.create).mockReset();
     vi.mocked(prisma.account.create).mockReset();
+    vi.mocked(prisma.refreshToken.create).mockReset().mockResolvedValue({} as any);
+    vi.mocked(prisma.refreshToken.findUnique).mockReset();
+    vi.mocked(prisma.refreshToken.update).mockReset().mockResolvedValue({} as any);
+    vi.mocked(prisma.refreshToken.updateMany).mockReset().mockResolvedValue({ count: 0 } as any);
 
     mockJwtService.sign.mockReset().mockReturnValue('mock-token');
     mockJwtService.verify.mockReset();
+    mockJwtService.decode.mockReset();
     mockSessionsService.createSession.mockReset();
     mockSessionsService.removeSessionByToken.mockReset();
     mockTwoFactorService.verifyTwoFactor.mockReset();

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -287,10 +287,16 @@ export class AuthService {
     };
 
     const accessToken = this.jwtService.sign(payload);
-    const refreshToken = this.jwtService.sign(payload, {
-      secret: this.refreshSecret,
-      expiresIn: this.config.get('JWT_REFRESH_EXPIRES_IN', '30d'),
-    });
+    // A unique jti makes every refresh JWT distinct even when two are issued in the
+    // same second for the same user (register+login, rapid rotation) — otherwise
+    // identical payload+iat would collide on the stored tokenHash.
+    const refreshToken = this.jwtService.sign(
+      { ...payload, jti: crypto.randomUUID() },
+      {
+        secret: this.refreshSecret,
+        expiresIn: this.config.get('JWT_REFRESH_EXPIRES_IN', '30d'),
+      },
+    );
 
     // Persist the refresh token (hashed) so it is revocable + rotatable. Without
     // this a stateless refresh JWT would keep minting access tokens after logout.

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -135,27 +135,66 @@ export class AuthService {
   }
 
   async refreshToken(refreshToken: string): Promise<TokenResponseDto> {
+    let payload: { sub: string };
     try {
-      const payload = this.jwtService.verify(refreshToken, { secret: this.refreshSecret });
-      const user = await prisma.user.findUnique({
-        where: { id: payload.sub },
-      });
-
-      if (!user) {
-        throw new UnauthorizedException('Invalid token');
-      }
-
-      return this.generateTokens(user);
+      payload = this.jwtService.verify(refreshToken, { secret: this.refreshSecret });
     } catch {
       throw new UnauthorizedException('Invalid refresh token');
     }
+
+    const tokenHash = this.hashToken(refreshToken);
+    const stored = await prisma.refreshToken.findUnique({ where: { tokenHash } });
+
+    // Unknown token — not in the store (e.g. issued before rotation existed, or
+    // forged). Reject; the holder re-authenticates once.
+    if (!stored) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    // Reuse of an already-rotated token → someone is replaying an old token.
+    // Revoke the whole family so neither the attacker nor the victim can refresh.
+    if (stored.revokedAt) {
+      await this.revokeFamily(stored.family);
+      throw new UnauthorizedException('Refresh token reuse detected');
+    }
+
+    if (stored.expiresAt.getTime() < Date.now()) {
+      throw new UnauthorizedException('Refresh token expired');
+    }
+
+    const user = await prisma.user.findUnique({ where: { id: payload.sub } });
+    if (!user || !user.isActive) {
+      await this.revokeFamily(stored.family);
+      throw new UnauthorizedException('Invalid token');
+    }
+
+    // Rotate: revoke the presented token, mint a new pair in the SAME family.
+    await prisma.refreshToken.update({
+      where: { id: stored.id },
+      data: { revokedAt: new Date() },
+    });
+    return this.generateTokens(
+      user,
+      { ipAddress: stored.ipAddress ?? undefined, userAgent: stored.userAgent ?? undefined },
+      stored.family,
+    );
   }
 
   /**
-   * Logout — revoke current session.
+   * Logout — revoke the current access session AND the user's refresh tokens, so
+   * a logged-out client cannot mint new access tokens via /auth/refresh.
    */
   async logout(accessToken: string): Promise<void> {
     await this.sessionsService.removeSessionByToken(accessToken);
+    // decode (unverified) is enough — the caller was already authenticated to
+    // reach logout; a garbage token decodes to null and no-ops.
+    const payload = this.jwtService.decode(accessToken) as { sub?: string } | null;
+    if (payload?.sub) {
+      await prisma.refreshToken.updateMany({
+        where: { userId: payload.sub, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+    }
   }
 
   async getProfile(userId: string) {
@@ -236,6 +275,9 @@ export class AuthService {
   private async generateTokens(
     user: any,
     sessionContext?: { ipAddress?: string; userAgent?: string },
+    // Rotation lineage. Fresh logins start a new family; /auth/refresh reuses the
+    // rotated token's family so reuse detection spans the whole chain.
+    family?: string,
   ): Promise<TokenResponseDto> {
     const payload = {
       sub: user.id,
@@ -249,6 +291,10 @@ export class AuthService {
       secret: this.refreshSecret,
       expiresIn: this.config.get('JWT_REFRESH_EXPIRES_IN', '30d'),
     });
+
+    // Persist the refresh token (hashed) so it is revocable + rotatable. Without
+    // this a stateless refresh JWT would keep minting access tokens after logout.
+    await this.storeRefreshToken(user.id, refreshToken, family ?? crypto.randomUUID(), sessionContext);
 
     // Every issued access token is bound to a server-side session so logout and
     // session revocation actually invalidate it (JwtStrategy checks the session
@@ -272,6 +318,41 @@ export class AuthService {
         organizationId: user.organizationId,
       },
     };
+  }
+
+  // Store a refresh token as a SHA-256 hash (never the raw JWT), with its expiry
+  // taken from the token's own `exp` claim so the row and the JWT agree.
+  private async storeRefreshToken(
+    userId: string,
+    rawToken: string,
+    family: string,
+    ctx?: { ipAddress?: string; userAgent?: string },
+  ): Promise<void> {
+    const decoded = this.jwtService.decode(rawToken) as { exp?: number } | null;
+    const expiresAt = decoded?.exp
+      ? new Date(decoded.exp * 1000)
+      : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    await prisma.refreshToken.create({
+      data: {
+        userId,
+        tokenHash: this.hashToken(rawToken),
+        family,
+        expiresAt,
+        ipAddress: ctx?.ipAddress,
+        userAgent: ctx?.userAgent,
+      },
+    });
+  }
+
+  private hashToken(token: string): string {
+    return crypto.createHash('sha256').update(token).digest('hex');
+  }
+
+  private async revokeFamily(family: string): Promise<void> {
+    await prisma.refreshToken.updateMany({
+      where: { family, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
   }
 
   private async hashPassword(password: string): Promise<string> {

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -314,10 +314,13 @@ describe('API (e2e)', () => {
   // logged-out refresh token can't keep minting access tokens.
   describe('refresh token rotation & revocation', () => {
     it('rotates the refresh token and rejects reuse of the old one', async () => {
+      // Dedicated client IP: /auth/register is per-IP throttled (5/min).
+      const ip = '10.50.0.1';
       const email = `refresh_${Date.now()}@test.local`;
       const reg = await app.inject({
         method: 'POST',
         url: '/api/v1/auth/register',
+        remoteAddress: ip,
         payload: { email, password: 'password1234!', name: 'R', organizationName: 'R Org' },
       });
       expect(reg.statusCode).toBe(201);
@@ -328,6 +331,7 @@ describe('API (e2e)', () => {
       const rot = await app.inject({
         method: 'POST',
         url: '/api/v1/auth/refresh',
+        remoteAddress: ip,
         payload: { refreshToken: r1 },
       });
       expect([200, 201]).toContain(rot.statusCode);
@@ -340,6 +344,7 @@ describe('API (e2e)', () => {
       const reuse = await app.inject({
         method: 'POST',
         url: '/api/v1/auth/refresh',
+        remoteAddress: ip,
         payload: { refreshToken: r1 },
       });
       expect(reuse.statusCode).toBe(401);
@@ -347,16 +352,19 @@ describe('API (e2e)', () => {
       const afterReuse = await app.inject({
         method: 'POST',
         url: '/api/v1/auth/refresh',
+        remoteAddress: ip,
         payload: { refreshToken: r2 },
       });
       expect(afterReuse.statusCode).toBe(401);
     });
 
     it('logout revokes the refresh token (no new access tokens after logout)', async () => {
+      const ip = '10.50.0.2';
       const email = `refreshlogout_${Date.now()}@test.local`;
       const reg = await app.inject({
         method: 'POST',
         url: '/api/v1/auth/register',
+        remoteAddress: ip,
         payload: { email, password: 'password1234!', name: 'R', organizationName: 'R Org' },
       });
       const { accessToken, refreshToken } = reg.json();
@@ -364,6 +372,7 @@ describe('API (e2e)', () => {
       const logout = await app.inject({
         method: 'POST',
         url: '/api/v1/auth/logout',
+        remoteAddress: ip,
         headers: { authorization: `Bearer ${accessToken}` },
       });
       expect([200, 201]).toContain(logout.statusCode);
@@ -371,6 +380,7 @@ describe('API (e2e)', () => {
       const refresh = await app.inject({
         method: 'POST',
         url: '/api/v1/auth/refresh',
+        remoteAddress: ip,
         payload: { refreshToken },
       });
       expect(refresh.statusCode).toBe(401);

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -310,6 +310,73 @@ describe('API (e2e)', () => {
     });
   });
 
+  // Refresh tokens are revocable + rotated with reuse detection, so a leaked or
+  // logged-out refresh token can't keep minting access tokens.
+  describe('refresh token rotation & revocation', () => {
+    it('rotates the refresh token and rejects reuse of the old one', async () => {
+      const email = `refresh_${Date.now()}@test.local`;
+      const reg = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email, password: 'password1234!', name: 'R', organizationName: 'R Org' },
+      });
+      expect(reg.statusCode).toBe(201);
+      const r1: string = reg.json().refreshToken;
+      expect(r1).toBeTruthy();
+
+      // Rotate: exchange r1 for a fresh pair.
+      const rot = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/refresh',
+        payload: { refreshToken: r1 },
+      });
+      expect([200, 201]).toContain(rot.statusCode);
+      const r2: string = rot.json().refreshToken;
+      expect(r2).toBeTruthy();
+      expect(r2).not.toBe(r1);
+
+      // Replaying the now-rotated r1 is reuse → rejected, and it revokes the whole
+      // family, so even the fresh r2 is dead afterwards.
+      const reuse = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/refresh',
+        payload: { refreshToken: r1 },
+      });
+      expect(reuse.statusCode).toBe(401);
+
+      const afterReuse = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/refresh',
+        payload: { refreshToken: r2 },
+      });
+      expect(afterReuse.statusCode).toBe(401);
+    });
+
+    it('logout revokes the refresh token (no new access tokens after logout)', async () => {
+      const email = `refreshlogout_${Date.now()}@test.local`;
+      const reg = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email, password: 'password1234!', name: 'R', organizationName: 'R Org' },
+      });
+      const { accessToken, refreshToken } = reg.json();
+
+      const logout = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/logout',
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+      expect([200, 201]).toContain(logout.statusCode);
+
+      const refresh = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/refresh',
+        payload: { refreshToken },
+      });
+      expect(refresh.statusCode).toBe(401);
+    });
+  });
+
   // Webhooks are profile-scoped; the profile is org-scoped, so webhook access is
   // isolated across orgs. (This is the surface behind the recent bot integration.)
   describe('webhooks (profile-scoped, cross-org isolation)', () => {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -96,6 +96,7 @@ model User {
   notifications       Notification[]
   assignedConversations Conversation[] @relation("AssignedAgent")
   sessions            Session[]
+  refreshTokens       RefreshToken[]
   pushSubscriptions   PushSubscription[]
 
   @@map("users")
@@ -498,6 +499,29 @@ model Session {
   @@index([userId])
   @@index([expiresAt])
   @@map("sessions")
+}
+
+// Revocable, rotating refresh tokens. Each successful /auth/refresh rotates the
+// presented token (revoke it, mint a new one in the same `family`). Replaying an
+// already-revoked token is reuse: the whole family is revoked. Logout revokes the
+// user's active tokens. Stored as a SHA-256 hash of the raw JWT (never the token).
+model RefreshToken {
+  id          String   @id @default(uuid())
+  userId      String
+  tokenHash   String   @unique
+  family      String
+  expiresAt   DateTime
+  revokedAt   DateTime?
+  ipAddress   String?
+  userAgent   String?
+  createdAt   DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([family])
+  @@index([expiresAt])
+  @@map("refresh_tokens")
 }
 
 // ============================================


### PR DESCRIPTION
## Why

Closes the audit's headline **"false assurance"** gap (high severity): refresh tokens were stateless 30-day JWTs, so `logout` / "revoke sessions" removed the access session but **the refresh token kept minting new access tokens**. Refresh tokens are now stateful, rotated, and revocable — the shipped session-revocation is finally real end-to-end.

## What

- **New `RefreshToken` model** — the raw JWT is stored **only as a SHA-256 hash**, with a rotation `family`, expiry (from the token's own `exp`), and `revokedAt`. Created on boot via `prisma db push` (new table, non-destructive).
- **`generateTokens`** persists each issued refresh token (hashed) in a family. Fresh logins start a new family; `/auth/refresh` reuses the rotated token's family.
- **`refreshToken()`** now: verify → look up the stored hash → **rotate** (revoke the presented token, mint a new pair in the same family) → re-check the user exists + `isActive`. **Reuse detection**: replaying an already-revoked token revokes the *whole family* (kicks out both attacker and victim). Unknown/expired tokens are rejected.
- **`logout()`** now also revokes the user's active refresh tokens.

## Security properties
| Scenario | Result |
|---|---|
| Normal refresh | old token revoked, new pair issued (same family) |
| Replay a rotated token (leak) | **reuse detected → family revoked** |
| Logout then refresh | **401** (refresh revoked) |
| Deactivated user (`isActive=false`) refresh | **401** + family revoked |
| Unknown / expired token | **401** |

## Backward-compatibility / deploy
- Refresh tokens issued **before** this change aren't in the store → the first `/auth/refresh` after deploy returns 401 and the user logs in once. No access-token session (#27) is affected. #54 already split the refresh secret.
- Schema change is additive (`prisma db push` on api boot creates `refresh_tokens`). No data migration.

## Tests
- **e2e (live Postgres)** — rotation invalidates the old token; reuse of a rotated token revokes the family; logout kills the refresh token.
- auth.service unit mock extended for the new `prisma.refreshToken` calls.
- typecheck clean; runnable unit specs (messages/guards/metrics) green. Schema diff kept to the model + relation only (reverted a `prisma format` whole-file realign).

## Follow-up
Wire refresh revocation into the **"revoke all other sessions"** endpoint too (logout is fully covered here).