### PR TITLE
fix(groups): DB fallback so the group picker never silently empties

### DIFF
--- a/apps/api/src/modules/groups/groups-getall.spec.ts
+++ b/apps/api/src/modules/groups/groups-getall.spec.ts
@@ -1,0 +1,61 @@
+// Regression test for the empty-group-list bug (2026-07-20): the messages-page
+// group picker went empty because GroupsService.getAll returned [] whenever the
+// live whatsapp-web.js getGroups threw ("Get groups error: r" — a WhatsApp Web
+// build whose group Store isn't hooked, even while send works). getAll now falls
+// back to the groups persisted from message history, so the picker stays usable.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => ({
+  prisma: { conversation: { findMany: vi.fn() } },
+}));
+// Keep the heavy engine adapters (puppeteer/whatsapp-web.js) out of this unit test.
+vi.mock('../profiles/engine-manager.service', () => ({ EngineManagerService: class {} }));
+vi.mock('../engine-commands/engine-commands.service', () => ({ EngineCommandsService: class {} }));
+vi.mock('../../common/engine-host', () => ({ isWorkerEngine: vi.fn(() => false) }));
+
+import { prisma } from '@multiwa/database';
+import { GroupsService } from './groups.service';
+
+function makeService(engine: any) {
+  const engineManager = { getEngine: vi.fn(() => engine) } as any;
+  const engineCommands = { groupOp: vi.fn() } as any;
+  return new GroupsService(engineManager, engineCommands);
+}
+
+describe('GroupsService.getAll — resilient group list', () => {
+  beforeEach(() => vi.mocked(prisma.conversation.findMany).mockReset());
+
+  it('returns live engine groups when available and never touches the DB', async () => {
+    const svc = makeService({
+      getGroups: vi.fn().mockResolvedValue([{ id: '1@g.us', name: 'Live Group', participantCount: 3 }]),
+    });
+    const out = await svc.getAll('p1');
+    expect(out).toEqual([expect.objectContaining({ id: '1@g.us', name: 'Live Group', participantsCount: 3 })]);
+    expect(prisma.conversation.findMany).not.toHaveBeenCalled();
+  });
+
+  it('falls back to stored group conversations when live getGroups throws', async () => {
+    const svc = makeService({ getGroups: vi.fn().mockRejectedValue(new Error('r')) });
+    vi.mocked(prisma.conversation.findMany).mockResolvedValue([
+      { jid: '120@g.us', name: 'Stored Group', type: 'group', createdAt: new Date() },
+    ] as any);
+
+    const out = await svc.getAll('p1');
+
+    expect(out).toEqual([expect.objectContaining({ id: '120@g.us', name: 'Stored Group' })]);
+    expect(prisma.conversation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ profileId: 'p1' }) }),
+    );
+  });
+
+  it('falls back to the DB when live returns an empty list, defaulting a null name', async () => {
+    const svc = makeService({ getGroups: vi.fn().mockResolvedValue([]) });
+    vi.mocked(prisma.conversation.findMany).mockResolvedValue([
+      { jid: 'g@g.us', name: null, type: 'group', createdAt: new Date() },
+    ] as any);
+
+    const out = await svc.getAll('p1');
+
+    expect(out[0].name).toBe('Group Chat');
+  });
+});

