### PR TITLE
feat(observability): Prometheus alert rules + Alertmanager + SLOs (obs P1)

### DIFF
--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -58,6 +58,29 @@ sum(rate(multiwa_messages_failed_total[5m]))
    (adjust the targets to your network/host:port).
 2. Import [`grafana-dashboard.json`](./grafana-dashboard.json) into Grafana
    (Dashboards → New → Import) and select your Prometheus data source.
+3. `prometheus.yml` already loads [`alert-rules.yml`](./alert-rules.yml) and points
+   at an Alertmanager — run Alertmanager with [`alertmanager.yml`](./alertmanager.yml)
+   and replace the placeholder receiver with your sink (Slack, PagerDuty, a MultiWA
+   webhook, …). Comment out the `alerting:` block if you only want rule evaluation.
+
+## Alerting & SLOs
+
+[`alert-rules.yml`](./alert-rules.yml) ships rules for the failure modes that
+actually took MultiWA down and were invisible until a human noticed:
+
+| Alert | Fires when | Severity |
+|---|---|---|
+| `MultiWAApiDown` / `MultiWAWorkerDown` | scrape target unreachable | critical |
+| `WhatsAppAllProfilesDisconnected` | `multiwa_connected_profiles == 0` for 3m | critical |
+| `WhatsAppSendingStalled` | a profile is connected but **0 sends for 20m** (the "sending dead" incident) | critical |
+| `WhatsAppHighSendFailureRate` | send failure ratio > 20% for 10m | warning |
+| `HighHttpErrorRate` | 5xx ratio > 5% for 5m | warning |
+| `HighHttpLatencyP95` | p95 latency > 1s for 10m | warning |
+
+Target **SLOs** (tune to your traffic): availability — < 1 % of requests return 5xx;
+latency — p95 < 500 ms; WhatsApp — at least one profile connected and outbound sends
+non-zero during business hours. The alert thresholds above are set to page on a burn,
+not at the SLO boundary itself.
 
 ## Roadmap
 

--- a/docs/monitoring/alert-rules.yml
+++ b/docs/monitoring/alert-rules.yml
@@ -1,0 +1,94 @@
+# MultiWA Prometheus alerting rules.
+#
+# Load these by adding to prometheus.yml:
+#   rule_files:
+#     - alert-rules.yml
+# and point Prometheus at an Alertmanager (see alertmanager.yml).
+#
+# These cover the failure modes that actually took MultiWA down in production and
+# were invisible until a human noticed hours later: a WhatsApp profile dropping,
+# the outgoing send path wedging (a stale WhatsApp Web build), and API/worker
+# outages — plus HTTP error-rate / latency SLO burn.
+#
+# Metrics used (exposed by the api at /metrics, worker at :3002/metrics):
+#   multiwa_connected_profiles           gauge
+#   multiwa_messages_sent_total{type}    counter
+#   multiwa_messages_failed_total{type}  counter
+#   http_requests_total{method,route,status}          counter
+#   http_request_duration_seconds_bucket{...,le}      histogram
+#   up{job}                              Prometheus target health
+
+groups:
+  - name: multiwa-availability
+    rules:
+      - alert: MultiWAApiDown
+        expr: up{job="multiwa-api"} == 0
+        for: 1m
+        labels: { severity: critical }
+        annotations:
+          summary: "MultiWA API is down"
+          description: "The multiwa-api scrape target has been unreachable for over 1 minute."
+
+      - alert: MultiWAWorkerDown
+        expr: up{job="multiwa-worker"} == 0
+        for: 2m
+        labels: { severity: critical }
+        annotations:
+          summary: "MultiWA worker is down"
+          description: "The multiwa-worker scrape target has been unreachable for over 2 minutes; queued jobs (webhooks, broadcasts, automations) are not being processed."
+
+  - name: multiwa-whatsapp
+    rules:
+      # The exact 'profiles look disconnected' shape of the disk-full and
+      # WhatsApp-Web-version incidents.
+      - alert: WhatsAppAllProfilesDisconnected
+        expr: multiwa_connected_profiles == 0
+        for: 3m
+        labels: { severity: critical }
+        annotations:
+          summary: "No WhatsApp profiles are connected"
+          description: "multiwa_connected_profiles has been 0 for over 3 minutes — the gateway can neither send nor receive. Check the engine/session state."
+
+      # The exact 'sending dead' incident: a profile is connected (so we still
+      # receive) but nothing goes out — the engine send path is wedged.
+      - alert: WhatsAppSendingStalled
+        expr: (sum(rate(multiwa_messages_sent_total[10m])) == 0) and (multiwa_connected_profiles > 0)
+        for: 20m
+        labels: { severity: critical }
+        annotations:
+          summary: "Outgoing WhatsApp messages have stalled"
+          description: "A profile is connected but no messages have been sent for 20 minutes — the engine send path may be wedged (e.g. a stale pinned WhatsApp Web version). Sends fail while receives keep working."
+
+      - alert: WhatsAppHighSendFailureRate
+        expr: |
+          sum(rate(multiwa_messages_failed_total[10m]))
+            / clamp_min(sum(rate(multiwa_messages_sent_total[10m])) + sum(rate(multiwa_messages_failed_total[10m])), 1)
+            > 0.2
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: "WhatsApp send failure rate above 20%"
+          description: "Over 20% of attempted sends failed in the last 10 minutes (value: {{ $value | humanizePercentage }})."
+
+  - name: multiwa-http-slo
+    rules:
+      # SLO: < 1% of requests return 5xx (availability). Alert on a 5% burn.
+      - alert: HighHttpErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+            / clamp_min(sum(rate(http_requests_total[5m])), 1)
+            > 0.05
+        for: 5m
+        labels: { severity: warning }
+        annotations:
+          summary: "HTTP 5xx error rate above 5%"
+          description: "The API is serving over 5% 5xx for 5 minutes (value: {{ $value | humanizePercentage }}) — SLO burn."
+
+      # SLO: p95 latency < 500ms. Alert when p95 exceeds 1s for a sustained window.
+      - alert: HighHttpLatencyP95
+        expr: histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 1
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: "HTTP p95 latency above 1s"
+          description: "95th-percentile request latency has exceeded 1 second for 10 minutes (value: {{ $value }}s)."

