### PR TITLE
fix(quality): clear the 24 remaining CodeQL code-quality alerts (→ 0 open)

### DIFF
--- a/apps/admin/src/app/auth/login/page.tsx
+++ b/apps/admin/src/app/auth/login/page.tsx
@@ -6,7 +6,6 @@
 import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import {
   Check,
   ShieldCheck,
@@ -16,7 +15,6 @@ import {
 } from 'lucide-react';
 
 export default function LoginPage() {
-  const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 

--- a/apps/admin/src/app/dashboard/automation/builder/page.tsx
+++ b/apps/admin/src/app/dashboard/automation/builder/page.tsx
@@ -239,7 +239,7 @@ function convertFlowToAutomations(nodes: any[], edges: any[], profileId: string)
 
 export default function AutomationBuilderPage() {
   const router = useRouter();
-  const [saving, setSaving] = useState(false);
+  const [, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'draft' | 'saved' | 'error'>('idle');
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [selectedProfile, setSelectedProfile] = useState<string>('');

--- a/apps/admin/src/app/dashboard/chat/page.tsx
+++ b/apps/admin/src/app/dashboard/chat/page.tsx
@@ -35,8 +35,6 @@ import {
   Link as LinkIcon,
   Search,
   MoreVertical,
-  Info,
-  Sticker,
   Bell,
   BellOff,
   Trash2,
@@ -160,7 +158,6 @@ export default function ChatPage() {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const attachRef = useRef<HTMLInputElement>(null);
-  const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastTypingSentRef = useRef<number>(0);
   const socketRef = useRef<Socket | null>(null);
 
@@ -782,13 +779,11 @@ export default function ChatPage() {
               >
                 <ArrowLeft className="w-5 h-5" aria-hidden="true" />
               </button>
-              {selectedConversation && (
-                <div className="flex-1 min-w-0">
-                  <div className="font-medium text-foreground truncate">
-                    {getDisplayName(selectedConversation)}
-                  </div>
+              <div className="flex-1 min-w-0">
+                <div className="font-medium text-foreground truncate">
+                  {getDisplayName(selectedConversation)}
                 </div>
-              )}
+              </div>
             </div>
             {/* Chat Header */}
             <div className="p-4 border-b border-border bg-secondary/30 flex items-center gap-4">

--- a/apps/admin/src/app/dashboard/messages/page.tsx
+++ b/apps/admin/src/app/dashboard/messages/page.tsx
@@ -21,7 +21,6 @@ import {
   FileUp,
   Search,
   Clock,
-  Calendar,
   Loader2,
   AlertCircle,
   CheckCircle2,
@@ -382,28 +381,6 @@ export default function MessagesPage() {
     }
   };
 
-  const buildContent = (url: string) => {
-    switch (messageType) {
-      case 'TEXT':
-        return { text: textContent };
-      case 'IMAGE':
-      case 'VIDEO':
-      case 'AUDIO':
-        return {
-          url,
-          caption: caption || undefined,
-        };
-      case 'DOCUMENT':
-        return {
-          url,
-          filename: fileName || 'document',
-          caption: caption || undefined,
-        };
-      default:
-        return { text: textContent };
-    }
-  };
-
   const sendMessage = async () => {
     if (!selectedProfile || !recipient) {
       setStatus('Please select profile and enter recipient');
@@ -480,8 +457,6 @@ export default function MessagesPage() {
         setStatus('Sending message...');
       }
 
-      const content = buildContent(finalUrl);
-      
       // Determine endpoint and body based on message type
       const typeEndpointMap: Record<string, string> = {
         TEXT: 'text',

--- a/apps/admin/src/app/dashboard/page.tsx
+++ b/apps/admin/src/app/dashboard/page.tsx
@@ -76,7 +76,6 @@ export default function DashboardPage() {
     fetchDataCb();
 
     const wsUrl = getSocketUrl();
-    const token = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
     const socket = io(`${wsUrl}/ws`, {
       transports: ['websocket', 'polling'],
       auth: (cb) => cb({ token: typeof window !== 'undefined' ? localStorage.getItem('accessToken') : undefined }),
@@ -240,7 +239,7 @@ export default function DashboardPage() {
         {loading ? (
           <ProfileGrid>
             {[1, 2, 3].map((i) => (
-              <ProfileCard key={i} id="" name="" status="offline" loading />
+              <ProfileCard key={i} id={`skeleton-${i}`} name="" status="offline" loading />
             ))}
           </ProfileGrid>
         ) : profiles.length > 0 ? (

--- a/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/profiles/[id]/page.tsx
@@ -36,7 +36,6 @@ import {
   MessageCircle,
   PlugZap,
   RefreshCw,
-  Power,
   Trash2,
   AlertTriangle,
   Smartphone,
@@ -108,14 +107,6 @@ const fmtPhone = (raw: string | null | undefined): string => {
   if (digits.length <= 8) return `${digits.slice(0, 4)} ${digits.slice(4)}`;
   return `+${digits.slice(0, 2)} ${digits.slice(2, 6)} ${digits.slice(6, 10)} ${digits.slice(10)}`.trim();
 };
-
-const ChipDot = ({ color }: { color: string }) => (
-  <span
-    aria-hidden
-    className="inline-block w-1.5 h-1.5 rounded-full"
-    style={{ background: color }}
-  />
-);
 
 function StatusBadge({ status }: { status: WireStatus }) {
   const s = (status || '').toLowerCase();

--- a/apps/admin/src/app/dashboard/profiles/new/page.tsx
+++ b/apps/admin/src/app/dashboard/profiles/new/page.tsx
@@ -24,7 +24,7 @@ export default function NewProfilePage() {
   const [engineType, setEngineType] = useState('whatsapp-web-js');
   const [loading, setLoading] = useState(false);
   const [qrCode, setQrCode] = useState<string | null>(null);
-  const [profileId, setProfileId] = useState<string | null>(null);
+  const [, setProfileId] = useState<string | null>(null);
   const [status, setStatus] = useState('Initializing...');
   const [showEngineCompare, setShowEngineCompare] = useState(false);
   const socketRef = useRef<Socket | null>(null);

--- a/apps/admin/src/app/dashboard/settings/page.tsx
+++ b/apps/admin/src/app/dashboard/settings/page.tsx
@@ -3,10 +3,9 @@
 
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import {
-  Plus,
   X,
   CheckCircle2,
   XCircle,
@@ -29,7 +28,6 @@ import {
   Folder,
   Cloud,
   ArrowRight,
-  Trash2,
   type LucideIcon,
 } from 'lucide-react';
 import { api, User, Profile } from '@/lib/api';
@@ -396,12 +394,6 @@ export default function SettingsPage() {
     } finally {
       setDeletingAccount(false);
     }
-  };
-
-  const copyApiKey = () => {
-    const token = localStorage.getItem('accessToken') || '';
-    navigator.clipboard.writeText(token);
-    toast({ title: 'API key copied to clipboard' });
   };
 
   const fetchMembers = async () => {

--- a/apps/admin/src/components/dashboard/MessageChart.tsx
+++ b/apps/admin/src/components/dashboard/MessageChart.tsx
@@ -3,7 +3,7 @@
 
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { formatWeekdayShort } from '@/lib/datetime';
 import {
   AreaChart,

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -85,7 +85,6 @@ function HomepageHeader() {
 }
 
 export default function Home(): ReactNode {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
       title="Open Source WhatsApp API Gateway"

--- a/packages/chatwoot-bridge/src/index.ts
+++ b/packages/chatwoot-bridge/src/index.ts
@@ -9,7 +9,7 @@
 import express from 'express';
 import axios, { AxiosInstance } from 'axios';
 
-const cleanLog = (v: unknown) => String(v ?? '').replace(/[\r\n\t\x00-\x1f\x7f]/g, ' ');
+const cleanLog = (v: unknown) => String(v ?? '').replace(/\p{Cc}/gu, ' ');
 
 // ─── Configuration ────────────────────────────────────────────────────────
 

--- a/packages/chatwoot-bridge/src/index.ts
+++ b/packages/chatwoot-bridge/src/index.ts
@@ -9,6 +9,8 @@
 import express from 'express';
 import axios, { AxiosInstance } from 'axios';
 
+const cleanLog = (v: unknown) => String(v ?? '').replace(/[\r\n\t\x00-\x1f\x7f]/g, ' ');
+
 // ─── Configuration ────────────────────────────────────────────────────────
 
 export interface ChatwootBridgeConfig {
@@ -113,7 +115,7 @@ export class ChatwootBridge {
       }
     );
 
-    console.log(`[Bridge] MultiWA → Chatwoot: ${phoneNumber} → Conv #${conversation.id}`);
+    console.log(`[Bridge] MultiWA → Chatwoot: ${cleanLog(phoneNumber)} → Conv #${conversation.id}`);
   }
 
   /**
@@ -142,7 +144,7 @@ export class ChatwootBridge {
       text: content,
     });
 
-    console.log(`[Bridge] Chatwoot → MultiWA: Conv #${conversation.id} → ${phone}`);
+    console.log(`[Bridge] Chatwoot → MultiWA: Conv #${conversation.id} → ${cleanLog(phone)}`);
   }
 
   private async findOrCreateChatwootContact(phone: string, name?: string) {

--- a/scripts/webhook-receiver.js
+++ b/scripts/webhook-receiver.js
@@ -28,7 +28,7 @@
 const http = require("http");
 const crypto = require("crypto");
 
-const cleanLog = (v) => String(v ?? "").replace(/[\r\n\t\x00-\x1f\x7f]/g, " ");
+const cleanLog = (v) => String(v ?? "").replace(/\p{Cc}/gu, " ");
 
 // === Configuration ===
 const PORT = parseInt(process.argv[2] || "9999", 10);

--- a/scripts/webhook-receiver.js
+++ b/scripts/webhook-receiver.js
@@ -28,6 +28,8 @@
 const http = require("http");
 const crypto = require("crypto");
 
+const cleanLog = (v) => String(v ?? "").replace(/[\r\n\t\x00-\x1f\x7f]/g, " ");
+
 // === Configuration ===
 const PORT = parseInt(process.argv[2] || "9999", 10);
 const SECRET = process.env.WEBHOOK_SECRET || "";
@@ -256,9 +258,9 @@ const server = http.createServer((req, res) => {
     // Headers
     const event = req.headers["x-multiwa-event"] || "unknown";
     const signature = req.headers["x-multiwa-signature"] || "";
-    console.log(`  Event:     ${event}`);
-    console.log(`  Path:      ${req.url}`);
-    console.log(`  Signature: ${signature || "(none)"}`);
+    console.log(`  Event:     ${cleanLog(event)}`);
+    console.log(`  Path:      ${cleanLog(req.url)}`);
+    console.log(`  Signature: ${cleanLog(signature) || "(none)"}`);
 
     // Verify HMAC if secret is available
     if (SECRET && signature) {
@@ -269,8 +271,8 @@ const server = http.createServer((req, res) => {
       const isValid = signature === expected;
       console.log(`  Verified:  ${isValid ? "✅ Valid" : "❌ Invalid"}`);
       if (!isValid) {
-        console.log(`    Expected: ${expected}`);
-        console.log(`    Got:      ${signature}`);
+        console.log(`    Expected: ${cleanLog(expected)}`);
+        console.log(`    Got:      ${cleanLog(signature)}`);
       }
     }
 
@@ -287,7 +289,7 @@ const server = http.createServer((req, res) => {
       );
     } catch (e) {
       console.log("\n  📦 Raw Body:");
-      console.log("    " + (body || "(empty)"));
+      console.log("    " + (cleanLog(body) || "(empty)"));
     }
 
     // Auto-reply: forward to Me&Me group


### PR DESCRIPTION
Follow-up to #80. The CodeQL tab had **36 open**; I re-triaged all of them:

- **12 verified false positives dismissed** (with per-alert justifications on GitHub): SSRF already guarded by `assertWebhookUrlSafe` + `redirect:'error'` (autoreply), SHA-256 hashing of **high-entropy API keys** (not passwords — standard practice), React `src` attributes routed through `fixMediaUrl` (allowlists http/https), a linear CSV-field loop bound, and DB-UUID-derived session paths.
- **24 genuine code-quality findings fixed here** → tab reaches **0 open** the right way.

## Changes
| Rule | Count | Fix |
|------|-------|-----|
| Log injection (medium) | 7 | `cleanLog` control-char stripper wraps user-controlled values in `scripts/webhook-receiver.js` + `packages/chatwoot-bridge` logs |
| Unused import/var/function (note) | 15 | remove dead code across admin + docs-site (also removes orphaned imports/functions so no new alert appears) |
| Useless conditional | 1 | drop redundant `selectedConversation &&` inside its already-truthy branch |
| Malformed id | 1 | loading skeletons `id=""` → `id={`skeleton-${i}`}` |

## Validation
- ✅ `pnpm --filter admin typecheck` + `build`
- ✅ `pnpm --filter @multiwa/chatwoot-bridge build`

Minimal diff (21 insertions, 68 deletions). No behaviour change.