### PR TITLE
fix(auth): align messages API-key scope with admin UI convention (fixes silent send-403)

### DIFF
--- a/apps/api/src/modules/messages/messages-scope.spec.ts
+++ b/apps/api/src/modules/messages/messages-scope.spec.ts
@@ -1,0 +1,35 @@
+// Regression guard for the 2026-07-20 production incident: the admin UI stores
+// `messages:write` for "Send Messages" (and `messages:read` for "Read Messages"),
+// but the MessagesController's @RequireScope had been set to the singular
+// `message:send` / `message:read`. The mismatch made EVERY UI-issued API key fail
+// to send with 403. This test locks the controller's scope strings to the exact
+// values the admin UI issues, so any future drift fails CI instead of production.
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+import { API_KEY_SCOPE } from '../auth/decorators/require-scope.decorator';
+import { MessagesController } from './messages.controller';
+
+// Must match apps/admin/src/app/dashboard/api-keys/page.tsx PERMISSIONS values.
+const UI_SEND_SCOPE = 'messages:write';
+const UI_READ_SCOPE = 'messages:read';
+
+describe('MessagesController API-key scopes match the admin UI convention', () => {
+  it('class-level (send) scope is the UI "Send Messages" value', () => {
+    const scopes = Reflect.getMetadata(API_KEY_SCOPE, MessagesController);
+    expect(scopes).toEqual([UI_SEND_SCOPE]);
+  });
+
+  it('every read (GET) route override uses the UI "Read Messages" value, never a singular string', () => {
+    const proto = MessagesController.prototype as unknown as Record<string, unknown>;
+    const overrides = Object.getOwnPropertyNames(proto)
+      .filter((name) => name !== 'constructor' && typeof proto[name] === 'function')
+      .map((name) => Reflect.getMetadata(API_KEY_SCOPE, proto[name] as object))
+      .filter((meta): meta is string[] => Array.isArray(meta));
+
+    // At least one route overrides the class default to read.
+    expect(overrides.length).toBeGreaterThan(0);
+    for (const scopes of overrides) {
+      expect(scopes).toEqual([UI_READ_SCOPE]);
+    }
+  });
+});

--- a/apps/api/src/modules/messages/messages.controller.ts
+++ b/apps/api/src/modules/messages/messages.controller.ts
@@ -45,10 +45,13 @@ const ApiSend = (summary: string, description?: string) =>
 @Controller('messages')
 // ApiKeyScopeGuard runs between auth and tenant: a cheap in-memory capability
 // check before the per-resource tenant DB lookup. Class default requires the
-// `message:send` scope; the read (GET) routes below override it to `message:read`.
+// `messages:write` scope; the read (GET) routes below override it to `messages:read`.
+// These strings MUST match the values the admin UI stores (api-keys page:
+// `messages:write` = "Send Messages", `messages:read` = "Read Messages") — a
+// mismatch (e.g. `message:send`) makes every UI-issued key fail send with 403.
 // No-op for JWT logins and for API keys with no scopes / a `*` wildcard.
 @UseGuards(JwtOrApiKeyGuard, ApiKeyScopeGuard, TenantGuard)
-@RequireScope('message:send')
+@RequireScope('messages:write')
 @ApiBearerAuth()
 @ApiSecurity('api-key')
 @ApiAuthErrors()
@@ -211,7 +214,7 @@ export class MessagesController {
   }
 
   @Get('schedule/:profileId')
-  @RequireScope('message:read')
+  @RequireScope('messages:read')
   @RequireTenant({ from: 'param', key: 'profileId', resource: 'profile' })
   @ApiOperation({ summary: 'Get scheduled messages by profile' })
   @ApiQuery({ name: 'status', required: false, enum: ['pending', 'sent', 'failed', 'cancelled'] })
@@ -231,7 +234,7 @@ export class MessagesController {
 
   // Get messages by profile
   @Get('profile/:profileId')
-  @RequireScope('message:read')
+  @RequireScope('messages:read')
   @RequireTenant({ from: 'param', key: 'profileId', resource: 'profile' })
   @ApiOperation({ summary: 'Get messages by profile' })
   @ApiQuery({ name: 'limit', required: false })
@@ -250,7 +253,7 @@ export class MessagesController {
 
   // Get messages by conversation
   @Get('conversation/:conversationId')
-  @RequireScope('message:read')
+  @RequireScope('messages:read')
   @RequireTenant({ from: 'param', key: 'conversationId', resource: 'conversation' })
   @ApiOperation({ summary: 'Get messages by conversation' })
   @ApiQuery({ name: 'limit', required: false })
@@ -266,7 +269,7 @@ export class MessagesController {
   // Load older messages on-demand: pulls deeper history from WhatsApp, persists it,
   // and returns the refreshed page. Profile must be connected.
   @Get('conversation/:conversationId/load-older')
-  @RequireScope('message:read')
+  @RequireScope('messages:read')
   @RequireTenant({ from: 'param', key: 'conversationId', resource: 'conversation' })
   @ApiOperation({ summary: 'Fetch older messages for a conversation from WhatsApp and persist them' })
   @ApiQuery({ name: 'limit', required: false, description: 'Total most-recent messages to pull (default 100, max 500)' })
@@ -279,7 +282,7 @@ export class MessagesController {
 
   // Get single message
   @Get(':id')
-  @RequireScope('message:read')
+  @RequireScope('messages:read')
   @RequireTenant({ from: 'param', key: 'id', resource: 'message' })
   @ApiOperation({ summary: 'Get message by ID' })
   @ApiNotFound('Message')


### PR DESCRIPTION
## Incident

**wagw, 2026-07-20:** every UI-issued API key (VirA bot + all integrations) failed to send with `403 "API key missing required scope(s): message:send"`, so the bot stopped replying even though incoming + webhook delivery worked.

## Root cause — scope-string mismatch

| Where | String |
|-------|--------|
| Admin UI "Send Messages" ([api-keys page](apps/admin/src/app/dashboard/api-keys/page.tsx#L65)) stores | `messages:write` |
| Admin UI "Read Messages" stores | `messages:read` |
| `MessagesController` `@RequireScope` required | `message:send` / `message:read` (singular) |

`ApiKeyScopeGuard` only lets a key through when it carries one of the required scopes (unless the key's permission list is empty or `*`). Every key carries `messages:write` (from the UI), which never equals `message:send` → **403 on every send**. GETs kept working only because the bots read via the Conversations/Contacts controllers, which don't gate on these scopes.

## Fix

Change the six `@RequireScope` strings on `MessagesController` to the exact values the admin UI issues:
- class default (send): `message:send` → **`messages:write`**
- 5 GET routes: `message:read` → **`messages:read`**

No data migration needed — every existing key already carries `messages:write` / `messages:read`.

Adds `messages-scope.spec.ts`, which reads the `@RequireScope` metadata off the controller and locks it to the UI convention, so any future guard/UI drift fails CI instead of silently breaking production sends.

## Validation

- ✅ api typecheck + build; new regression test passes (2/2)
- ✅ All six scope strings confirmed aligned

## Ops note

wagw was **hotfixed live** (appended `message:send`/`message:read` to all 11 keys' `permissions`) to restore sending immediately — confirmed working (VirA replies flowing). This PR makes the code correct so UI-issued keys work **without** that hotfix once the api image is redeployed (rides along with the pending Prisma 7 deploy).