### PR TITLE
docs: mark @multiwa/sdk (TypeScript) as published on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,21 +233,24 @@ curl -X POST http://localhost:3333/api/v1/accounts/YOUR_ACCOUNT_ID/profiles/YOUR
 
 ## 📦 SDKs
 
-The Python SDK is published on PyPI (`pip install multiwa`) and the n8n
-community node on npm (`npm install n8n-nodes-multiwa`). The TypeScript and
-PHP SDKs are included in the repository today; their registry publishing
-(npm `@multiwa/sdk`, Packagist) is tracked as a release follow-up — until
-those registries are verified, install them from this repo or via the local
-workspace path.
+The TypeScript SDK is published on npm (`npm install @multiwa/sdk`), the
+Python SDK on PyPI (`pip install multiwa`), and the n8n community node on npm
+(`npm install n8n-nodes-multiwa`). The PHP SDK is included in the repository
+today; its Packagist publishing is tracked as a release follow-up — until then,
+install it from this repo or via the local workspace path.
 
 | Language | Source | Status |
 |----------|--------|--------|
-| TypeScript/Node.js | [`packages/sdk`](packages/sdk) | Included in repository · registry publishing pending |
+| TypeScript/Node.js | [`packages/sdk`](packages/sdk) | Published on npm · `npm install @multiwa/sdk` |
 | Python | [`packages/sdk-python`](packages/sdk-python) | Published on PyPI · `pip install multiwa` |
 | PHP | [`packages/sdk-php`](packages/sdk-php) | Included in repository · registry publishing pending |
 | n8n community node | [`packages/n8n-nodes-multiwa`](packages/n8n-nodes-multiwa) | Published on npm · `npm install n8n-nodes-multiwa` |
 
 ### TypeScript SDK Example
+
+```bash
+npm install @multiwa/sdk
+```
 
 ```typescript
 import { MultiWAClient } from '@multiwa/sdk';

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Welcome to the MultiWA documentation. MultiWA is a free, open-source WhatsApp AP
 - **Python SDK source**: [`packages/sdk-python`](../packages/sdk-python)
 - **PHP SDK source**: [`packages/sdk-php`](../packages/sdk-php)
 
-> The Python SDK is live on PyPI (`pip install multiwa`) and the n8n community node on npm (`npm install n8n-nodes-multiwa`). The TypeScript (`@multiwa/sdk`) and PHP (`multiwa/sdk`) SDKs still ship as in-repo packages; their public registry entries are tracked as a release follow-up — until then, install them from this repository or via the package's local path.
+> The TypeScript SDK is live on npm (`npm install @multiwa/sdk`), the Python SDK on PyPI (`pip install multiwa`), and the n8n community node on npm (`npm install n8n-nodes-multiwa`). The PHP SDK (`multiwa/sdk`) still ships as an in-repo package; its Packagist entry is tracked as a release follow-up — until then, install it from this repository or via the package's local path.
 
 ---
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -54,10 +54,10 @@ everything that needs human attention.
 - [ ] Local-dev examples use `http://localhost:3000` (port 3000).
 - [ ] No SDK install snippet implies a registry release that has not
       actually happened. Published packages use their real install command
-      (Python: `pip install multiwa`; n8n node: `npm install
-      n8n-nodes-multiwa`). SDKs still awaiting a registry (TypeScript
-      `@multiwa/sdk`, PHP `multiwa/sdk`) must say "Included in repository ·
-      registry publishing pending."
+      (TypeScript: `npm install @multiwa/sdk`; Python: `pip install multiwa`;
+      n8n node: `npm install n8n-nodes-multiwa`). SDKs still awaiting a
+      registry (PHP `multiwa/sdk`) must say "Included in repository · registry
+      publishing pending."
 
 ## 5. Docker Quick Start Smoke Test
 


### PR DESCRIPTION
## What

`@multiwa/sdk@1.0.0` is now **live on npm** — the `@multiwa` org was created, and the publish workflow shipped it with sigstore build provenance from GitHub Actions. `npm view @multiwa/sdk version` resolves `1.0.0` (dist-tag `latest`).

This flips the last interim "TypeScript SDK — registry publishing pending" disclaimers to the real install command.

## Changes

- **README.md** — SDK table: TypeScript → *Published on npm · `npm install @multiwa/sdk`*; intro paragraph updated; added an `npm install @multiwa/sdk` line above the TS example.
- **docs/README.md** — index SDK note reflects TS live.
- **docs/release-checklist.md** — snippet-audit item lists TS among the real-install packages; only PHP (`multiwa/sdk` on Packagist) remains pending.

## State after this PR

| SDK | Registry | Status |
|-----|----------|--------|
| `@multiwa/sdk` | npm | ✅ live |
| `multiwa` | PyPI | ✅ live |
| `n8n-nodes-multiwa` | npm | ✅ live |
| `multiwa/sdk` | Packagist | ⏳ pending (needs split repo) |