### PR TITLE
test(worker): stand up vitest + cover 4 processors/services (+34 tests, 0→21% worker coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,10 @@ jobs:
       - name: Run SDK tests
         run: pnpm --filter @multiwa/sdk test
 
+      # Worker unit tests (pure — prisma/engine deps mocked, no DB/Redis needed).
+      - name: Run worker tests (with coverage gate)
+        run: pnpm --filter @multiwa/worker run test:cov
+
       # Create the schema in the test DB (no migrations dir → db push), same mechanism
       # as the Prisma generate step above. Kept out of vitest so it runs in a full shell.
       - name: Prepare e2e database

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -9,7 +9,9 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:cov": "vitest run --coverage"
   },
   "dependencies": {
     "@multiwa/core": "workspace:*",
@@ -36,6 +38,8 @@
     "@types/qrcode": "^1.5.6",
     "@types/web-push": "^3.6.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^2.0.0",
+    "@vitest/coverage-v8": "^2"
   }
 }

--- a/apps/worker/src/engine/webhook-dispatcher.service.spec.ts
+++ b/apps/worker/src/engine/webhook-dispatcher.service.spec.ts
@@ -1,0 +1,162 @@
+// Unit spec for the worker's WorkerWebhookDispatcherService — mirrors the API
+// dispatcher: it subscribes to the engine event bus and enqueues a 'deliver'
+// webhook job ONLY for enabled webhooks whose `events` list subscribes to the
+// fired event. Locks the fan-out contract: right job for a subscribed event,
+// nothing for an unknown/disabled/unsubscribed one, and no crash on a DB blip.
+//
+// Prisma + the BullMQ queue are mocked (no DB, no Redis). The real APP_EVENT_SET
+// from @multiwa/core (aliased to source) is used so the event-name guard is real.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted mock — the service imports `prisma` from '@multiwa/database' at module
+// load. Only webhook.findMany is used; createPrismaClient is provided defensively.
+vi.mock('@multiwa/database', () => {
+  const prisma = { webhook: { findMany: vi.fn() } };
+  return { prisma, createPrismaClient: () => prisma };
+});
+
+import { prisma } from '@multiwa/database';
+import {
+  WorkerWebhookDispatcherService,
+  WORKER_WEBHOOK_QUEUE,
+} from './webhook-dispatcher.service';
+
+const findMany = () => vi.mocked(prisma.webhook.findMany);
+
+// Flush the fire-and-forget `void this.dispatch(...)` microtask chain.
+const flush = () => new Promise((r) => setImmediate(r));
+
+function makeService() {
+  const onAny = vi.fn();
+  const eventEmitter = { onAny } as any;
+  const queueAdd = vi.fn().mockResolvedValue({ id: 'job-1' });
+  const webhookQueue = { add: queueAdd } as any;
+  const service = new WorkerWebhookDispatcherService(eventEmitter, webhookQueue);
+  return { service, onAny, queueAdd };
+}
+
+describe('WorkerWebhookDispatcherService', () => {
+  beforeEach(() => {
+    findMany().mockReset();
+  });
+
+  it('exposes a stable DI token for the worker webhook queue', () => {
+    expect(WORKER_WEBHOOK_QUEUE).toBe('WORKER_WEBHOOK_QUEUE');
+  });
+
+  it('subscribes to the engine event bus once on module init', () => {
+    const { service, onAny } = makeService();
+    service.onModuleInit();
+    expect(onAny).toHaveBeenCalledTimes(1);
+    expect(onAny.mock.calls[0][0]).toBeInstanceOf(Function);
+  });
+
+  it('enqueues a deliver job for a subscribed+enabled webhook, filtering on enabled:true and events.has', async () => {
+    const { service, queueAdd } = makeService();
+    findMany().mockResolvedValueOnce([{ id: 'wh_1' }] as any);
+    const payload = { profileId: 'p1', id: 'MSG_1', from: '628123@c.us', body: 'hi' };
+
+    await (service as any).dispatch('message.received', payload);
+
+    // The query itself is the "only enabled + only subscribed" contract.
+    expect(findMany()).toHaveBeenCalledWith({
+      where: { profileId: 'p1', enabled: true, events: { has: 'message.received' } },
+      select: { id: true },
+    });
+    expect(queueAdd).toHaveBeenCalledTimes(1);
+    expect(queueAdd).toHaveBeenCalledWith(
+      'deliver',
+      { webhookId: 'wh_1', event: 'message.received', payload },
+      expect.objectContaining({
+        jobId: 'wh_1-message.received-MSG_1',
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 30000 },
+        removeOnComplete: 200,
+        removeOnFail: 100,
+      }),
+    );
+  });
+
+  it('does NOTHING for a known event when no enabled/subscribed webhook matches', async () => {
+    const { service, queueAdd } = makeService();
+    findMany().mockResolvedValueOnce([] as any);
+
+    await (service as any).dispatch('message.sent', { profileId: 'p1', id: 'M2' });
+
+    // It queried (with the enabled+events filter) but enqueued nothing.
+    expect(findMany()).toHaveBeenCalledTimes(1);
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+
+  it('skips unknown/non-canonical events without ever querying the DB', async () => {
+    const { service, queueAdd } = makeService();
+
+    // Colon channel name + a bogus dot name — neither is in APP_EVENT_SET.
+    await (service as any).dispatch('message:received', { profileId: 'p1', id: 'x' });
+    await (service as any).dispatch('totally.made.up', { profileId: 'p1', id: 'x' });
+
+    expect(findMany()).not.toHaveBeenCalled();
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+
+  it('skips events with no profileId (cannot scope the webhook lookup)', async () => {
+    const { service, queueAdd } = makeService();
+
+    await (service as any).dispatch('message.received', { id: 'no-profile' });
+
+    expect(findMany()).not.toHaveBeenCalled();
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+
+  it('fans out one job per matching webhook and omits jobId when there is no message id', async () => {
+    const { service, queueAdd } = makeService();
+    findMany().mockResolvedValueOnce([{ id: 'a' }, { id: 'b' }] as any);
+
+    await (service as any).dispatch('connection.ready', { profileId: 'p1' });
+
+    expect(queueAdd).toHaveBeenCalledTimes(2);
+    expect(queueAdd.mock.calls.map((c) => (c[1] as any).webhookId)).toEqual(['a', 'b']);
+    // No messageId → jobId must be undefined (no dedup key).
+    expect((queueAdd.mock.calls[0][2] as any).jobId).toBeUndefined();
+  });
+
+  it('derives the message id from payload.messageId when payload.id is absent', async () => {
+    const { service, queueAdd } = makeService();
+    findMany().mockResolvedValueOnce([{ id: 'wh_9' }] as any);
+
+    await (service as any).dispatch('message.delivered', { profileId: 'p1', messageId: 'WA_42' });
+
+    expect((queueAdd.mock.calls[0][2] as any).jobId).toBe('wh_9-message.delivered-WA_42');
+  });
+
+  it('swallows a prisma failure (never crashes the event loop) and enqueues nothing', async () => {
+    const { service, queueAdd } = makeService();
+    findMany().mockRejectedValueOnce(new Error('db down'));
+
+    await expect(
+      (service as any).dispatch('message.received', { profileId: 'p1', id: 'boom' }),
+    ).resolves.toBeUndefined();
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+
+  it('routes an emitted bus event (incl. array event names joined by ".") through to the queue', async () => {
+    const { service, onAny, queueAdd } = makeService();
+    service.onModuleInit();
+    const handler = onAny.mock.calls[0][0] as (e: string | string[], p: unknown) => void;
+    findMany().mockResolvedValueOnce([{ id: 'wh_x' }] as any);
+
+    // EventEmitter2 wildcard mode can hand the segments as an array.
+    handler(['message', 'received'], { profileId: 'p1', id: 'MID' });
+    await flush();
+
+    expect(findMany()).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ events: { has: 'message.received' } }) }),
+    );
+    expect(queueAdd).toHaveBeenCalledWith(
+      'deliver',
+      expect.objectContaining({ webhookId: 'wh_x', event: 'message.received' }),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/worker/src/processors/automation.processor.spec.ts
+++ b/apps/worker/src/processors/automation.processor.spec.ts
@@ -1,0 +1,232 @@
+// Unit spec for the worker AutomationProcessor — locks the trigger/condition/action
+// branching: which incoming messages fire which automations, how conditions are
+// evaluated (message_contains / message_matches / contact_has_tag), and that a
+// non-matching message performs NO side effect (no reply, no tag write, no stats bump).
+//
+// The processor calls `const prisma = createPrismaClient()` at MODULE LOAD, so the
+// @multiwa/database mock is hoisted and returns a stable client object; the test
+// grabs that same object via createPrismaClient() to drive per-test return values.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => {
+  const client = {
+    contact: { findUnique: vi.fn(), update: vi.fn() },
+    automation: { findMany: vi.fn(), update: vi.fn() },
+    conversation: { findFirst: vi.fn(), create: vi.fn() },
+    message: { create: vi.fn() },
+  };
+  // createPrismaClient() must return the SAME object each call so the module-load
+  // instance and the test's handle are identical.
+  return { createPrismaClient: () => client, prisma: client };
+});
+
+import { createPrismaClient } from '@multiwa/database';
+import { AutomationProcessor, AutomationJob } from './automation.processor';
+
+const prisma = createPrismaClient() as any;
+
+// Minimal Job stand-in — the processor only reads `.data`.
+const makeJob = (data: Partial<AutomationJob>): any => ({
+  data: {
+    profileId: 'p1',
+    event: 'message.received',
+    contactId: 'c1',
+    messageBody: '',
+    ...data,
+  },
+});
+
+const contactFixture = (over: Partial<{ id: string; phone: string; tags: string[] }> = {}) => ({
+  id: 'c1',
+  phone: '628123456789',
+  tags: [] as string[],
+  ...over,
+});
+
+// Automation row factory with sensible defaults (active, wildcard trigger, no conditions).
+const automationFixture = (over: Record<string, any> = {}) => ({
+  id: 'a1',
+  profileId: 'p1',
+  isActive: true,
+  priority: 0,
+  triggerType: '*',
+  conditions: null,
+  actions: [],
+  stats: {},
+  ...over,
+});
+
+describe('AutomationProcessor.process', () => {
+  let processor: AutomationProcessor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    processor = new AutomationProcessor();
+
+    // Safe defaults; individual tests override what they exercise.
+    prisma.contact.findUnique.mockResolvedValue(contactFixture());
+    prisma.contact.update.mockResolvedValue({});
+    prisma.automation.findMany.mockResolvedValue([]);
+    prisma.automation.update.mockResolvedValue({});
+    prisma.conversation.findFirst.mockResolvedValue(null);
+    prisma.conversation.create.mockResolvedValue({ id: 'conv1' });
+    prisma.message.create.mockResolvedValue({});
+  });
+
+  it('throws when the contact does not exist (and never queries automations)', async () => {
+    prisma.contact.findUnique.mockResolvedValueOnce(null);
+
+    await expect(processor.process(makeJob({ contactId: 'ghost' }))).rejects.toThrow('Contact not found');
+    expect(prisma.automation.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns matched:0 and performs no action when there are no active automations', async () => {
+    prisma.automation.findMany.mockResolvedValueOnce([]);
+
+    const result = await processor.process(makeJob({}));
+
+    expect(result).toEqual({ matched: 0 });
+    // The query filters to active automations for this profile.
+    expect(prisma.automation.findMany).toHaveBeenCalledWith({
+      where: { profileId: 'p1', isActive: true },
+      orderBy: { priority: 'desc' },
+    });
+    expect(prisma.message.create).not.toHaveBeenCalled();
+  });
+
+  it('skips an automation whose triggerType does not match the event (no result row, no side effect)', async () => {
+    prisma.automation.findMany.mockResolvedValueOnce([
+      automationFixture({ triggerType: 'message.sent', actions: [{ type: 'send_message', value: 'hi' }] }),
+    ]);
+
+    const result = await processor.process(makeJob({ event: 'message.received' }));
+
+    // A trigger mismatch `continue`s before pushing any result row.
+    expect(result.matched).toBe(0);
+    expect(result.results).toHaveLength(0);
+    expect(prisma.message.create).not.toHaveBeenCalled();
+    expect(prisma.automation.update).not.toHaveBeenCalled();
+  });
+
+  it('fires a matching message_contains condition (case-insensitive) and sends the reply + bumps stats', async () => {
+    prisma.automation.findMany.mockResolvedValueOnce([
+      automationFixture({
+        triggerType: 'message.received',
+        conditions: [{ type: 'message_contains', value: ['HELLO'] }],
+        actions: [{ type: 'send_message', value: 'Hi there' }],
+        stats: { trigger_count: 2 },
+      }),
+    ]);
+
+    const result = await processor.process(makeJob({ messageBody: 'well hello world' }));
+
+    expect(result.matched).toBe(1);
+    // A conversation was created from the contact phone -> WhatsApp JID.
+    expect(prisma.conversation.create).toHaveBeenCalledWith({
+      data: { profileId: 'p1', contactId: 'c1', jid: '628123456789@s.whatsapp.net' },
+    });
+    // Outgoing reply message carries the action value as text.
+    expect(prisma.message.create).toHaveBeenCalledTimes(1);
+    const msgArg = prisma.message.create.mock.calls[0][0].data;
+    expect(msgArg).toMatchObject({
+      direction: 'outgoing',
+      type: 'text',
+      content: { text: 'Hi there' },
+      conversationId: 'conv1',
+    });
+    // Stats incremented off the prior trigger_count (2 -> 3).
+    expect(prisma.automation.update.mock.calls[0][0].data.stats.trigger_count).toBe(3);
+  });
+
+  it('performs NO action when a message_contains condition does not match', async () => {
+    prisma.automation.findMany.mockResolvedValueOnce([
+      automationFixture({
+        triggerType: 'message.received',
+        conditions: [{ type: 'message_contains', value: ['refund'] }],
+        actions: [{ type: 'send_message', value: 'Hi there' }],
+      }),
+    ]);
+
+    const result = await processor.process(makeJob({ messageBody: 'where is my order' }));
+
+    // Condition fail pushes a matched:false result row but runs no actions.
+    expect(result.matched).toBe(0);
+    expect(result.results).toHaveLength(1);
+    expect(result.results![0].matched).toBe(false);
+    expect(prisma.message.create).not.toHaveBeenCalled();
+    expect(prisma.automation.update).not.toHaveBeenCalled();
+  });
+
+  it('evaluates a message_matches regex condition case-insensitively', async () => {
+    prisma.automation.findMany.mockResolvedValueOnce([
+      automationFixture({
+        conditions: [{ type: 'message_matches', value: '^order\\s+\\d+' }],
+        actions: [{ type: 'send_message', value: 'Tracking your order' }],
+      }),
+    ]);
+
+    // Uppercase input matches the lowercase-authored pattern via the 'i' flag.
+    const result = await processor.process(makeJob({ messageBody: 'ORDER 42 please' }));
+
+    expect(result.matched).toBe(1);
+    expect(prisma.message.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires ALL conditions to pass: contact_has_tag gates the action', async () => {
+    prisma.automation.findMany.mockResolvedValue([
+      automationFixture({
+        conditions: [
+          { type: 'message_contains', value: ['hello'] },
+          { type: 'contact_has_tag', value: 'vip' },
+        ],
+        actions: [{ type: 'send_message', value: 'VIP hello' }],
+      }),
+    ]);
+
+    // Contact WITHOUT the required tag -> no action.
+    prisma.contact.findUnique.mockResolvedValueOnce(contactFixture({ tags: ['regular'] }));
+    const miss = await processor.process(makeJob({ messageBody: 'hello there' }));
+    expect(miss.matched).toBe(0);
+    expect(prisma.message.create).not.toHaveBeenCalled();
+
+    // Contact WITH the required tag -> action fires.
+    prisma.contact.findUnique.mockResolvedValueOnce(contactFixture({ tags: ['vip'] }));
+    const hit = await processor.process(makeJob({ messageBody: 'hello there' }));
+    expect(hit.matched).toBe(1);
+    expect(prisma.message.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses an existing conversation instead of creating a new one', async () => {
+    prisma.automation.findMany.mockResolvedValueOnce([
+      automationFixture({ actions: [{ type: 'send_message', value: 'reuse' }] }),
+    ]);
+    prisma.conversation.findFirst.mockResolvedValueOnce({ id: 'existing-conv' });
+
+    await processor.process(makeJob({ messageBody: 'anything' }));
+
+    expect(prisma.conversation.create).not.toHaveBeenCalled();
+    expect(prisma.message.create.mock.calls[0][0].data.conversationId).toBe('existing-conv');
+  });
+
+  it('applies add_tag and remove_tag actions to the contact (deduping added tags)', async () => {
+    prisma.automation.findMany.mockResolvedValueOnce([
+      automationFixture({
+        actions: [
+          { type: 'add_tag', value: 'lead' },
+          { type: 'remove_tag', value: 'old' },
+        ],
+      }),
+    ]);
+    prisma.contact.findUnique.mockResolvedValueOnce(contactFixture({ tags: ['old', 'lead'] }));
+
+    const result = await processor.process(makeJob({ messageBody: 'x' }));
+
+    expect(result.matched).toBe(1);
+    // add_tag dedupes against existing tags.
+    expect(prisma.contact.update.mock.calls[0][0].data.tags).toEqual(['old', 'lead']);
+    // remove_tag strips the named tag.
+    expect(prisma.contact.update.mock.calls[1][0].data.tags).toEqual(['lead']);
+    expect(prisma.message.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/processors/message.processor.spec.ts
+++ b/apps/worker/src/processors/message.processor.spec.ts
@@ -1,0 +1,130 @@
+// Unit spec for the worker MessageProcessor. Locks the send-job routing contract:
+// a job is only marked QUEUED (handed to the gateway) when its profile exists AND
+// is CONNECTED; every other path (missing profile, wrong status, DB error) must
+// mark the message FAILED with the error captured in metadata and re-throw so BullMQ
+// retries. Prisma is mocked (no DB) — the processor calls createPrismaClient() at
+// module load, so the mock returns a STABLE object shared with the exported `prisma`.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => {
+  const mockPrisma = {
+    profile: { findUnique: vi.fn() },
+    message: { update: vi.fn() },
+  };
+  // Same object for both entry points so the source's createPrismaClient() and the
+  // `prisma` we import in tests point at one shared set of vi.fn() spies.
+  return { createPrismaClient: () => mockPrisma, prisma: mockPrisma };
+});
+
+import { prisma } from '@multiwa/database';
+import { MessageProcessor, type MessageJob } from './message.processor';
+
+const findUnique = () => vi.mocked(prisma.profile.findUnique);
+const updateMsg = () => vi.mocked(prisma.message.update);
+
+function makeJob(over: Partial<MessageJob> = {}) {
+  return {
+    data: {
+      profileId: 'prof-1',
+      messageId: 'msg-1',
+      to: '628123456789@c.us',
+      type: 'chat',
+      content: { body: 'hi' },
+      ...over,
+    },
+  } as any;
+}
+
+describe('MessageProcessor.process', () => {
+  const processor = new MessageProcessor();
+
+  beforeEach(() => {
+    findUnique().mockReset();
+    updateMsg().mockReset();
+    updateMsg().mockResolvedValue({} as any);
+  });
+
+  it('marks the message QUEUED and returns queued_for_gateway when the profile is CONNECTED', async () => {
+    findUnique().mockResolvedValueOnce({ id: 'prof-1', status: 'CONNECTED' } as any);
+
+    const result = await processor.process(makeJob());
+
+    // Looked the profile up by the job's profileId.
+    expect(findUnique()).toHaveBeenCalledWith({ where: { id: 'prof-1' } });
+    // The ONLY write is the QUEUED status update on the right message.
+    expect(updateMsg()).toHaveBeenCalledTimes(1);
+    expect(updateMsg()).toHaveBeenCalledWith({
+      where: { id: 'msg-1' },
+      data: { status: 'QUEUED' },
+    });
+    // Result echoes routing metadata for the gateway.
+    expect(result).toEqual({
+      success: true,
+      profileId: 'prof-1',
+      messageId: 'msg-1',
+      to: '628123456789@c.us',
+      type: 'chat',
+      status: 'queued_for_gateway',
+    });
+  });
+
+  it('throws and marks the message FAILED (with error metadata) when the profile is missing', async () => {
+    findUnique().mockResolvedValueOnce(null as any);
+
+    await expect(processor.process(makeJob())).rejects.toThrow('Profile not connected');
+
+    // Never queued; the single write is the FAILED update carrying the reason.
+    expect(updateMsg()).toHaveBeenCalledTimes(1);
+    expect(updateMsg()).toHaveBeenCalledWith({
+      where: { id: 'msg-1' },
+      data: {
+        status: 'FAILED',
+        metadata: { error: 'Profile not connected' },
+      },
+    });
+    // It must NOT have queued the message.
+    expect(updateMsg()).not.toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'QUEUED' } }),
+    );
+  });
+
+  it('treats any non-CONNECTED status as not connected and fails the message', async () => {
+    findUnique().mockResolvedValueOnce({ id: 'prof-1', status: 'DISCONNECTED' } as any);
+
+    await expect(processor.process(makeJob())).rejects.toThrow('Profile not connected');
+
+    expect(updateMsg()).toHaveBeenCalledWith({
+      where: { id: 'msg-1' },
+      data: { status: 'FAILED', metadata: { error: 'Profile not connected' } },
+    });
+  });
+
+  it('re-throws the ORIGINAL db error and still records it as FAILED when the QUEUED update fails', async () => {
+    findUnique().mockResolvedValueOnce({ id: 'prof-1', status: 'CONNECTED' } as any);
+    const boom = new Error('db write timeout');
+    // First update (QUEUED) rejects; second update (FAILED, in catch) resolves.
+    updateMsg().mockRejectedValueOnce(boom).mockResolvedValueOnce({} as any);
+
+    await expect(processor.process(makeJob())).rejects.toBe(boom);
+
+    expect(updateMsg()).toHaveBeenCalledTimes(2);
+    // The catch block persists the caught error message.
+    expect(updateMsg()).toHaveBeenLastCalledWith({
+      where: { id: 'msg-1' },
+      data: { status: 'FAILED', metadata: { error: 'db write timeout' } },
+    });
+  });
+
+  it('records "Unknown error" when a non-Error value is thrown', async () => {
+    // findUnique rejects with a bare string (not an Error instance).
+    findUnique().mockRejectedValueOnce('nope' as any);
+
+    await expect(processor.process(makeJob())).rejects.toBe('nope');
+
+    expect(updateMsg()).toHaveBeenCalledWith({
+      where: { id: 'msg-1' },
+      data: { status: 'FAILED', metadata: { error: 'Unknown error' } },
+    });
+  });
+});

--- a/apps/worker/src/processors/webhook.processor.spec.ts
+++ b/apps/worker/src/processors/webhook.processor.spec.ts
@@ -1,0 +1,235 @@
+// Unit spec for the worker's WebhookProcessor. Locks three contracts:
+//   1. X-MultiWA-Signature is a deterministic sha256 HMAC over the canonical
+//      signed body (same body+secret => same hex sig) so SDK verifiers keep working.
+//   2. The WebhookLog PII policy (policedLogPayload / WEBHOOK_LOG_PAYLOAD_MAX_BYTES):
+//      0 => {}, -1 => full payload, N => message-body fields truncated with a
+//      marker, default 512.
+//   3. Delivery calls assertWebhookUrlSafe BEFORE fetch, sends the HMAC header, and
+//      writes a WebhookLog row with the right statusCode on non-2xx / network failure.
+//
+// The processor calls `createPrismaClient()` at MODULE LOAD, so the database mock
+// is hoisted and returns a single shared instance. No DB, no network, no Nest.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as crypto from 'crypto';
+
+// One shared mock prisma instance: createPrismaClient() (called at module load by
+// the SUT) and every later call return the SAME object, so the fns we assert on
+// are the fns the processor actually invokes.
+vi.mock('@multiwa/database', () => {
+  const mockPrisma = {
+    webhook: { findUnique: vi.fn() },
+    webhookLog: { create: vi.fn() },
+  };
+  return {
+    createPrismaClient: () => mockPrisma,
+    prisma: mockPrisma,
+  };
+});
+
+// assertWebhookUrlSafe is the SSRF guard; the pass-through returns the url so we
+// can assert fetch is called with the validated target.
+vi.mock('@multiwa/engine-runtime', () => ({
+  assertWebhookUrlSafe: vi.fn(async (u: string) => u),
+}));
+
+import { createPrismaClient } from '@multiwa/database';
+import { assertWebhookUrlSafe } from '@multiwa/engine-runtime';
+import { WebhookProcessor } from './webhook.processor';
+
+const mockPrisma = createPrismaClient() as unknown as {
+  webhook: { findUnique: ReturnType<typeof vi.fn> };
+  webhookLog: { create: ReturnType<typeof vi.fn> };
+};
+
+const fetchMock = vi.fn();
+
+const ENV_KEY = 'WEBHOOK_LOG_PAYLOAD_MAX_BYTES';
+
+function makeWebhook(overrides: Record<string, any> = {}) {
+  return {
+    id: 'wh-1',
+    enabled: true,
+    events: ['message.received'],
+    profileId: 'profile-123',
+    secret: 'top-secret',
+    url: 'https://hook.example.com/in',
+    headers: {},
+    ...overrides,
+  };
+}
+
+function makeResponse(overrides: Partial<{ ok: boolean; status: number; text: string }> = {}) {
+  const { ok = true, status = 200, text = 'OK' } = overrides;
+  return { ok, status, text: vi.fn(async () => text) };
+}
+
+function makeJob(dataOverrides: Record<string, any> = {}) {
+  return {
+    data: {
+      webhookId: 'wh-1',
+      event: 'message.received',
+      payload: { id: 'm1', body: 'hello' },
+      ...dataOverrides,
+    },
+  } as any;
+}
+
+describe('WebhookProcessor', () => {
+  beforeEach(() => {
+    vi.mocked(mockPrisma.webhook.findUnique).mockReset();
+    vi.mocked(mockPrisma.webhookLog.create).mockReset().mockResolvedValue({} as any);
+    vi.mocked(assertWebhookUrlSafe).mockClear();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    delete process.env[ENV_KEY];
+  });
+
+  // ---- 1. HMAC signature ------------------------------------------------------
+
+  it('signs the canonical body with a deterministic sha256 HMAC (same body+secret => same sig)', async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook());
+    fetchMock.mockResolvedValueOnce(makeResponse());
+
+    await new WebhookProcessor().process(makeJob());
+
+    const [, init] = fetchMock.mock.calls[0];
+    const sentBody: string = init.body;
+    const header: string = init.headers['X-MultiWA-Signature'];
+
+    // Recompute independently over the EXACT body that was sent.
+    const expected = crypto.createHmac('sha256', 'top-secret').update(sentBody).digest('hex');
+    const expectedAgain = crypto.createHmac('sha256', 'top-secret').update(sentBody).digest('hex');
+
+    expect(header).toBe(`sha256=${expected}`);
+    expect(expected).toBe(expectedAgain); // deterministic
+    expect(header).toMatch(/^sha256=[0-9a-f]{64}$/); // hex sha256
+    // A different secret must NOT collide with the emitted signature.
+    const other = crypto.createHmac('sha256', 'other-secret').update(sentBody).digest('hex');
+    expect(header).not.toBe(`sha256=${other}`);
+  });
+
+  // ---- 2. WebhookLog PII policy (policedLogPayload) ---------------------------
+
+  it('policy default (env unset) truncates body/text/caption/message to 512 + marker', async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook());
+    fetchMock.mockResolvedValueOnce(makeResponse());
+
+    const long = 'a'.repeat(600);
+    await new WebhookProcessor().process(
+      makeJob({ payload: { body: long, text: long, caption: long, message: long, id: 'keep' } }),
+    );
+
+    const logged = mockPrisma.webhookLog.create.mock.calls[0][0].data.payload;
+    for (const key of ['body', 'text', 'caption', 'message']) {
+      expect(logged[key]).toBe('a'.repeat(512) + '…[truncated]');
+    }
+    expect(logged.id).toBe('keep'); // non-message fields pass through untouched
+  });
+
+  it('policy 0 stores {} (PLN Batam PII-off posture)', async () => {
+    process.env[ENV_KEY] = '0';
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook());
+    fetchMock.mockResolvedValueOnce(makeResponse());
+
+    await new WebhookProcessor().process(makeJob({ payload: { body: 'secret text', id: 'm1' } }));
+
+    expect(mockPrisma.webhookLog.create.mock.calls[0][0].data.payload).toEqual({});
+  });
+
+  it('policy -1 stores the full payload with no redaction', async () => {
+    process.env[ENV_KEY] = '-1';
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook());
+    fetchMock.mockResolvedValueOnce(makeResponse());
+
+    const payload = { body: 'x'.repeat(2000), id: 'm1' };
+    await new WebhookProcessor().process(makeJob({ payload }));
+
+    expect(mockPrisma.webhookLog.create.mock.calls[0][0].data.payload).toEqual(payload);
+  });
+
+  it('policy N truncates each message field to N chars + marker', async () => {
+    process.env[ENV_KEY] = '10';
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook());
+    fetchMock.mockResolvedValueOnce(makeResponse());
+
+    await new WebhookProcessor().process(
+      makeJob({ payload: { body: 'b'.repeat(20), text: 'short' } }),
+    );
+
+    const logged = mockPrisma.webhookLog.create.mock.calls[0][0].data.payload;
+    expect(logged.body).toBe('b'.repeat(10) + '…[truncated]');
+    expect(logged.text).toBe('short'); // below N => left alone
+  });
+
+  // ---- 3. Delivery: SSRF guard + HMAC header + status logging -----------------
+
+  it('calls assertWebhookUrlSafe BEFORE fetch, then fetches the safe url with the HMAC header', async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook());
+    fetchMock.mockResolvedValueOnce(makeResponse());
+
+    await new WebhookProcessor().process(makeJob());
+
+    expect(assertWebhookUrlSafe).toHaveBeenCalledWith('https://hook.example.com/in');
+    // Order: the SSRF guard must run before the network request.
+    const guardOrder = vi.mocked(assertWebhookUrlSafe).mock.invocationCallOrder[0];
+    const fetchOrder = fetchMock.mock.invocationCallOrder[0];
+    expect(guardOrder).toBeLessThan(fetchOrder);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://hook.example.com/in');
+    expect(init.method).toBe('POST');
+    expect(init.headers['X-MultiWA-Signature']).toMatch(/^sha256=[0-9a-f]{64}$/);
+    expect(init.headers['X-MultiWA-Event']).toBe('message.received');
+    expect(init.redirect).toBe('error');
+  });
+
+  it('logs statusCode from a non-2xx response and then throws', async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook());
+    fetchMock.mockResolvedValueOnce(makeResponse({ ok: false, status: 500, text: 'boom' }));
+
+    await expect(new WebhookProcessor().process(makeJob())).rejects.toThrow('Webhook returned 500');
+
+    // First row is the delivery row carrying the real status code.
+    const first = mockPrisma.webhookLog.create.mock.calls[0][0].data;
+    expect(first.statusCode).toBe(500);
+    expect(first.success).toBe(false);
+    expect(first.response).toBe('boom');
+  });
+
+  it('logs a null statusCode + error message when fetch rejects, then rethrows', async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook());
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    await expect(new WebhookProcessor().process(makeJob())).rejects.toThrow('ECONNREFUSED');
+
+    const logged = mockPrisma.webhookLog.create.mock.calls[0][0].data;
+    expect(logged.statusCode).toBeNull();
+    expect(logged.success).toBe(false);
+    expect(logged.response).toBe('ECONNREFUSED');
+  });
+
+  // ---- guards -----------------------------------------------------------------
+
+  it('throws and never fetches when the webhook is disabled', async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(makeWebhook({ enabled: false }));
+
+    await expect(new WebhookProcessor().process(makeJob())).rejects.toThrow(
+      'Webhook not found or disabled',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(assertWebhookUrlSafe).not.toHaveBeenCalled();
+  });
+
+  it('skips (no fetch, no log) when the event is not subscribed', async () => {
+    mockPrisma.webhook.findUnique.mockResolvedValueOnce(
+      makeWebhook({ events: ['message.sent'] }),
+    );
+
+    const result = await new WebhookProcessor().process(makeJob());
+
+    expect(result).toEqual({ skipped: true, reason: 'Event not subscribed' });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockPrisma.webhookLog.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    root: './src',
+    include: ['**/*.{test,spec}.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      // `all: true` counts untested modules too, so the % reflects real breadth of
+      // the worker's business logic (processors + engine services), not just the
+      // files a spec happens to import.
+      all: true,
+      include: ['processors/**/*.ts', 'engine/**/*.ts'],
+      exclude: ['**/*.spec.ts', 'main.ts', 'index.ts', '**/*.module.ts', '**/engine-manager.service.ts'],
+      // Ratchet floor set just below the current coverage so the gate passes today
+      // and only fails on a REGRESSION. Raise as coverage grows.
+      thresholds: {
+        lines: 20,
+        statements: 20,
+        functions: 45,
+        branches: 70,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      // Resolve the shared engine runtime + core to source so vi.mock reaches into
+      // them and specs don't depend on a built dist (the CI Tests job doesn't build
+      // every package's dist). Test-only; runtime/typecheck use the packages' dist.
+      '@multiwa/engine-runtime': path.resolve(__dirname, '../../packages/engine-runtime/src/index.ts'),
+      '@multiwa/core': path.resolve(__dirname, '../../packages/core/src/index.ts'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,12 +382,18 @@ importers:
       '@types/web-push':
         specifier: ^3.6.0
         version: 3.6.4
+      '@vitest/coverage-v8':
+        specifier: ^2
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.8)(terser@5.46.0))
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.8)(terser@5.46.0)
 
   packages/chatwoot-bridge:
     dependencies:


### PR DESCRIPTION
Testing part 2 (worker) — the `apps/worker` app had **zero tests and no test infra** (only `apps/api` was wired to CI). This stands up vitest for the worker and lands **34 validated unit tests**.

## Infra
- `apps/worker/vitest.config.ts` (v8 coverage, engine-runtime/core aliased to source), `test`/`test:cov` scripts, vitest devDeps, and a **CI step** (`Run worker tests (with coverage gate)` in the Tests job). Lockfile stays HTTPS-clean (0 SSH).

## Tests (prisma/engine/fetch mocked, sources untouched)
| Unit | Tests | Locks |
|------|-------|-------|
| webhook.processor | 10 | deterministic HMAC signature; the `WEBHOOK_LOG_PAYLOAD_MAX_BYTES` PII policy (0→`{}`, -1→full, N→truncate); `assertWebhookUrlSafe` **before** fetch + correct statusCode logging |
| automation.processor | 9 | trigger/event gating, contains/matches/has_tag conditions (AND), send/add_tag/remove_tag actions + stat bump, zero writes on non-match |
| message.processor | 5 | send job QUEUED only when profile exists AND CONNECTED; else FAILED + reason + re-throw for retry |
| webhook-dispatcher.service | 10 | fan-out only to enabled webhooks subscribed to the event; correct BullMQ options; nothing enqueued for unsubscribed/unknown events |

## Coverage (worker)
stmts/lines **0 → 21.5%**, funcs **52.9%**, branches **81.6%** (processors **92.9%**). Gate: lines/statements 20, functions 45, branches 70 (ratchet floor). **34 tests pass**, worker typecheck clean.

## Follow-up
The heavy engine services (rule-engine, messages, ai, engine-manager) remain for a later pass; engine-manager is also slated for the de-dup refactor.