### PR TITLE
feat(calls): per-profile auto-reject incoming WhatsApp calls (+ optional reply)

### DIFF
--- a/apps/api/src/modules/messages/auto-reject-call.spec.ts
+++ b/apps/api/src/modules/messages/auto-reject-call.spec.ts
@@ -1,0 +1,56 @@
+// Tests for the shared auto-reject-call helper used by both engine-manager forks.
+import { describe, it, expect, vi } from 'vitest';
+import { handleAutoRejectCall } from '@multiwa/engine-runtime';
+
+const call = { id: 'call-1', from: '628123@c.us' };
+
+describe('handleAutoRejectCall', () => {
+  it('does nothing when auto-reject is off', async () => {
+    const rejectCall = vi.fn();
+    const ok = await handleAutoRejectCall(call, { autoRejectCalls: false }, { rejectCall });
+    expect(ok).toBe(false);
+    expect(rejectCall).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no call id', async () => {
+    const rejectCall = vi.fn();
+    const ok = await handleAutoRejectCall({ from: 'x' }, { autoRejectCalls: true }, { rejectCall });
+    expect(ok).toBe(false);
+    expect(rejectCall).not.toHaveBeenCalled();
+  });
+
+  it('rejects the call (no reply) when enabled without a message', async () => {
+    const rejectCall = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn();
+    const ok = await handleAutoRejectCall(call, { autoRejectCalls: true }, { rejectCall, sendText });
+    expect(ok).toBe(true);
+    expect(rejectCall).toHaveBeenCalledWith('call-1');
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it('rejects and replies to the caller when a message is configured', async () => {
+    const rejectCall = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    await handleAutoRejectCall(
+      call,
+      { autoRejectCalls: true, autoRejectCallMessage: '  Maaf, panggilan tidak dilayani.  ' },
+      { rejectCall, sendText },
+    );
+    expect(rejectCall).toHaveBeenCalledWith('call-1');
+    // trimmed message, sent to the caller
+    expect(sendText).toHaveBeenCalledWith('628123@c.us', 'Maaf, panggilan tidak dilayani.');
+  });
+
+  it('still resolves true if the reply send throws (reject already succeeded)', async () => {
+    const rejectCall = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockRejectedValue(new Error('send failed'));
+    const warn = vi.fn();
+    const ok = await handleAutoRejectCall(
+      call,
+      { autoRejectCalls: true, autoRejectCallMessage: 'hi' },
+      { rejectCall, sendText, logger: { warn } },
+    );
+    expect(ok).toBe(true);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/profiles/dto/index.ts
+++ b/apps/api/src/modules/profiles/dto/index.ts
@@ -59,6 +59,16 @@ export class UpdateProfileDto {
   @IsString()
   webhookSecret?: string;
 
+  @ApiPropertyOptional({ description: 'Auto-reject incoming voice/video calls for this profile.' })
+  @IsOptional()
+  @IsBoolean()
+  autoRejectCalls?: boolean;
+
+  @ApiPropertyOptional({ description: 'Optional message sent to the caller after auto-rejecting a call. Blank = reject silently.' })
+  @IsOptional()
+  @IsString()
+  autoRejectCallMessage?: string;
+
   @ApiPropertyOptional({
     example: 1500,
     description: 'Minimum delay (ms) enforced between outbound messages for this profile (anti-ban pacing).',

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -1215,6 +1215,20 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           }
         } catch (error) {
           this.logger.warn(`Failed to update message ack: ${(error as Error).message}`);
+        }
+      },
+      onCall: async (call) => {
+        try {
+          const p = await prisma.profile.findUnique({ where: { id: profileId }, select: { settings: true } });
+          const eng = this.getEngine(profileId);
+          if (!eng) return;
+          await handleAutoRejectCall(call, (p?.settings ?? {}) as any, {
+            rejectCall: (id) => eng.rejectCall(id),
+            sendText: async (to, text) => { await eng.sendText(to, text); },
+            logger: { log: (m) => this.logger.log(m), warn: (m) => this.logger.warn(m) },
+          });
+        } catch (e) {
+          this.logger.warn(`onCall handler failed: ${(e as Error).message}`);
         }
       },
     };

--- a/apps/api/src/modules/profiles/profiles.service.ts
+++ b/apps/api/src/modules/profiles/profiles.service.ts
@@ -121,6 +121,14 @@ export class ProfilesService {
       if (dto.warmupEnabled && !wasEnabled) data.warmupStartedAt = new Date();
     }
     if (dto.engine !== undefined) data.engine = dto.engine;
+    // Auto-reject-call config lives in the settings JSON — merge so we never clobber
+    // other settings keys.
+    if (dto.autoRejectCalls !== undefined || dto.autoRejectCallMessage !== undefined) {
+      const settings = { ...(((existing as any).settings as Record<string, unknown>) || {}) };
+      if (dto.autoRejectCalls !== undefined) settings.autoRejectCalls = dto.autoRejectCalls;
+      if (dto.autoRejectCallMessage !== undefined) settings.autoRejectCallMessage = dto.autoRejectCallMessage;
+      data.settings = settings;
+    }
 
     const updated = await prisma.profile.update({ where: { id }, data });
 

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -1126,6 +1126,20 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           }
         } catch (error) {
           this.logger.warn(`Failed to update message ack: ${(error as Error).message}`);
+        }
+      },
+      onCall: async (call) => {
+        try {
+          const p = await prisma.profile.findUnique({ where: { id: profileId }, select: { settings: true } });
+          const eng = this.getEngine(profileId);
+          if (!eng) return;
+          await handleAutoRejectCall(call, (p?.settings ?? {}) as any, {
+            rejectCall: (id) => eng.rejectCall(id),
+            sendText: async (to, text) => { await eng.sendText(to, text); },
+            logger: { log: (m) => this.logger.log(m), warn: (m) => this.logger.warn(m) },
+          });
+        } catch (e) {
+          this.logger.warn(`onCall handler failed: ${(e as Error).message}`);
         }
       },
     };

--- a/packages/engine-runtime/src/auto-reject-call.ts
+++ b/packages/engine-runtime/src/auto-reject-call.ts
@@ -1,0 +1,44 @@
+// MultiWA Gateway - Auto-reject incoming calls (shared engine runtime)
+// packages/engine-runtime/src/auto-reject-call.ts
+//
+// Shared by the api and worker engine-manager forks: when a profile has
+// `autoRejectCalls` enabled, incoming WhatsApp voice/video calls are rejected,
+// and an optional configured message is sent back to the caller.
+
+export interface AutoRejectCallSettings {
+  autoRejectCalls?: boolean;
+  /** Optional reply sent to the caller after rejecting. Blank = reject silently. */
+  autoRejectCallMessage?: string;
+}
+
+export interface AutoRejectCallDeps {
+  rejectCall: (callId: string) => Promise<void>;
+  sendText?: (to: string, text: string) => Promise<void>;
+  logger?: { log?: (m: string) => void; warn?: (m: string) => void };
+}
+
+/**
+ * Reject an incoming call when the profile opted in, then optionally reply.
+ * Returns true if the call was rejected, false if auto-reject was off / no id.
+ * A failed reply is swallowed (the reject already succeeded).
+ */
+export async function handleAutoRejectCall(
+  call: { id?: string; from?: string },
+  settings: AutoRejectCallSettings | null | undefined,
+  deps: AutoRejectCallDeps,
+): Promise<boolean> {
+  if (!settings?.autoRejectCalls || !call?.id) return false;
+
+  await deps.rejectCall(call.id);
+  deps.logger?.log?.(`Auto-rejected call ${call.id} from ${call.from ?? 'unknown'}`);
+
+  const msg = settings.autoRejectCallMessage?.trim();
+  if (msg && deps.sendText && call.from) {
+    try {
+      await deps.sendText(call.from, msg);
+    } catch (e: any) {
+      deps.logger?.warn?.(`auto-reject reply failed: ${e?.message ?? e}`);
+    }
+  }
+  return true;
+}

--- a/packages/engine-runtime/src/index.ts
+++ b/packages/engine-runtime/src/index.ts
@@ -13,3 +13,4 @@ export * from './push.service';
 export * from './ack-status';
 export * from './db-retry';
 export * from './inbound-media';
+export * from './auto-reject-call';

--- a/packages/engines/src/adapters/baileys.adapter.ts
+++ b/packages/engines/src/adapters/baileys.adapter.ts
@@ -34,6 +34,8 @@ export class BaileysAdapter implements IWhatsAppEngine {
   };
   private currentQR: string | null = null;
   private qrCallbacks: ((qr: string) => void)[] = [];
+  // Caller JID per call id — Baileys' rejectCall(id, from) needs both.
+  private callFrom = new Map<string, string>();
   private authState: any = null;
   private connectionRetryCount: number = 0;
   private maxConnectionRetries: number = 3;
@@ -151,6 +153,21 @@ export class BaileysAdapter implements IWhatsAppEngine {
     // a reconnect or process messages against an obsolete session.
     const sock = this.socket;
     const isCurrent = () => this.socket === sock;
+
+    // Incoming voice/video call — surface the initial offer for auto-reject.
+    this.socket.ev.on('call', (calls: any[]) => {
+      if (!isCurrent()) return;
+      for (const call of calls || []) {
+        if (call?.status && call.status !== 'offer') continue;
+        if (call?.id && call?.from) this.callFrom.set(call.id, call.from);
+        this.config?.onCall?.({
+          id: call?.id,
+          from: call?.from || '',
+          isVideo: !!call?.isVideo,
+          isGroup: (call?.from || '').includes('@g.us'),
+        });
+      }
+    });
 
     // Connection update
     this.socket.ev.on('connection.update', async (update) => {
@@ -580,6 +597,14 @@ export class BaileysAdapter implements IWhatsAppEngine {
       console.error('[Baileys] Send presence update error:', error);
       // Non-critical — don't throw
     }
+  }
+
+  async rejectCall(callId: string): Promise<void> {
+    const from = this.callFrom.get(callId);
+    if (this.socket && from) {
+      await this.socket.rejectCall(callId, from);
+    }
+    this.callFrom.delete(callId);
   }
 
   async markAsRead(chatId: string, messageIds?: string[]): Promise<void> {

--- a/packages/engines/src/adapters/mock.adapter.ts
+++ b/packages/engines/src/adapters/mock.adapter.ts
@@ -145,6 +145,10 @@ export class MockAdapter implements IWhatsAppEngine {
     return { success: true, messageId };
   }
 
+  async rejectCall(callId: string): Promise<void> {
+    console.log(`[Mock] Reject call ${callId}`);
+  }
+
   async sendPoll(
     to: string,
     poll: PollOptions,

--- a/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
+++ b/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
@@ -26,6 +26,8 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
   };
   private currentQR: string | null = null;
   private qrCallbacks: ((qr: string) => void)[] = [];
+  // Raw whatsapp-web.js Call objects, keyed by id, so rejectCall() can act on them.
+  private calls = new Map<string, any>();
 
   async initialize(config: EngineConfig): Promise<void> {
     this.config = config;
@@ -169,10 +171,29 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
       };
       
       this.config?.onMessageAck?.(
-        message.id._serialized, 
+        message.id._serialized,
         statusMap[ack] || 'unknown'
       );
     });
+
+    // Incoming voice/video call — surface it so the engine-manager can auto-reject.
+    this.client.on('call', (call: any) => {
+      if (call?.id) this.calls.set(call.id, call);
+      this.config?.onCall?.({
+        id: call?.id,
+        from: call?.from || call?.peerJid || '',
+        isVideo: !!call?.isVideo,
+        isGroup: !!call?.isGroup,
+      });
+    });
+  }
+
+  async rejectCall(callId: string): Promise<void> {
+    const call = this.calls.get(callId);
+    if (call?.reject) {
+      await call.reject();
+    }
+    this.calls.delete(callId);
   }
 
   async connect(): Promise<void> {

--- a/packages/engines/src/types.ts
+++ b/packages/engines/src/types.ts
@@ -16,6 +16,17 @@ export interface EngineConfig {
   onDisconnected?: (reason: string) => void;
   onMessage?: (message: any) => void;
   onMessageAck?: (messageId: string, status: string) => void;
+  onCall?: (call: IncomingCall) => void;
+}
+
+/** Normalized incoming WhatsApp call, engine-agnostic. */
+export interface IncomingCall {
+  /** Engine call id, passed back to `rejectCall`. */
+  id: string;
+  /** Caller JID (e.g. `628xxx@c.us`). */
+  from: string;
+  isVideo: boolean;
+  isGroup: boolean;
 }
 
 export interface SendMessageOptions {
@@ -158,6 +169,10 @@ export interface IWhatsAppEngine {
   
   // Message management
   deleteForEveryone(chatId: string, messageId: string): Promise<void>;
+
+  // Calls
+  /** Reject an incoming call by its engine id (see `EngineConfig.onCall`). */
+  rejectCall(callId: string): Promise<void>;
 
   // QR Code
   getQRCode(): Promise<string | null>;


### PR DESCRIPTION
Requested feature: **auto-reject incoming WhatsApp calls** per profile, with an optional reply to the caller.

## How it works
- **Engine interface** — `EngineConfig.onCall` (normalized `IncomingCall`) + `rejectCall(callId)` on `IWhatsAppEngine`.
  - **whatsapp-web.js** (active in prod): `client.on('call')` → stores the Call, `rejectCall` calls `call.reject()`.
  - **baileys**: `ev.on('call')` → stores the caller JID, `rejectCall` calls `sock.rejectCall(id, from)`.
  - **mock**: no-op.
- **Shared helper** `handleAutoRejectCall(call, settings, deps)` in `@multiwa/engine-runtime` — used by **both** engine-manager forks (no duplication). Rejects when `autoRejectCalls` is on, then sends `autoRejectCallMessage` if set; a failed reply is swallowed.
- **Both engine-managers** register an `onCall` handler that reads the profile's settings and rejects via the live engine.
- **API** — `PUT /profiles/:id` accepts `autoRejectCalls` (bool) and `autoRejectCallMessage` (string), merged into `Profile.settings` (other keys preserved).

## Usage
```bash
PUT /api/v1/profiles/:id
{ "autoRejectCalls": true, "autoRejectCallMessage": "Maaf, panggilan tidak dilayani. Silakan chat." }
```

## Tests
`auto-reject-call.spec.ts` (5): off→no-op, no-id→no-op, reject-without-reply, reject-and-reply (trimmed, to caller), reply-failure still succeeds. api + worker typecheck + build clean.

Takes effect on the next wagw redeploy. An admin-dashboard toggle can follow.