### PR TITLE
fix(security): clear 8 open CodeQL alerts (log-injection + unused import)

### DIFF
--- a/apps/admin/src/app/dashboard/messages/page.tsx
+++ b/apps/admin/src/app/dashboard/messages/page.tsx
@@ -19,7 +19,6 @@ import {
   BarChart3,
   MessageSquare,
   FileUp,
-  Search,
   Clock,
   Loader2,
   AlertCircle,

--- a/packages/chatwoot-bridge/src/index.ts
+++ b/packages/chatwoot-bridge/src/index.ts
@@ -9,7 +9,10 @@
 import express from 'express';
 import axios, { AxiosInstance } from 'axios';
 
-const cleanLog = (v: unknown) => String(v ?? '').replace(/\p{Cc}/gu, ' ');
+// Strip CR/LF first (the CodeQL-recognized log-injection barrier), then any
+// remaining Unicode control chars, before interpolating untrusted values into logs.
+const cleanLog = (v: unknown) =>
+  String(v ?? '').replace(/[\r\n]/g, ' ').replace(/\p{Cc}/gu, ' ');
 
 // ─── Configuration ────────────────────────────────────────────────────────
 

--- a/scripts/webhook-receiver.js
+++ b/scripts/webhook-receiver.js
@@ -28,7 +28,10 @@
 const http = require("http");
 const crypto = require("crypto");
 
-const cleanLog = (v) => String(v ?? "").replace(/\p{Cc}/gu, " ");
+// Strip CR/LF first (the CodeQL-recognized log-injection barrier), then any
+// remaining Unicode control chars, before logging untrusted request data.
+const cleanLog = (v) =>
+  String(v ?? "").replace(/[\r\n]/g, " ").replace(/\p{Cc}/gu, " ");
 
 // === Configuration ===
 const PORT = parseInt(process.argv[2] || "9999", 10);


### PR DESCRIPTION
## What

Clears all 8 open code-scanning alerts on `main`.

### Log injection (7 alerts — `js/log-injection`)
- `scripts/webhook-receiver.js` (lines 261–292, ×5)
- `packages/chatwoot-bridge/src/index.ts` (lines 118, 147, ×2)

Both files already funnel untrusted values through a `cleanLog()` helper that stripped Unicode control characters with `.replace(/\p{Cc}/gu, ' ')`. That **does** remove CR/LF at runtime, but CodeQL's `js/log-injection` query doesn't recognise the `\p{Cc}` Unicode-property class as a newline barrier, so the taint path stayed "open".

Fix: prepend an explicit `.replace(/[\r\n]/g, ' ')` — the sanitizer pattern CodeQL recognises — ahead of the existing control-char strip. Runtime behaviour is unchanged (newlines were already collapsed); the taint tracker now sees a barrier.

### Unused import (1 alert — `js/unused-local-variable`)
- `apps/admin/src/app/dashboard/messages/page.tsx:7` — "Unused import `Search`."

The lucide `Search` icon was imported but never rendered (the only other `Search` occurrences are placeholder **strings** like `"Search contacts…"`). Removed the import.

## Verification
- No runtime change: `cleanLog()` output is identical for all inputs (CR/LF were already replaced by `\p{Cc}`; the new step just makes the barrier explicit).
- CodeQL re-runs on this PR — expect the 8 alerts to resolve on merge.