### PR TITLE
docs: mark PyPI (multiwa) + npm (n8n-nodes-multiwa) as published

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,16 +233,19 @@ curl -X POST http://localhost:3333/api/v1/accounts/YOUR_ACCOUNT_ID/profiles/YOUR
 
 ## 📦 SDKs
 
-Official SDKs are included in the repository today. Registry publishing
-(NPM, PyPI, Packagist) is tracked as a release follow-up — until those
-registries are verified, install from this repo or via the local
+The Python SDK is published on PyPI (`pip install multiwa`) and the n8n
+community node on npm (`npm install n8n-nodes-multiwa`). The TypeScript and
+PHP SDKs are included in the repository today; their registry publishing
+(npm `@multiwa/sdk`, Packagist) is tracked as a release follow-up — until
+those registries are verified, install them from this repo or via the local
 workspace path.
 
 | Language | Source | Status |
 |----------|--------|--------|
 | TypeScript/Node.js | [`packages/sdk`](packages/sdk) | Included in repository · registry publishing pending |
-| Python | [`packages/sdk-python`](packages/sdk-python) | Included in repository · registry publishing pending |
+| Python | [`packages/sdk-python`](packages/sdk-python) | Published on PyPI · `pip install multiwa` |
 | PHP | [`packages/sdk-php`](packages/sdk-php) | Included in repository · registry publishing pending |
+| n8n community node | [`packages/n8n-nodes-multiwa`](packages/n8n-nodes-multiwa) | Published on npm · `npm install n8n-nodes-multiwa` |
 
 ### TypeScript SDK Example
 

--- a/docs/13-sdk-python.md
+++ b/docs/13-sdk-python.md
@@ -6,16 +6,9 @@ Official Python SDK for MultiWA.
 
 ## Installation
 
-Registry publishing is pending — `multiwa` is not yet on PyPI. Install from this
-repository meanwhile:
-
 ```bash
-pip install ./packages/sdk-python
-# or straight from GitHub:
-pip install "git+https://github.com/ribato22/MultiWA.git#subdirectory=packages/sdk-python"
+pip install multiwa
 ```
-
-Once it is published, `pip install multiwa` will work directly.
 
 ---
 

--- a/docs/15-n8n-integration.md
+++ b/docs/15-n8n-integration.md
@@ -8,14 +8,9 @@ Use MultiWA with n8n for powerful workflow automation.
 
 ### n8n Community Nodes
 
-Registry publishing is pending — `n8n-nodes-multiwa` is not yet on npm. Install from
-this repository meanwhile:
-
 ```bash
-npm install ./packages/n8n-nodes-multiwa
+npm install n8n-nodes-multiwa
 ```
-
-Once it is published, `npm install n8n-nodes-multiwa` will work directly.
 
 Or install via n8n UI:
 1. Go to **Settings** → **Community Nodes**

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Welcome to the MultiWA documentation. MultiWA is a free, open-source WhatsApp AP
 - **Python SDK source**: [`packages/sdk-python`](../packages/sdk-python)
 - **PHP SDK source**: [`packages/sdk-php`](../packages/sdk-php)
 
-> SDKs ship as in-repo packages today. The public registry entries (`@multiwa/sdk`, `multiwa-sdk`, `multiwa/sdk`) are tracked as a release follow-up; until then, install from this repository or via the package's local path.
+> The Python SDK is live on PyPI (`pip install multiwa`) and the n8n community node on npm (`npm install n8n-nodes-multiwa`). The TypeScript (`@multiwa/sdk`) and PHP (`multiwa/sdk`) SDKs still ship as in-repo packages; their public registry entries are tracked as a release follow-up — until then, install them from this repository or via the package's local path.
 
 ---
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -53,8 +53,11 @@ everything that needs human attention.
 - [ ] Docker examples use `http://localhost:3333` (port 3333).
 - [ ] Local-dev examples use `http://localhost:3000` (port 3000).
 - [ ] No SDK install snippet implies a registry release that has not
-      actually happened. Until publishing is verified, every SDK README
-      must say "Included in repository · registry publishing pending."
+      actually happened. Published packages use their real install command
+      (Python: `pip install multiwa`; n8n node: `npm install
+      n8n-nodes-multiwa`). SDKs still awaiting a registry (TypeScript
+      `@multiwa/sdk`, PHP `multiwa/sdk`) must say "Included in repository ·
+      registry publishing pending."
 
 ## 5. Docker Quick Start Smoke Test
 


### PR DESCRIPTION
## What

The Python SDK is now **live on PyPI** (\`pip install multiwa\`) and the n8n community node is **live on npm** (\`npm install n8n-nodes-multiwa\`). This reverts the interim "publishing pending / install from repo" disclaimers to the real registry install commands, and reflects the live status everywhere it was tracked.

## Changes

- **README.md** — SDK table: Python → *Published on PyPI · \`pip install multiwa\`*; new row for the n8n node (*Published on npm*). Intro paragraph updated. TypeScript (\`@multiwa/sdk\`) and PHP (\`multiwa/sdk\`) stay *registry publishing pending*.
- **docs/13-sdk-python.md** — install snippet back to \`pip install multiwa\`.
- **docs/15-n8n-integration.md** — install snippet back to \`npm install n8n-nodes-multiwa\`.
- **docs/README.md** — index SDK note reflects the two live registries.
- **docs/release-checklist.md** — snippet-audit item now allows real install commands for published packages, keeping the pending disclaimer only for the not-yet-published TS/PHP SDKs.

## Not in scope

\`@multiwa/sdk\` (TypeScript) is **not** yet on npm — the \`@multiwa\` npm org still needs to be created before that scoped package can publish. Its docs deliberately remain marked pending, so nothing here overstates the release state.