### PR TITLE
fix(security): CodeQL-recognised CR/LF barrier (empty-string replace) for the 7 log-injection alerts

### DIFF
--- a/packages/chatwoot-bridge/src/index.ts
+++ b/packages/chatwoot-bridge/src/index.ts
@@ -9,10 +9,12 @@
 import express from 'express';
 import axios, { AxiosInstance } from 'axios';
 
-// Strip CR/LF first (the CodeQL-recognized log-injection barrier), then any
-// remaining Unicode control chars, before interpolating untrusted values into logs.
+// Drop CR/LF entirely, then collapse any remaining Unicode control chars to a
+// space, before interpolating untrusted values into logs. The empty-string
+// replacement on /[\r\n]/ is the exact form CodeQL recognises as a
+// log-injection barrier (StringReplaceCall.replaces(s, "") with s matching \n).
 const cleanLog = (v: unknown) =>
-  String(v ?? '').replace(/[\r\n]/g, ' ').replace(/\p{Cc}/gu, ' ');
+  String(v ?? '').replace(/[\r\n]/g, '').replace(/\p{Cc}/gu, ' ');
 
 // ─── Configuration ────────────────────────────────────────────────────────
 

--- a/scripts/webhook-receiver.js
+++ b/scripts/webhook-receiver.js
@@ -28,10 +28,12 @@
 const http = require("http");
 const crypto = require("crypto");
 
-// Strip CR/LF first (the CodeQL-recognized log-injection barrier), then any
-// remaining Unicode control chars, before logging untrusted request data.
+// Drop CR/LF entirely, then collapse any remaining Unicode control chars to a
+// space, before logging untrusted request data. The empty-string replacement
+// on /[\r\n]/ is the exact form CodeQL recognises as a log-injection barrier
+// (StringReplaceCall.replaces(s, "") with s matching \n).
 const cleanLog = (v) =>
-  String(v ?? "").replace(/[\r\n]/g, " ").replace(/\p{Cc}/gu, " ");
+  String(v ?? "").replace(/[\r\n]/g, "").replace(/\p{Cc}/gu, " ");
 
 // === Configuration ===
 const PORT = parseInt(process.argv[2] || "9999", 10);


### PR DESCRIPTION
## Why a follow-up to #99

#99 prepended `.replace(/[\r\n]/g, ' ')` to `cleanLog()`, but after the CodeQL re-scan on `main` **all 7 `js/log-injection` alerts stayed open** (line numbers just shifted +3). So that form was not recognised as a barrier.

Reading the CodeQL query source ([`LogInjectionQuery.qll`](https://github.com/github/codeql/blob/main/javascript/ql/lib/semmle/javascript/security/dataflow/LogInjectionQuery.qll)) shows the recognised `String.replace` sanitizer is precisely:

```ql
this.(StringReplaceCall).replaces(s, "") and s.regexpMatch("\\n")
```

Two requirements my #99 fix missed:
1. The **replacement must be the empty string `""`**, not a space `" "`.
2. CodeQL does **not** expand `\p{Cc}` to `\n`, so the original control-char strip was never seen as a barrier either.

## Fix

`cleanLog()` now runs `.replace(/[\r\n]/g, '')` (empty replacement — the recognised barrier) and keeps the `.replace(/\p{Cc}/gu, ' ')` pass afterwards for defence-in-depth on other control chars.

- `scripts/webhook-receiver.js` (5 alerts)
- `packages/chatwoot-bridge/src/index.ts` (2 alerts)

Runtime effect: CR/LF are now removed rather than turned into spaces; every other control char is still collapsed to a space. Injected newlines — the actual attack vector — are eliminated.

Expect all 7 alerts to close on the post-merge CodeQL scan of `main`.