### PR TITLE
docs(dist): honest SDK/n8n install instructions (stop advertising unpublished packages)

### DIFF
--- a/docs/13-sdk-python.md
+++ b/docs/13-sdk-python.md
@@ -6,9 +6,16 @@ Official Python SDK for MultiWA.
 
 ## Installation
 
+Registry publishing is pending — `multiwa` is not yet on PyPI. Install from this
+repository meanwhile:
+
 ```bash
-pip install multiwa
+pip install ./packages/sdk-python
+# or straight from GitHub:
+pip install "git+https://github.com/ribato22/MultiWA.git#subdirectory=packages/sdk-python"
 ```
+
+Once it is published, `pip install multiwa` will work directly.
 
 ---
 

--- a/docs/15-n8n-integration.md
+++ b/docs/15-n8n-integration.md
@@ -8,9 +8,14 @@ Use MultiWA with n8n for powerful workflow automation.
 
 ### n8n Community Nodes
 
+Registry publishing is pending — `n8n-nodes-multiwa` is not yet on npm. Install from
+this repository meanwhile:
+
 ```bash
-npm install n8n-nodes-multiwa
+npm install ./packages/n8n-nodes-multiwa
 ```
+
+Once it is published, `npm install n8n-nodes-multiwa` will work directly.
 
 Or install via n8n UI:
 1. Go to **Settings** → **Community Nodes**


### PR DESCRIPTION
Distribution/docs-accuracy: the audit flagged install commands that **don't resolve**. `docs/13-sdk-python.md` advertised `pip install multiwa` and `docs/15-n8n-integration.md` advertised `npm install n8n-nodes-multiwa`, but neither package is published to PyPI/npm yet — so both commands fail. (The README's SDK table already says "registry publishing pending"; these two docs contradicted it.)

## Change
Both docs now show the **working install-from-source** method and note the one-line registry command works once published:
- Python: `pip install ./packages/sdk-python` (or `git+…#subdirectory=packages/sdk-python`)
- n8n: `npm install ./packages/n8n-nodes-multiwa`

Docs-only, no code change.

## Still needs you (to actually publish — unblocks the rest of the Distribution tier)
- Configure the **PyPI Trusted Publisher** (OIDC) for `multiwa` and the **npm Trusted Publisher** for `@multiwa/sdk` / `n8n-nodes-multiwa` (or set first-publish `NPM_TOKEN`), then the existing `publish-sdk*.yml` workflows publish on an `sdk-v*` tag with provenance — no tokens stored.
- Go-ahead to trigger `docker-publish.yml` (workflow_dispatch) to refresh the public **GHCR** `latest` images, which currently predate all #54–#89 hardening (GHCR uses `GITHUB_TOKEN`, no extra secret needed).