### PR TITLE
feat(observability): domain metrics — messages sent/failed + connected-profile gauge (audit Tier-6 pt.2)

### DIFF
--- a/apps/api/src/metrics/metrics-events.listener.spec.ts
+++ b/apps/api/src/metrics/metrics-events.listener.spec.ts
@@ -1,0 +1,60 @@
+// Unit tests for MetricsEventsListener — event → metric wiring + DB resync,
+// with MetricsService and prisma mocked (no database).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => ({
+  prisma: { profile: { count: vi.fn() } },
+}));
+
+import { prisma } from '@multiwa/database';
+import { MetricsEventsListener } from './metrics-events.listener';
+
+function makeMetrics() {
+  return {
+    messagesSentTotal: { inc: vi.fn() },
+    messagesFailedTotal: { inc: vi.fn() },
+    connectedProfiles: { inc: vi.fn(), dec: vi.fn(), set: vi.fn() },
+  } as any;
+}
+
+describe('MetricsEventsListener', () => {
+  let metrics: ReturnType<typeof makeMetrics>;
+  let listener: MetricsEventsListener;
+
+  beforeEach(() => {
+    vi.mocked(prisma.profile.count).mockReset();
+    metrics = makeMetrics();
+    listener = new MetricsEventsListener(metrics);
+  });
+
+  it('resyncs the connected-profiles gauge from the DB on init', async () => {
+    vi.mocked(prisma.profile.count).mockResolvedValueOnce(3 as any);
+    await listener.onModuleInit();
+    expect(prisma.profile.count).toHaveBeenCalledWith({ where: { status: 'connected' } });
+    expect(metrics.connectedProfiles.set).toHaveBeenCalledWith(3);
+  });
+
+  it('swallows a DB error during resync (never throws)', async () => {
+    vi.mocked(prisma.profile.count).mockRejectedValueOnce(new Error('db down'));
+    await expect(listener.onModuleInit()).resolves.toBeUndefined();
+    expect(metrics.connectedProfiles.set).not.toHaveBeenCalled();
+  });
+
+  it('counts sent/failed by type and adjusts the gauge on connect/disconnect', () => {
+    listener.onMessageSent({ type: 'text' });
+    expect(metrics.messagesSentTotal.inc).toHaveBeenCalledWith({ type: 'text' });
+
+    listener.onMessageFailed({ type: 'image' });
+    expect(metrics.messagesFailedTotal.inc).toHaveBeenCalledWith({ type: 'image' });
+
+    listener.onMessageSent({}); // missing type falls back
+    expect(metrics.messagesSentTotal.inc).toHaveBeenCalledWith({ type: 'unknown' });
+
+    listener.onConnectionReady();
+    expect(metrics.connectedProfiles.inc).toHaveBeenCalledOnce();
+
+    listener.onConnectionDisconnected();
+    expect(metrics.connectedProfiles.dec).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/metrics/metrics-events.listener.ts
+++ b/apps/api/src/metrics/metrics-events.listener.ts
@@ -1,0 +1,66 @@
+// MultiWA Gateway API - Domain metrics event listener
+// apps/api/src/metrics/metrics-events.listener.ts
+//
+// Bridges the in-process EventEmitter bus to Prometheus counters/gauge. Runs off
+// the send hot path (event handlers) and every handler is guarded, so a metrics
+// error can never affect message delivery or connection handling.
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { prisma } from '@multiwa/database';
+import { AppEvents } from '@multiwa/core';
+import { MetricsService } from './metrics.service';
+
+@Injectable()
+export class MetricsEventsListener implements OnModuleInit {
+  private readonly logger = new Logger(MetricsEventsListener.name);
+
+  constructor(private readonly metrics: MetricsService) {}
+
+  // Resync the connected-profiles gauge from the source of truth at startup so a
+  // process restart doesn't leave it stuck at 0 until profiles reconnect.
+  async onModuleInit(): Promise<void> {
+    try {
+      const connected = await prisma.profile.count({ where: { status: 'connected' } });
+      this.metrics.connectedProfiles.set(connected);
+    } catch (err) {
+      this.logger.debug(`connected-profiles resync failed: ${(err as Error).message}`);
+    }
+  }
+
+  @OnEvent(AppEvents.MESSAGE.SENT)
+  onMessageSent(payload: { type?: string }): void {
+    try {
+      this.metrics.messagesSentTotal.inc({ type: payload?.type ?? 'unknown' });
+    } catch (err) {
+      this.logger.debug(`messagesSent metric failed: ${(err as Error).message}`);
+    }
+  }
+
+  @OnEvent(AppEvents.MESSAGE.FAILED)
+  onMessageFailed(payload: { type?: string }): void {
+    try {
+      this.metrics.messagesFailedTotal.inc({ type: payload?.type ?? 'unknown' });
+    } catch (err) {
+      this.logger.debug(`messagesFailed metric failed: ${(err as Error).message}`);
+    }
+  }
+
+  @OnEvent(AppEvents.CONNECTION.READY)
+  onConnectionReady(): void {
+    try {
+      this.metrics.connectedProfiles.inc();
+    } catch (err) {
+      this.logger.debug(`connectedProfiles.inc failed: ${(err as Error).message}`);
+    }
+  }
+
+  @OnEvent(AppEvents.CONNECTION.DISCONNECTED)
+  onConnectionDisconnected(): void {
+    try {
+      this.metrics.connectedProfiles.dec();
+    } catch (err) {
+      this.logger.debug(`connectedProfiles.dec failed: ${(err as Error).message}`);
+    }
+  }
+}

--- a/apps/api/src/metrics/metrics.module.ts
+++ b/apps/api/src/metrics/metrics.module.ts
@@ -6,6 +6,7 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { MetricsController } from './metrics.controller';
 import { MetricsService } from './metrics.service';
 import { HttpMetricsInterceptor } from './http-metrics.interceptor';
+import { MetricsEventsListener } from './metrics-events.listener';
 
 @Module({
   controllers: [MetricsController],
@@ -14,6 +15,8 @@ import { HttpMetricsInterceptor } from './http-metrics.interceptor';
     // Global HTTP RED interceptor. MetricsModule is imported first in AppModule,
     // so this is the outermost interceptor and measures total handler time.
     { provide: APP_INTERCEPTOR, useClass: HttpMetricsInterceptor },
+    // Domain metrics from the EventEmitter bus (messages sent/failed, connected profiles).
+    MetricsEventsListener,
   ],
   exports: [MetricsService],
 })

--- a/apps/api/src/metrics/metrics.service.ts
+++ b/apps/api/src/metrics/metrics.service.ts
@@ -8,7 +8,7 @@
 // added by injecting this service and registering on `registry` via getOrCreate.
 
 import { Injectable } from '@nestjs/common';
-import { collectDefaultMetrics, Registry, Counter, Histogram, Metric } from 'prom-client';
+import { collectDefaultMetrics, Registry, Counter, Histogram, Gauge, Metric } from 'prom-client';
 
 @Injectable()
 export class MetricsService {
@@ -18,6 +18,14 @@ export class MetricsService {
   // (e.g. /api/v1/messages/:id), never the raw URL, so cardinality stays bounded.
   readonly httpRequestsTotal: Counter<'method' | 'route' | 'status'>;
   readonly httpRequestDuration: Histogram<'method' | 'route' | 'status'>;
+
+  // Domain metrics. Incremented by MetricsEventsListener off the EventEmitter bus
+  // (never on the send hot path). `type` = message type (text/image/…).
+  readonly messagesSentTotal: Counter<'type'>;
+  readonly messagesFailedTotal: Counter<'type'>;
+  // Approximate live count of connected WhatsApp profiles: resynced from the DB at
+  // startup, then adjusted by connection.ready / connection.disconnected events.
+  readonly connectedProfiles: Gauge;
 
   constructor() {
     this.registry.setDefaultLabels({ app: 'multiwa-api' });
@@ -42,6 +50,38 @@ export class MetricsService {
           help: 'HTTP request latency (seconds) by method, matched route pattern, and status code',
           labelNames: ['method', 'route', 'status'] as const,
           buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+          registers: [this.registry],
+        }),
+    );
+
+    this.messagesSentTotal = this.getOrCreate(
+      'multiwa_messages_sent_total',
+      () =>
+        new Counter({
+          name: 'multiwa_messages_sent_total',
+          help: 'WhatsApp messages sent successfully, by message type',
+          labelNames: ['type'] as const,
+          registers: [this.registry],
+        }),
+    );
+
+    this.messagesFailedTotal = this.getOrCreate(
+      'multiwa_messages_failed_total',
+      () =>
+        new Counter({
+          name: 'multiwa_messages_failed_total',
+          help: 'WhatsApp message sends that failed, by message type',
+          labelNames: ['type'] as const,
+          registers: [this.registry],
+        }),
+    );
+
+    this.connectedProfiles = this.getOrCreate(
+      'multiwa_connected_profiles',
+      () =>
+        new Gauge({
+          name: 'multiwa_connected_profiles',
+          help: 'WhatsApp profiles currently connected (approximate)',
           registers: [this.registry],
         }),
     );

--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -36,6 +36,22 @@ sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total
 histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket[5m])))
 ```
 
+## Domain metrics (API)
+
+Emitted off the internal event bus by a listener (never on the send hot path).
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `multiwa_messages_sent_total` | counter | `type` | messages sent OK, by message type |
+| `multiwa_messages_failed_total` | counter | `type` | message sends that failed, by type |
+| `multiwa_connected_profiles` | gauge | — | connected WhatsApp profiles (resynced from the DB at startup, then adjusted by connection events — approximate) |
+
+```promql
+# Send failure ratio
+sum(rate(multiwa_messages_failed_total[5m]))
+  / sum(rate(multiwa_messages_sent_total[5m]) + rate(multiwa_messages_failed_total[5m]))
+```
+
 ## Setup
 
 1. Point Prometheus at the endpoints — see [`prometheus.yml`](./prometheus.yml)
@@ -45,6 +61,6 @@ histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_
 
 ## Roadmap
 
-Domain counters (messages sent/failed, send-gate 429 by lane, webhook
-delivery/failure, connected-profile gauge) and OpenTelemetry tracing are
-tracked as follow-ups — see the world-class roadmap.
+Remaining observability follow-ups: send-gate 429 by lane and webhook
+delivery/failure counters (these live in the engine-runtime / worker, a
+different process registry), plus OpenTelemetry tracing and an error sink.


### PR DESCRIPTION
## Why

Extends the HTTP RED metrics (#60) with the **domain signal** the audit asked for — message throughput/failures and connected profiles — so an operator can alert on send-failure rate, not just HTTP status. Wired **off the internal EventEmitter bus** so nothing touches the send hot path.

## What

- **MetricsService** — three new series on the existing `/metrics` registry (via the `getOrCreate` guard):
  | Metric | Type | Labels |
  |---|---|---|
  | `multiwa_messages_sent_total` | counter | `type` |
  | `multiwa_messages_failed_total` | counter | `type` |
  | `multiwa_connected_profiles` | gauge | — |
- **MetricsEventsListener** — `@OnEvent(message.sent/failed)` increments the counters by message type; `connection.ready/disconnected` adjust the gauge. The gauge is **resynced from the DB** (`profiles where status='connected'`) at startup so a restart doesn't leave it stuck at 0. **Every handler is `try/caught`** — a metrics error can never affect delivery or connection handling.
- **docs/monitoring/README** updated with the new metrics + a send-failure-ratio query.

## Safety
Purely additive — event listeners + new metrics. No change to `MessagesService`/`engine-manager` (they already emit these events). MetricsService stays prisma-free (the DB read lives in the listener), so its unit spec is unaffected.

## Scope / deferred
API-process metrics only. **Send-gate 429-by-lane** and **webhook delivery/failure** live in `engine-runtime`/`worker` (a different process registry) and stay follow-ups, as does **OpenTelemetry tracing + error sink**.

## Tests
`MetricsEventsListener` unit spec (event→metric wiring, DB resync, error swallowed) — green alongside the existing metrics specs (8 total). typecheck clean.