### PR TITLE
fix(ci): SDK/n8n publish workflows need Node 22 (npm@latest = npm 12)

### DIFF
--- a/.github/workflows/publish-n8n-node.yml
+++ b/.github/workflows/publish-n8n-node.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
           cache: pnpm
 

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
           cache: pnpm
 


### PR DESCRIPTION
The npm SDK + n8n publish workflows upgrade npm via `npm install -g npm@latest` for OIDC support, but `npm@latest` is now **npm 12**, which requires Node `^22.22.2 || ^24.15 || >=26` — the workflows ran on **Node 20**, so the upgrade step failed with EBADENGINE (both publishes failed; PyPI succeeded). Bumps both workflows to `node-version: 22`. No package/version change.