--- a/docs/monitoring/alertmanager.yml
+++ b/docs/monitoring/alertmanager.yml
@@ -1,0 +1,37 @@
+# Sample Alertmanager config for MultiWA.
+#
+# Point Prometheus at Alertmanager (see prometheus.yml `alerting:` block) and run
+# Alertmanager with this file. Replace the receiver webhook/email with your own
+# (Slack, PagerDuty, Opsgenie, a MultiWA webhook back into WhatsApp, etc.).
+# `critical` alerts page immediately; `warning` alerts are grouped and slower.
+
+route:
+  receiver: default
+  group_by: ['alertname']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity = "critical"
+      receiver: pager
+      group_wait: 10s
+      repeat_interval: 1h
+
+receivers:
+  - name: default
+    webhook_configs:
+      # Replace with your own sink (Slack incoming webhook, a MultiWA webhook, …).
+      - url: "http://example.invalid/alertmanager"
+        send_resolved: true
+
+  - name: pager
+    webhook_configs:
+      - url: "http://example.invalid/alertmanager/critical"
+        send_resolved: true
+
+inhibit_rules:
+  # If everything is down (API down), don't also page for the derived WhatsApp alerts.
+  - source_matchers: [alertname = "MultiWAApiDown"]
+    target_matchers: [severity = "critical"]
+    equal: ['service']

--- a/docs/monitoring/prometheus.yml
+++ b/docs/monitoring/prometheus.yml
@@ -10,6 +10,17 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# Alerting rules (availability, WhatsApp connectivity / send-stall, HTTP SLO burn).
+rule_files:
+  - alert-rules.yml
+
+# Point at an Alertmanager (see alertmanager.yml). Comment out if you only want
+# recording/evaluation without paging.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
 scrape_configs:
   - job_name: multiwa-api
     metrics_path: /metrics


### PR DESCRIPTION
Closes the audit's observability P1: **metrics are collected but nothing pages** — so the WhatsApp-version "sending dead" outage and profile-disconnect incidents this session were invisible until a human noticed hours later.

## Adds
- **`alert-rules.yml`** — Prometheus rules for the real failure modes:

  | Alert | Fires when | Sev |
  |---|---|---|
  | `MultiWAApiDown` / `MultiWAWorkerDown` | target unreachable | critical |
  | `WhatsAppAllProfilesDisconnected` | `multiwa_connected_profiles == 0` (3m) | critical |
  | `WhatsAppSendingStalled` | profile connected but **0 sends for 20m** — the "sending dead" incident | critical |
  | `WhatsAppHighSendFailureRate` | failure ratio > 20% (10m) | warning |
  | `HighHttpErrorRate` / `HighHttpLatencyP95` | 5xx > 5% / p95 > 1s | warning |

- **`alertmanager.yml`** — sample routing (critical→page, warning→grouped), inhibit rules.
- **`prometheus.yml`** — wires `rule_files` + an `alerting:` block.
- **README** — alert table + target **SLOs** (availability < 1% 5xx, p95 < 500ms, WhatsApp send non-zero).

Config/docs only, no code change. These rules would have **paged** during both incidents instead of leaving them silent.