### PR TITLE
fix(engine): guard message-ack with no id — stop WHERE 1=1 mass update + Postgres deadlocks

### DIFF
--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -1163,6 +1163,14 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
         }
       },
       onMessageAck: async (messageId: string, status: string) => {
+        // Guard an unresolvable ack id: Prisma treats `where: { messageId: undefined }`
+        // as NO filter, so updateMany degrades to `WHERE 1=1` and would rewrite EVERY
+        // message's status — table-wide corruption + a full-table lock that deadlocks
+        // against concurrent acks. Skip when the id is absent/empty.
+        if (!messageId) {
+          this.logger.warn(`[ACK] Ignoring ack with no message id (status: ${status})`);
+          return;
+        }
         this.logger.log(`[ACK] Message ${messageId} → status: ${status}`);
         try {
           // The engine adapter already maps numeric ack to string status

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -1082,6 +1082,14 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
         }
       },
       onMessageAck: async (messageId: string, status: string) => {
+        // Guard an unresolvable ack id: Prisma treats `where: { messageId: undefined }`
+        // as NO filter, so updateMany degrades to `WHERE 1=1` and would rewrite EVERY
+        // message's status — table-wide corruption + a full-table lock that deadlocks
+        // against concurrent acks. Skip when the id is absent/empty.
+        if (!messageId) {
+          this.logger.warn(`[ACK] Ignoring ack with no message id (status: ${status})`);
+          return;
+        }
         this.logger.log(`[ACK] Message ${messageId} → status: ${status}`);
         try {
           // The engine adapter already maps numeric ack to string status


### PR DESCRIPTION
## Why (found in production)

The final-check on wagw surfaced **~350 Postgres deadlocks/24h**, all on one statement:
```
UPDATE "public"."messages" SET "status" = $1 WHERE 1=1
```
`WHERE 1=1` = **update every row in `messages`**.

## Root cause

The WhatsApp ack handler (in **both** the api and worker `engine-manager` forks) ran:
```ts
onMessageAck: async (messageId: string, status: string) => {
  const updated = await prisma.message.updateMany({ where: { messageId }, data: { status } });
```
`messageId` is *typed* `string`, but the engine can deliver an ack whose id is **`undefined`** (unresolvable id — same class as the inbound `@lid` bug fixed in #48). Prisma treats `where: { messageId: undefined }` as **no filter**, so the query becomes `WHERE 1=1` and:
1. **rewrites the status of every message** in the table (silent corruption of unrelated messages),
2. locks the whole table row-by-row → concurrent acks deadlock (the 350/24h),
3. is a large, needless full-table write on a hot path.

## Fix

Early-return when the ack id is absent — no id → nothing to update. Applied to both forks (identical handler):
```ts
if (!messageId) {
  this.logger.warn(`[ACK] Ignoring ack with no message id (status: ${status})`);
  return;
}
```

## Impact
Eliminates the mass-update, the status corruption, and the deadlock source. **Not yet deployed** — like the rest of this session's work it lands on `main`; deploy to wagw when ready (this one is a clear win to prioritize).

## Validation
api + worker typecheck clean. **Follow-up**: extract the shared ack logic into one tested helper (ties into the `engine-manager` de-duplication the audit flagged) to add a regression test, and audit the other `updateMany` sites for the same undefined-filter footgun.