### PR TITLE
fix(security): resolve the real CodeQL critical/high findings (SSRF, XSS, type-confusion, weak randomness, ReDoS)

### DIFF
--- a/apps/admin/src/app/dashboard/chat/page.tsx
+++ b/apps/admin/src/app/dashboard/chat/page.tsx
@@ -73,7 +73,18 @@ const formatPhone = (phone: string) => {
 const fixMediaUrl = (url?: string): string => {
   if (!url) return '';
   // Replace Docker-internal minio hostname with localhost
-  return url.replace(/http:\/\/minio:9000/g, 'http://localhost:9000');
+  const normalized = url.replace(/http:\/\/minio:9000/g, 'http://localhost:9000');
+  // Allowlist http/https only: message content.url is user-controlled, so a
+  // `javascript:`/`data:`/`vbscript:` URL rendered into an <a href> (document
+  // links / window.open) would be stored XSS in the admin origin. Reject anything
+  // else. A relative path resolves against the base and stays same-origin.
+  try {
+    const p = new URL(normalized, 'http://localhost');
+    if (p.protocol !== 'http:' && p.protocol !== 'https:') return '';
+  } catch {
+    return '';
+  }
+  return normalized;
 };
 
 // Check if a name looks like a raw JID (e.g. "120363421805328930@g.us" or "6282283011108@s.whatsapp.net" or all digits)

--- a/apps/api/src/modules/automation/rule-engine.service.ts
+++ b/apps/api/src/modules/automation/rule-engine.service.ts
@@ -3,6 +3,7 @@
 
 import { Injectable, Inject, forwardRef, Logger } from '@nestjs/common';
 import { prisma } from '@multiwa/database';
+import { assertWebhookUrlSafe } from '@multiwa/engine-runtime';
 import { AutomationService } from './automation.service';
 import { MessagesService } from '../messages/messages.service';
 import { AIService } from '../ai/ai.service';
@@ -602,12 +603,17 @@ export class RuleEngineService {
     }
   }
 