--- a/apps/api/src/modules/groups/groups.service.ts
+++ b/apps/api/src/modules/groups/groups.service.ts
@@ -13,6 +13,7 @@ import {
 import { EngineManagerService } from '../profiles/engine-manager.service';
 import { EngineCommandsService } from '../engine-commands/engine-commands.service';
 import { isWorkerEngine } from '../../common/engine-host';
+import { prisma } from '@multiwa/database';
 
 export interface GroupInfo {
   id: string;
@@ -45,39 +46,62 @@ export class GroupsService {
    * Get all groups for a profile
    */
   async getAll(profileId: string): Promise<GroupInfo[]> {
-    if (isWorkerEngine()) return this.engineCommands.groupOp(profileId, 'getAll', {});
+    // Try the live engine first (freshest membership counts), but never let a flaky
+    // engine call empty the group list: whatsapp-web.js getGroups can throw (e.g. a
+    // WhatsApp Web build whose group Store isn't hooked) while send still works. Fall
+    // back to the groups persisted from message history so the picker stays usable.
+    try {
+      const live = isWorkerEngine()
+        ? await this.engineCommands.groupOp(profileId, 'getAll', {})
+        : await this.getFromLiveEngine(profileId);
+      if (Array.isArray(live) && live.length > 0) return live;
+    } catch (error: any) {
+      this.logger.warn(`Live getGroups failed for ${profileId} (${error?.message}); using stored groups`);
+    }
+    return this.getGroupsFromDb(profileId);
+  }
+
+  private async getFromLiveEngine(profileId: string): Promise<GroupInfo[]> {
     const engine = this.engineManager.getEngine(profileId);
     if (!engine) {
-      // Return empty array if engine not connected (instead of throwing error)
-      this.logger.warn(`Profile ${profileId} not connected, returning empty groups`);
+      this.logger.warn(`Profile ${profileId} not connected; using stored groups`);
       return [];
     }
+    // Add timeout to prevent indefinite hang (30 seconds)
+    const timeoutMs = 30000;
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`getGroups timed out after ${timeoutMs}ms`)), timeoutMs)
+    );
+    const groups = await Promise.race([engine.getGroups(), timeoutPromise]);
+    this.logger.log(`Mapping ${groups.length} live groups for profile ${profileId}`);
+    return groups.map(g => ({
+      id: g.id,
+      name: g.name,
+      description: g.description || '',
+      owner: '',
+      createdAt: new Date(),
+      participantsCount: g.participantCount || g.participants?.length || 0,
+    }));
+  }
 
-    try {
-      // Add timeout to prevent indefinite hang (30 seconds)
-      const timeoutMs = 30000;
-      const groupsPromise = engine.getGroups();
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`getGroups timed out after ${timeoutMs}ms`)), timeoutMs)
-      );
-      
-      const groups = await Promise.race([groupsPromise, timeoutPromise]);
-      
-      this.logger.log(`Mapping ${groups.length} groups for profile ${profileId}`);
-      
-      return groups.map(g => ({
-        id: g.id,
-        name: g.name,
-        description: g.description || '',
-        owner: '',
-        createdAt: new Date(),
-        participantsCount: g.participantCount || g.participants?.length || 0,
-      }));
-    } catch (error: any) {
-      this.logger.error(`Failed to get groups for ${profileId}: ${error.message}`);
-      // Return empty array instead of throwing - engine may be disconnected
-      return [];
-    }
+  /**
+   * Fallback source: groups persisted from message history (conversations of type
+   * "group"). Resilient to engine / WhatsApp-Web-version issues that break the live
+   * getGroups call, so the group picker never silently empties.
+   */
+  private async getGroupsFromDb(profileId: string): Promise<GroupInfo[]> {
+    const convs = await prisma.conversation.findMany({
+      where: { profileId, OR: [{ type: 'group' }, { jid: { endsWith: '@g.us' } }] },
+      orderBy: { updatedAt: 'desc' },
+    });
+    return convs.map((c) => ({
+      id: c.jid,
+      name: c.name || 'Group Chat',
+      description: '',
+      owner: '',
+      createdAt: c.createdAt,
+      participantsCount: 0,
+    }));
   }
 
   /**


### PR DESCRIPTION
## Bug (reported in prod)
The messages-page **group list is empty**. Root cause: `GET /groups/profile/:id` → `GroupsService.getAll` calls the **live** `whatsapp-web.js getGroups()`, which currently throws `Get groups error: r` on the deployed WhatsApp Web build (its group Store isn't hooked by wwebjs 1.34.7 — **send works, groups don't**). `getAll` caught the error and returned `[]`, so every profile's picker emptied despite **23 group conversations** existing in the DB.

## Fix
`getAll` now tries the live engine first (freshest counts) but **falls back to persisted group conversations** (`type: 'group'` / `jid` ending `@g.us`) when the live call throws **or** returns empty — covering both the local-engine and `ENGINE_HOST=worker` paths. The picker stays usable regardless of engine/WA-Web-version flakiness.

## Tests
`groups-getall.spec.ts` — live-first (no DB touch), throw→DB fallback, empty→DB fallback (+ null-name → "Group Chat"). 3/3 pass; api typecheck + build pass.

## Scope note
This fixes the **list**. Live membership counts / group metadata still need a whatsapp-web.js upgrade to a build whose group Store hooks the current WhatsApp Web — tracked separately.