### PR TITLE
chore(deps): drop uuid for node:crypto randomUUID (resolves Dependabot #66)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -53,7 +53,6 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
     "socket.io": "^4.7.0",
-    "uuid": "^9.0.0",
     "web-push": "^3.6.7"
   },
   "devDependencies": {
@@ -66,7 +65,6 @@
     "@types/node": "^22.0.0",
     "@types/nodemailer": "^7.0.9",
     "@types/passport-jwt": "^4.0.0",
-    "@types/uuid": "^9",
     "@types/web-push": "^3.6.4",
     "@vitest/coverage-v8": "^2",
     "typescript": "^5.7.0",

--- a/apps/api/src/modules/bulk/bulk.service.ts
+++ b/apps/api/src/modules/bulk/bulk.service.ts
@@ -5,7 +5,7 @@ import { Injectable, Logger, NotFoundException, BadRequestException, HttpExcepti
 import { SendBulkDto, BulkBatchStatus, BulkMessageType, BulkMessageContent } from './dto';
 import { EngineManagerService } from '../profiles/engine-manager.service';
 import { MessagesService } from '../messages/messages.service';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID as uuidv4 } from 'node:crypto';
 
 @Injectable()
 export class BulkService {

--- a/apps/api/src/modules/uploads/uploads.service.ts
+++ b/apps/api/src/modules/uploads/uploads.service.ts
@@ -2,7 +2,7 @@
 // apps/api/src/modules/uploads/uploads.service.ts
 
 import { Injectable, Inject, Logger } from '@nestjs/common';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { STORAGE_ADAPTER, type IStorageAdapter } from './storage.interface';
 
 @Injectable()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,9 +268,6 @@ importers:
       socket.io:
         specifier: ^4.7.0
         version: 4.8.3
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
@@ -302,9 +299,6 @@ importers:
       '@types/passport-jwt':
         specifier: ^4.0.0
         version: 4.0.1
-      '@types/uuid':
-        specifier: ^9
-        version: 9.0.8
       '@types/web-push':
         specifier: ^3.6.4
         version: 3.6.4
@@ -2982,9 +2976,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -7740,11 +7731,6 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   v8flags@3.2.0:
     resolution: {integrity: sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==}
     engines: {node: '>= 0.10'}
@@ -10914,8 +10900,6 @@ snapshots:
       '@types/send': 0.17.6
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/validator@13.15.10': {}
 
@@ -16328,8 +16312,6 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   v8flags@3.2.0:
     dependencies:


### PR DESCRIPTION
## Why

Dependabot **#66** bumps `uuid` 9 → 14, which is **ESM-only** and breaks the CommonJS API build (uuid's own deprecation notice: *"For CommonJS codebases, use uuid@11"*). That PR's CI is red for exactly this reason.

Rather than fight the ESM/CJS interop or pin to an already-deprecated version, **remove the dependency**: both call sites only need a v4 UUID, and the Node built-in **`crypto.randomUUID()`** provides one — the codebase already uses it (e.g. `auth.service`).

## What
- `uploads.service.ts` / `bulk.service.ts`: `import { v4 as … } from 'uuid'` → `import { randomUUID as … } from 'node:crypto'` (aliased, so the call sites are unchanged).
- Removed `uuid` + `@types/uuid` from `apps/api/package.json` and the lockfile — **contained diff** (only those two entries; the remaining `uuid@8/10` are unrelated transitive deps of ffmpeg/etc.).

## Result
One fewer runtime dependency, no ESM/CJS footgun, and **Dependabot #66 can be closed** (nothing left to bump). typecheck clean.