-  // Call external webhook
+  // Call external webhook. The URL comes from an attacker-controllable automation
+  // action, so it MUST pass the SSRF guard (blocks cloud metadata + private ranges,
+  // DNS-resolved) and use redirect:error + a timeout — same as autoreply/webhooks.
   private async callWebhook(url: string, method: string, data: any): Promise<any> {
-    const response = await fetch(url, {
+    const safeUrl = await assertWebhookUrlSafe(url);
+    const response = await fetch(safeUrl, {
       method: method || 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
+      redirect: 'error',
+      signal: AbortSignal.timeout(30000),
     });
 
     return {

--- a/apps/api/src/modules/contacts/contacts.service.ts
+++ b/apps/api/src/modules/contacts/contacts.service.ts
@@ -326,7 +326,11 @@ export class ContactsService {
   // Add tags to contact
   async addTags(id: string, tags: string[]) {
     const contact = await this.findOne(id);
-    const newTags = [...new Set([...contact.tags, ...tags])];
+    // `tags` reaches here untyped (@Body('tags') skips the ValidationPipe for the
+    // native Array metatype). Coerce to string[] so a non-array (e.g. { tags: 5 })
+    // can't throw on spread or corrupt data on a string's substring semantics.
+    const addList = (Array.isArray(tags) ? tags : []).filter((t): t is string => typeof t === 'string');
+    const newTags = [...new Set([...contact.tags, ...addList])];
     
     return prisma.contact.update({
       where: { id },
@@ -337,7 +341,11 @@ export class ContactsService {
   // Remove tags from contact
   async removeTags(id: string, tagsToRemove: string[]) {
     const contact = await this.findOne(id);
-    const newTags = contact.tags.filter((t) => !tagsToRemove.includes(t));
+    // Coerce to string[] (see addTags): a non-array/string `tagsToRemove` would
+    // otherwise throw (500) or run String.includes substring matching and delete
+    // unintended tags.
+    const removeList = (Array.isArray(tagsToRemove) ? tagsToRemove : []).filter((t): t is string => typeof t === 'string');
+    const newTags = contact.tags.filter((t) => !removeList.includes(t));
     
     return prisma.contact.update({
       where: { id },

--- a/apps/api/src/modules/organizations/organizations.service.ts
+++ b/apps/api/src/modules/organizations/organizations.service.ts
@@ -2,6 +2,7 @@
 import { Injectable, NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
 import { prisma } from '@multiwa/database';
 import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
 
 // Roles that may be assigned through member-management endpoints. `owner` is
 // deliberately excluded: ownership is set when the org is created and is not
@@ -62,8 +63,10 @@ export class OrganizationsService {
       throw new BadRequestException('A user with this email already exists');
     }
 
-    // Create member with a temporary password
-    const tempPassword = Math.random().toString(36).slice(-10);
+    // Create member with a temporary password. Must be cryptographically random:
+    // Math.random() is a predictable PRNG, so a temp LOGIN password minted with it
+    // is guessable -> account takeover before first login.
+    const tempPassword = crypto.randomBytes(12).toString('base64url');
     const passwordHash = await bcrypt.hash(tempPassword, 10);
 
     const user = await prisma.user.create({

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -580,6 +580,13 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
    * Initialize and connect a WhatsApp engine for a profile
    */
   async connectProfile(profileId: string): Promise<{ status: string; message: string }> {
+    // Defense-in-depth: profileId is server-generated (uuid) and the DB lookup below
+    // already rejects unknown ids, but validate the shape up front so it can NEVER
+    // reach the SESSIONS_DIR/<profileId> filesystem paths (path traversal) even if a
+    // future caller skips the lookup.
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(profileId)) {
+      throw new Error('Invalid profileId');
+    }
     this.logger.log(`Connecting profile: ${profileId}`);
     // A (re)connect clears any "manually disconnected" marker so the reconnect
     // sweep watches this profile again.

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -42,8 +42,18 @@ export interface MultiWAClientOptions {
  *     => 'http://localhost:3333/api/v1/messages/text'
  */
 export function joinApiUrl(baseUrl: string, path: string): string {
-  const base = String(baseUrl || '').replace(/\/+$/, '');
-  const rel = String(path || '').replace(/^\/+/, '');
+  // Linear, backtracking-free slash trimming. The previous `/\/+$/` was O(n^2)
+  // (polynomial ReDoS) on a long run of leading slashes; char-scanning is O(n).
+  const b = String(baseUrl || '');
+  let end = b.length;
+  while (end > 0 && b.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  const base = b.slice(0, end);
+
+  const p = String(path || '');
+  let start = 0;
+  while (start < p.length && p.charCodeAt(start) === 47) start++;
+  const rel = p.slice(start);
+
   return rel.length ? `${base}/${rel}` : base;
 }
 


### PR DESCRIPTION
## Why

The CodeQL scanning added in #57 surfaced **40 alerts**. A 5-agent triage verified each against the actual code (real vs false-positive). This fixes the **genuinely exploitable** ones and documents the rest.

## 🔴 Real — fixed
| Sev | Finding | Fix |
|---|---|---|
| critical | **SSRF** — automation `rule-engine.callWebhook()` fetched an attacker-controlled `action.url` with no guard (→ cloud metadata / internal services + response oracle) | route through the existing `assertWebhookUrlSafe` + `redirect:'error'` + 30s timeout |
| critical | **Type confusion** — contacts `addTags`/`removeTags` took `@Body('tags')` (bypasses ValidationPipe for native Array): `{tags:5}`→500, `{tags:"vip"}`→substring-delete | coerce to `string[]` in both |
| high | **Insecure randomness** — a new org member's temporary **login** password used `Math.random()` (predictable → account takeover before first login) | `crypto.randomBytes(12).toString('base64url')` |
| high | **Stored XSS** — admin chat rendered user-controlled `content.url` into `<a href>`/`window.open`; a `javascript:` url executes in the admin origin | `fixMediaUrl` now allowlists `http`/`https` only (single chokepoint) |
| high | **ReDoS** — SDK `joinApiUrl` used polynomial `/\/+$/` | linear char-scan (behavior-identical — `url.test.ts` 9/9) |

**Defense-in-depth:** `connectProfile` validates `profileId` is a uuid up front so it can never reach the `SESSIONS_DIR/<id>` fs paths (clears 3 path-injection alerts already blocked by the DB existence check).

## ⚪ False-positives (no code change — dismiss in UI / clears on re-scan)
- **autoreply SSRF** (`:197`/`:301`) — already guarded by `assertWebhookUrlSafe`; CodeQL doesn't model the custom sanitizer.
- **api-key / session SHA-256 "weak hash"** — correct for **high-entropy random tokens** (256-bit `mwa_` keys); bcrypt would break the O(1) indexed lookup and is meant for low-entropy human passwords (GitHub PAT / Stripe pattern).
- **media `<video>`/`<img>` src + google-maps href XSS** — browsers don't execute `javascript:` in those sinks / the scheme is hard-coded (`fixMediaUrl` covers them anyway).
- **contacts CSV loop-bound** — linear parse, body-size-capped.
- **webhook-receiver sample log-injection** — accept-risk (non-production dev tool).

## Verified
api typecheck clean · sdk build + tests green (17/17, `joinApiUrl` behavior preserved) · admin typecheck clean.

## Follow-up
Register `assertWebhookUrlSafe` as a CodeQL sanitizer (a custom qlpack model) so the autoreply SSRF alerts auto-clear; optional `@IsUrl` on the media send DTOs as a second XSS layer; optional HMAC-pepper on token hashes (needs a keyHash migration).