### PR TITLE
fix(security): fail closed on destructive user-data paths when userId is absent (footgun audit)

### DIFF
--- a/apps/api/src/modules/accounts/gdpr.controller.ts
+++ b/apps/api/src/modules/accounts/gdpr.controller.ts
@@ -1,7 +1,7 @@
 // MultiWA Gateway - GDPR Compliance Controller
 // apps/api/src/modules/accounts/gdpr.controller.ts
 
-import { Controller, Get, Delete, Req, UseGuards, Logger } from '@nestjs/common';
+import { Controller, Get, Delete, Req, UseGuards, Logger, UnauthorizedException } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiSecurity, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ApiAuthErrors, ApiNotFound } from '../../common/decorators/api-responses';
@@ -224,7 +224,14 @@ export class GdprController {
   @ApiResponse({ status: 404, description: 'User not found' })
   @ApiNotFound('User')
   async deleteAccount(@Req() req: any) {
-    const userId = req.user.id;
+    const userId = req.user?.id;
+    // Fail closed: every deleteMany below filters by { userId }. With an undefined
+    // userId, Prisma drops the filter (WHERE 1=1) and would erase EVERY user's push
+    // subscriptions/notifications/audit logs/sessions/API keys. The auth guard already
+    // guarantees a user id, but this operation is IRREVERSIBLE, so we double-check.
+    if (!userId) {
+      throw new UnauthorizedException('Authenticated user id is required');
+    }
     this.logger.warn(`GDPR account deletion requested by user ${userId}`);
 
     const deletionLog: Record<string, number> = {};

--- a/apps/api/src/modules/auth/sessions.service.ts
+++ b/apps/api/src/modules/auth/sessions.service.ts
@@ -137,6 +137,9 @@ export class SessionsService {
    * Revoke all sessions except the current one.
    */
   async revokeAllSessions(userId: string, currentToken?: string): Promise<number> {
+    // Fail closed: an undefined userId would make deleteMany drop the filter
+    // (WHERE 1=1) and delete EVERY user's sessions. Guard the destructive path.
+    if (!userId) return 0;
     const where: any = { userId };
 
     if (currentToken) {


### PR DESCRIPTION
## Why

Follow-up to **#73** (the ack `WHERE 1=1` deadlock/mass-update fix). I audited **all 17 `updateMany` + all `deleteMany`** call sites for the same footgun — a single-field `where` that Prisma degrades to `WHERE 1=1` when the field is `undefined`.

**Audit result:** the ack handler (fixed in #73) was the **only** site taking an undefined single-field filter from an **untrusted source** (an engine callback). Every other site is safe:
- **multi-condition** `where` (undefined one field still leaves a bounded filter),
- sourced from **auth guards / route params / DB rows** (always defined), or
- **intentionally broad** (daily counter reset, connected-profile startup cleanup).

## What

Two paths get a **belt-and-suspenders** guard anyway, because they `deleteMany({ where: { userId } })` and their blast radius is **catastrophic + irreversible** — an undefined `userId` would wipe **every** user's data:
- **GDPR delete-account** (push subs / notifications / audit logs / sessions / API keys) → **throws** if `req.user?.id` is absent.
- **`SessionsService.revokeAllSessions`** → returns `0` (no-op) if `userId` is absent.

The auth guards already guarantee a user id, so this is **defense-in-depth on irreversible operations**, not a live bug (unlike #73, which was actively firing in production).

## Validation
api typecheck clean. Behavior unchanged for all real (authenticated) requests.