### PR TITLE
build(deps): pin git deps to HTTPS tarballs + CI lockfile guard (kills the Dependabot SSH-rewrite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,17 @@ jobs:
   lint-and-build:
     name: Lint, Typecheck & Build
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v7
+
+      - name: Guard — lockfile must resolve git deps over HTTPS (no SSH)
+        run: |
+          if grep -nE 'git@github\.com:|ssh://git@github\.com' pnpm-lock.yaml; then
+            echo "::error::pnpm-lock.yaml contains SSH git URLs. Dependabot's environment rewrites the transitive git deps (libsignal, @whiskeysockets/eslint-config) to git@github.com:, which breaks 'pnpm install --frozen-lockfile' and the air-gapped Docker image build. Fix: regenerate the lockfile with 'pnpm install' (the pnpm.overrides in package.json pin the HTTPS codeload tarballs) on a host without a git url.insteadOf rewrite, then commit."
+            exit 1
+          fi
+          echo "OK: no SSH git URLs in pnpm-lock.yaml"
 
       - uses: pnpm/action-setup@v6
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,11 @@
     "@types/qrcode": "^1.5.6",
     "otplib": "^13.4.1",
     "qrcode": "^1.5.4"
+  },
+  "pnpm": {
+    "overrides": {
+      "@whiskeysockets/eslint-config": "https://codeload.github.com/whiskeysockets/eslint-config/tar.gz/299e8389baf62f9aa3034de18ff0d62cc0a5e838",
+      "libsignal": "https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@whiskeysockets/eslint-config': https://codeload.github.com/whiskeysockets/eslint-config/tar.gz/299e8389baf62f9aa3034de18ff0d62cc0a5e838
+  libsignal: https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
+
 importers:
 
   .:


### PR DESCRIPTION
## Problem

The #63/#65/#77/#78 Dependabot triage found one **systemic** blocker across all four PRs: Dependabot's environment rewrites the two **transitive git dependencies** — `@whiskeysockets/eslint-config` and the **runtime-critical `libsignal`** (Baileys' Signal-protocol crypto) — from their `https://codeload.github.com/...` tarballs to `git@github.com:` **SSH** URLs when it regenerates `pnpm-lock.yaml`.

That breaks `pnpm install --frozen-lockfile` in CI (`Permission denied (publickey)`) and would **brick the offline Docker image build** shipped to the air-gapped PLN server. It recurs on every Dependabot PR that touches the lockfile.

## Fix — two layers

**1. Prevention (`pnpm.overrides`)** — the root `package.json` now pins both packages to their exact HTTPS codeload tarball URLs:

```json
"pnpm": {
  "overrides": {
    "@whiskeysockets/eslint-config": "https://codeload.github.com/whiskeysockets/eslint-config/tar.gz/299e8389…",
    "libsignal": "https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df…"
  }
}
```

The override value is a **direct tarball URL, not a git ref**, so no `git url.insteadOf` rewrite can touch it — pnpm resolves HTTPS even inside Dependabot's environment. The lockfile diff is **4 lines** (the `overrides:` block); the resolved dependency tree is byte-identical (same pinned commits main already used).

**2. Detection (CI guard)** — a fast step in the *Lint, Typecheck & Build* job fails with a clear remediation message if `pnpm-lock.yaml` ever contains an SSH git URL again, instead of the cryptic publickey install error.

## Validation (local)

- ✅ `pnpm install --frozen-lockfile` (pnpm@9.15.0) passes
- ✅ 0 `git@github.com:` SSH URLs; git deps stay on the pinned HTTPS commits
- ✅ Guard trips on a simulated SSH url (exit 1) and passes on the real lockfile
- ✅ `ci.yml` valid YAML, `package.json` valid JSON

## Note on maintenance

The overrides pin exact commits. When `@whiskeysockets/baileys` is bumped deliberately and needs a newer `libsignal`, update the override URL to the new commit in the same PR. Until then this keeps every future Dependabot lockfile regeneration HTTPS-clean.