### PR TITLE
feat(security): allow creating expiring API keys (expiresInDays)

### DIFF
--- a/apps/api/src/modules/api-keys/api-keys.controller.ts
+++ b/apps/api/src/modules/api-keys/api-keys.controller.ts
@@ -31,9 +31,9 @@ export class ApiKeysController {
   @ApiValidationError()
   async create(
     @Req() req: any,
-    @Body() body: { name: string; permissions?: string[] },
+    @Body() body: { name: string; permissions?: string[]; expiresInDays?: number },
   ) {
-    const result = await this.service.create(req.user.id, body.name, body.permissions);
+    const result = await this.service.create(req.user.id, body.name, body.permissions, body.expiresInDays);
     this.auditService.log({
       action: AuditAction.APIKEY_CREATE,
       userId: req.user.id,

--- a/apps/api/src/modules/api-keys/api-keys.service.spec.ts
+++ b/apps/api/src/modules/api-keys/api-keys.service.spec.ts
@@ -52,6 +52,22 @@ describe('ApiKeysService', () => {
       expect(result.name).toBe('CI token');
     });
 
+    it('creates a non-expiring key by default', async () => {
+      await service.create('user-1', 'k');
+      const persisted = vi.mocked(prisma.apiKey.create).mock.calls[0][0].data as any;
+      expect(persisted.expiresAt).toBeNull();
+    });
+
+    it('sets expiresAt ~N days out when expiresInDays is given', async () => {
+      const before = Date.now();
+      await service.create('user-1', 'k', [], 7);
+      const persisted = vi.mocked(prisma.apiKey.create).mock.calls[0][0].data as any;
+      expect(persisted.expiresAt).toBeInstanceOf(Date);
+      const ms = persisted.expiresAt.getTime() - before;
+      expect(ms).toBeGreaterThan(6.9 * 24 * 3600 * 1000);
+      expect(ms).toBeLessThan(7.1 * 24 * 3600 * 1000);
+    });
+
     it('persists ONLY a sha256 hash of the raw key — never the raw secret', async () => {
       const result = await service.create('user-1', 'CI token');
 

--- a/apps/api/src/modules/api-keys/api-keys.service.ts
+++ b/apps/api/src/modules/api-keys/api-keys.service.ts
@@ -8,11 +8,19 @@ import * as crypto from 'crypto';
 @Injectable()
 export class ApiKeysService {
   // Generate a new API key
-  async create(userId: string, name: string, permissions: string[] = []) {
+  async create(userId: string, name: string, permissions: string[] = [], expiresInDays?: number) {
     // Generate a random API key with prefix
     const rawKey = `mwa_${crypto.randomBytes(32).toString('hex')}`;
     const prefix = rawKey.substring(0, 12);
     const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
+
+    // Optional expiry: keys are non-expiring by default, but callers may request a
+    // TTL. The api-key strategy already rejects an expired key (`expiresAt` in the
+    // past); this lets operators actually mint short-lived keys.
+    const days = Number(expiresInDays);
+    const expiresAt = Number.isFinite(days) && days > 0
+      ? new Date(Date.now() + days * 24 * 60 * 60 * 1000)
+      : null;
 
     const apiKey = await prisma.apiKey.create({
       data: {
@@ -21,6 +29,7 @@ export class ApiKeysService {
         keyHash,
         prefix,
         permissions,
+        expiresAt,
       },
     });
 
@@ -31,6 +40,7 @@ export class ApiKeysService {
       key: rawKey,
       prefix: apiKey.prefix,
       permissions: apiKey.permissions,
+      expiresAt: apiKey.expiresAt,
       createdAt: apiKey.createdAt,
     };
   }


### PR DESCRIPTION
Audit security P2: the api-key strategy already **rejects** expired keys (`expiresAt` in the past), but `create()` never **set** `expiresAt` — so every issued key was non-expiring and operators couldn't mint a short-lived one.

## Change
- `ApiKeysService.create(userId, name, permissions, expiresInDays?)` — when `expiresInDays > 0`, sets `expiresAt = now + N days`; the create response returns `expiresAt`.
- `POST /api/v1/api-keys` accepts `expiresInDays` in the body and passes it through.
- Default unchanged: no `expiresInDays` → `expiresAt: null` → never expires (backward-compatible).

## Tests
+2 cases in `api-keys.service.spec.ts` (now 11): default → non-expiring; `expiresInDays: 7` → `expiresAt` ~7 days out. api typecheck + build pass.