### PR TITLE
refactor(engine): extract shared ack update into one tested helper (lock the #73 fix)

### DIFF
--- a/apps/api/src/modules/messages/ack-status.spec.ts
+++ b/apps/api/src/modules/messages/ack-status.spec.ts
@@ -1,0 +1,46 @@
+// Regression test for the shared ack update — locks the production fix: an ack
+// with no resolvable id must NEVER reach updateMany (which would become WHERE 1=1
+// and rewrite every message's status + deadlock). Prisma is mocked (no DB).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => ({
+  prisma: {
+    message: { findFirst: vi.fn(), updateMany: vi.fn() },
+  },
+}));
+
+import { prisma } from '@multiwa/database';
+import { applyAckStatusUpdate } from '@multiwa/engine-runtime';
+
+describe('applyAckStatusUpdate', () => {
+  beforeEach(() => {
+    vi.mocked(prisma.message.findFirst).mockReset();
+    vi.mocked(prisma.message.updateMany).mockReset();
+  });
+
+  it('returns null and touches NO rows when the ack id is undefined (never WHERE 1=1)', async () => {
+    const result = await applyAckStatusUpdate(undefined, 'delivered');
+    expect(result).toBeNull();
+    expect(prisma.message.findFirst).not.toHaveBeenCalled();
+    expect(prisma.message.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an empty-string id (also guarded)', async () => {
+    expect(await applyAckStatusUpdate('', 'read')).toBeNull();
+    expect(prisma.message.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('updates by the exact messageId and returns prior + count', async () => {
+    vi.mocked(prisma.message.findFirst).mockResolvedValueOnce({ status: 'sent', lane: 'cold' } as any);
+    vi.mocked(prisma.message.updateMany).mockResolvedValueOnce({ count: 1 } as any);
+
+    const result = await applyAckStatusUpdate('WA_MSG_123', 'delivered');
+
+    expect(prisma.message.updateMany).toHaveBeenCalledWith({
+      where: { messageId: 'WA_MSG_123' },
+      data: { status: 'delivered' },
+    });
+    expect(result).toEqual({ prior: { status: 'sent', lane: 'cold' }, count: 1 });
+  });
+});

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -1163,33 +1163,18 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
         }
       },
       onMessageAck: async (messageId: string, status: string) => {
-        // Guard an unresolvable ack id: Prisma treats `where: { messageId: undefined }`
-        // as NO filter, so updateMany degrades to `WHERE 1=1` and would rewrite EVERY
-        // message's status — table-wide corruption + a full-table lock that deadlocks
-        // against concurrent acks. Skip when the id is absent/empty.
-        if (!messageId) {
-          this.logger.warn(`[ACK] Ignoring ack with no message id (status: ${status})`);
-          return;
-        }
-        this.logger.log(`[ACK] Message ${messageId} → status: ${status}`);
         try {
-          // The engine adapter already maps numeric ack to string status
-          // (pending, sent, delivered, read, played)
-          // No need for double-mapping
-          
-          // Read prior state before updating so we can fire the cold-circuit eval on
-          // the FIRST terminal transition only (a message emits delivered→read→played).
-          const prior = await prisma.message.findFirst({
-            where: { messageId },
-            select: { status: true, lane: true },
-          });
-
-          const updated = await prisma.message.updateMany({
-            where: { messageId },
-            data: { status },
-          });
-
-          this.logger.log(`[ACK] Updated ${updated.count} message(s) for ${messageId} → ${status}`);
+          // Shared, guarded ack update: a null result means the ack had no resolvable
+          // id and was skipped. The guard lives in applyAckStatusUpdate so both
+          // engine-manager forks share ONE implementation (an absent id would otherwise
+          // degrade updateMany to WHERE 1=1 and rewrite every message + deadlock).
+          const ack = await applyAckStatusUpdate(messageId, status);
+          if (!ack) {
+            this.logger.warn(`[ACK] Ignoring ack with no message id (status: ${status})`);
+            return;
+          }
+          const { prior, count } = ack;
+          this.logger.log(`[ACK] Message ${messageId} → status: ${status} (updated ${count})`);
 
           // Emit WebSocket event for real-time UI updates
           this.realtime.emitMessageAck(profileId, messageId, status);

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -1082,33 +1082,18 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
         }
       },
       onMessageAck: async (messageId: string, status: string) => {
-        // Guard an unresolvable ack id: Prisma treats `where: { messageId: undefined }`
-        // as NO filter, so updateMany degrades to `WHERE 1=1` and would rewrite EVERY
-        // message's status — table-wide corruption + a full-table lock that deadlocks
-        // against concurrent acks. Skip when the id is absent/empty.
-        if (!messageId) {
-          this.logger.warn(`[ACK] Ignoring ack with no message id (status: ${status})`);
-          return;
-        }
-        this.logger.log(`[ACK] Message ${messageId} → status: ${status}`);
         try {
-          // The engine adapter already maps numeric ack to string status
-          // (pending, sent, delivered, read, played)
-          // No need for double-mapping
-          
-          // Read prior state before updating so the cold-circuit eval fires only on
-          // the FIRST terminal transition (a message emits delivered→read→played).
-          const prior = await prisma.message.findFirst({
-            where: { messageId },
-            select: { status: true, lane: true },
-          });
-
-          const updated = await prisma.message.updateMany({
-            where: { messageId },
-            data: { status },
-          });
-
-          this.logger.log(`[ACK] Updated ${updated.count} message(s) for ${messageId} → ${status}`);
+          // Shared, guarded ack update: a null result means the ack had no resolvable
+          // id and was skipped. The guard lives in applyAckStatusUpdate so both
+          // engine-manager forks share ONE implementation (an absent id would otherwise
+          // degrade updateMany to WHERE 1=1 and rewrite every message + deadlock).
+          const ack = await applyAckStatusUpdate(messageId, status);
+          if (!ack) {
+            this.logger.warn(`[ACK] Ignoring ack with no message id (status: ${status})`);
+            return;
+          }
+          const { prior, count } = ack;
+          this.logger.log(`[ACK] Message ${messageId} → status: ${status} (updated ${count})`);
 
           // Emit WebSocket event for real-time UI updates
           this.realtime.emitMessageAck(profileId, messageId, status);

--- a/packages/engine-runtime/src/ack-status.ts
+++ b/packages/engine-runtime/src/ack-status.ts
@@ -1,0 +1,54 @@
+// MultiWA Gateway - Shared WhatsApp delivery-ack status update
+// packages/engine-runtime/src/ack-status.ts
+//
+// Single implementation of the ack DB mutation, shared by the api and worker
+// engine-manager forks (which otherwise carry an identical ~1300-line copy and
+// drift). The guard here is load-bearing — see below.
+
+import { prisma } from '@multiwa/database';
+
+export interface AckPriorState {
+  status: string;
+  lane: string | null;
+}
+
+export interface AckUpdateResult {
+  /** The message's status/lane BEFORE this ack (for first-terminal-transition logic). */
+  prior: AckPriorState | null;
+  /** How many message rows this ack updated. */
+  count: number;
+}
+
+/**
+ * Apply a WhatsApp delivery ack (`delivered`/`read`/`played`/…) to the messages
+ * table, keyed by the engine's WhatsApp message id.
+ *
+ * Returns `null` when the ack has NO resolvable id — callers MUST treat that as
+ * "skip". This guard is critical: `prisma.message.updateMany({ where: { messageId:
+ * undefined } })` is treated by Prisma as an EMPTY filter (`WHERE 1=1`) and would
+ * rewrite EVERY message's status — silent corruption plus table-wide lock
+ * contention that deadlocks against concurrent acks (the production incident this
+ * helper was extracted to lock down).
+ */
+export async function applyAckStatusUpdate(
+  messageId: string | undefined | null,
+  status: string,
+): Promise<AckUpdateResult | null> {
+  if (!messageId) {
+    return null;
+  }
+
+  // Read prior state before updating so the caller can fire cold-circuit / terminal
+  // logic only on the FIRST terminal transition (a message emits delivered→read→played).
+  const prior = await prisma.message.findFirst({
+    where: { messageId },
+    select: { status: true, lane: true },
+  });
+
+  const { count } = await prisma.message.updateMany({
+    where: { messageId },
+    data: { status },
+  });
+
+  return { prior, count };
+}

--- a/packages/engine-runtime/src/index.ts
+++ b/packages/engine-runtime/src/index.ts
@@ -10,3 +10,4 @@ export * from './send-gate.service';
 export * from './webhook-safety';
 export * from './email.service';
 export * from './push.service';
+export * from './ack-status';


### PR DESCRIPTION
## Why

The #73 `WHERE 1=1` deadlock/corruption fix had to be applied to **both** the api and worker `engine-manager` forks — the ~1300-line duplicated copies the audit flagged. A load-bearing guard living in two hand-synced places is exactly the drift risk that finding warns about. This makes it **one shared, tested implementation** — the disciplined follow-up to #73 and the first concrete step of the engine-manager de-duplication.

## What

- **New `applyAckStatusUpdate(messageId, status)`** in `packages/engine-runtime` (whose index literally says *"a single implementation rather than per-app copies; services relocate here incrementally"*). It carries the guard: an absent id returns `null` so `updateMany` is **never reached** — the mass-update / deadlock cannot recur.
- **Both engine-manager forks** now call the helper and branch on `null`; the fork-specific realtime / event-bus / cold-circuit logic is **unchanged** (uses the returned `prior`). Behavior-preserving — net −14 lines per fork.
- **New regression test** (`ack-status.spec.ts`): the undefined-id case asserts `findFirst` + `updateMany` are **never called**, so the production bug is locked out of both forks at once.

## Verified
`engine-runtime` builds · api + worker typecheck clean · 18 unit specs green (incl. the 3 new). CI validates the ack path end-to-end via e2e.

Behavior-preserving relocation of already-deployed logic — low risk. Not urgent to deploy (the #73 fix is already live on wagw); this just ensures it can't drift.