### PR TITLE
feat(media): cap inbound media base64 + de-dup it across both engine-managers

### DIFF
--- a/apps/api/src/modules/messages/inbound-media.spec.ts
+++ b/apps/api/src/modules/messages/inbound-media.spec.ts
@@ -1,0 +1,47 @@
+// Tests for the shared inbound-media helper: the same logic both engine-manager
+// forks use to store a downloaded WhatsApp media, with a size cap so an oversized
+// base64 payload can't be inlined into (and bloat) the messages table.
+import { describe, it, expect } from 'vitest';
+import { applyInboundMedia, inboundMediaMaxBytes } from '@multiwa/engine-runtime';
+
+// A ~N-byte media: base64 length ≈ 4/3 * bytes, so to get `bytes` decoded we need
+// a base64 string of length ceil(bytes * 4 / 3).
+const b64OfBytes = (bytes: number) => 'A'.repeat(Math.ceil((bytes * 4) / 3));
+
+describe('applyInboundMedia', () => {
+  it('leaves content untouched when there is no media', () => {
+    const content: any = {};
+    expect(applyInboundMedia(content, null)).toBe(content);
+    expect(content).toEqual({});
+  });
+
+  it('sets metadata but no url when the media has no data', () => {
+    const content: any = {};
+    applyInboundMedia(content, { mimetype: 'image/png', filename: 'x.png' });
+    expect(content).toMatchObject({ mimetype: 'image/png', filename: 'x.png', hasMedia: true });
+    expect(content.url).toBeUndefined();
+  });
+
+  it('inlines a base64 data URL when under the cap', () => {
+    const content: any = {};
+    applyInboundMedia(content, { mimetype: 'image/jpeg', data: 'aGVsbG8=' }, 1024);
+    expect(content.url).toBe('data:image/jpeg;base64,aGVsbG8=');
+    expect(content.hasMedia).toBe(true);
+    expect(content.mediaOmitted).toBeUndefined();
+    expect(content.mediaBytes).toBeGreaterThan(0);
+  });
+
+  it('does NOT inline oversized media — flags mediaOmitted instead', () => {
+    const content: any = {};
+    const maxBytes = 1024;
+    applyInboundMedia(content, { mimetype: 'video/mp4', data: b64OfBytes(maxBytes * 4) }, maxBytes);
+    expect(content.url).toBeUndefined();
+    expect(content.mediaOmitted).toBe(true);
+    expect(content.hasMedia).toBe(true);
+    expect(content.mediaBytes).toBeGreaterThan(maxBytes);
+  });
+
+  it('defaults the cap to 5 MB (overridable via env)', () => {
+    expect(inboundMediaMaxBytes()).toBe(5 * 1024 * 1024);
+  });
+});

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -933,15 +933,10 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           if (message.hasMedia) {
             try {
               const media = await message.downloadMedia?.();
-              if (media) {
-                content.mimetype = media.mimetype;
-                content.filename = media.filename;
-                content.hasMedia = true;
-                // Store base64 data as data URL for frontend rendering
-                if (media.data) {
-                  content.url = `data:${media.mimetype};base64,${media.data}`;
-                }
-              }
+              // Shared: sets mimetype/filename/hasMedia and inlines the base64 data
+              // URL only when it's under the size cap (oversized media is flagged,
+              // not stored, to avoid bloating Postgres).
+              applyInboundMedia(content, media);
             } catch (e) {
               this.logger.warn(`Failed to download media: ${(e as Error).message}`);
               content.hasMedia = true;

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -866,15 +866,10 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           if (message.hasMedia) {
             try {
               const media = await message.downloadMedia?.();
-              if (media) {
-                content.mimetype = media.mimetype;
-                content.filename = media.filename;
-                content.hasMedia = true;
-                // Store base64 data as data URL for frontend rendering
-                if (media.data) {
-                  content.url = `data:${media.mimetype};base64,${media.data}`;
-                }
-              }
+              // Shared: sets mimetype/filename/hasMedia and inlines the base64 data
+              // URL only when it's under the size cap (oversized media is flagged,
+              // not stored, to avoid bloating Postgres).
+              applyInboundMedia(content, media);
             } catch (e) {
               this.logger.warn(`Failed to download media: ${(e as Error).message}`);
               content.hasMedia = true;

--- a/packages/engine-runtime/src/inbound-media.ts
+++ b/packages/engine-runtime/src/inbound-media.ts
@@ -1,0 +1,66 @@
+// MultiWA Gateway - Inbound media handling (shared engine runtime)
+// packages/engine-runtime/src/inbound-media.ts
+//
+// Single implementation of "store a downloaded inbound WhatsApp media on the
+// message content", shared by the api and worker engine-manager forks (which
+// otherwise carry an identical copy and drift). Adds a size cap: arbitrarily
+// large base64 data URLs in the messages table bloat Postgres and are a DoS
+// vector, so oversized media is not inlined.
+
+export interface InboundMediaLike {
+  mimetype?: string;
+  filename?: string;
+  /** base64-encoded media payload (no data: prefix). */
+  data?: string;
+}
+
+export interface InboundMediaContent {
+  mimetype?: string;
+  filename?: string;
+  hasMedia?: boolean;
+  url?: string;
+  /** Set when the media exceeded the cap and was NOT inlined. */
+  mediaOmitted?: boolean;
+  /** Decoded size of the media in bytes (present whenever `data` was). */
+  mediaBytes?: number;
+}
+
+const DEFAULT_MAX_INBOUND_MEDIA_BYTES = 5 * 1024 * 1024; // 5 MB
+
+/** Cap for inlining inbound media as a base64 data URL. Override with MAX_INBOUND_MEDIA_BYTES. */
+export function inboundMediaMaxBytes(): number {
+  const n = Number(process.env.MAX_INBOUND_MEDIA_BYTES);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_INBOUND_MEDIA_BYTES;
+}
+
+/** Decoded byte length of a base64 string (ignoring padding subtleties). */
+function base64Bytes(b64: string): number {
+  return Math.floor((b64.length * 3) / 4);
+}
+
+/**
+ * Populate `content` from a downloaded inbound media object. The base64 data URL
+ * is inlined ONLY when it is under the size cap (default 5 MB); oversized media
+ * is flagged (`mediaOmitted`) instead of stored, so a single large video can't
+ * bloat the messages table / exhaust the DB. Returns the (mutated) content.
+ */
+export function applyInboundMedia<T extends InboundMediaContent>(
+  content: T,
+  media: InboundMediaLike | null | undefined,
+  maxBytes: number = inboundMediaMaxBytes(),
+): T {
+  if (!media) return content;
+  content.mimetype = media.mimetype;
+  content.filename = media.filename;
+  content.hasMedia = true;
+  if (media.data) {
+    const bytes = base64Bytes(media.data);
+    content.mediaBytes = bytes;
+    if (bytes <= maxBytes) {
+      content.url = `data:${media.mimetype};base64,${media.data}`;
+    } else {
+      content.mediaOmitted = true;
+    }
+  }
+  return content;
+}

--- a/packages/engine-runtime/src/index.ts
+++ b/packages/engine-runtime/src/index.ts
@@ -12,3 +12,4 @@ export * from './email.service';
 export * from './push.service';
 export * from './ack-status';
 export * from './db-retry';
+export * from './inbound-media';


### PR DESCRIPTION
Product/Architecture P1 from the audit: inbound WhatsApp media was stored as a base64 data URL in the `messages` table with **no size cap**, via an **identical block copy-pasted into both engine-manager forks**. A single large video inlines megabytes of base64 per row — a Postgres-bloat / DoS vector — and the duplication is drift-prone.

## Change
- New shared `applyInboundMedia(content, media)` in `@multiwa/engine-runtime`: sets `mimetype`/`filename`/`hasMedia` and inlines the base64 data URL **only when under the cap** (default **5 MB**, override `MAX_INBOUND_MEDIA_BYTES`); oversized media is flagged `mediaOmitted` (with `mediaBytes`) instead of stored.
- Both `apps/api` and `apps/worker` engine-managers now call the one helper — the duplicated block is gone (continues the #79 ack-helper de-dup).

## Tests
`inbound-media.spec.ts` (5): no-media no-op, metadata-without-data, inline-under-cap, omit-over-cap, 5 MB default. api + worker typecheck clean; engine-runtime builds.

Behaviour is unchanged for normal media (< 5 MB); only pathologically large payloads are now dropped instead of bloating the DB.