### PR TITLE
fix(security): sanitize conversation.id in Chatwoot bridge logs (last log-injection alert)

### DIFF
--- a/packages/chatwoot-bridge/src/index.ts
+++ b/packages/chatwoot-bridge/src/index.ts
@@ -120,7 +120,7 @@ export class ChatwootBridge {
       }
     );
 
-    console.log(`[Bridge] MultiWA → Chatwoot: ${cleanLog(phoneNumber)} → Conv #${conversation.id}`);
+    console.log(`[Bridge] MultiWA → Chatwoot: ${cleanLog(phoneNumber)} → Conv #${cleanLog(conversation.id)}`);
   }
 
   /**
@@ -149,7 +149,7 @@ export class ChatwootBridge {
       text: content,
     });
 
-    console.log(`[Bridge] Chatwoot → MultiWA: Conv #${conversation.id} → ${cleanLog(phone)}`);
+    console.log(`[Bridge] Chatwoot → MultiWA: Conv #${cleanLog(conversation.id)} → ${cleanLog(phone)}`);
   }
 
   private async findOrCreateChatwootContact(phone: string, name?: string) {


### PR DESCRIPTION
## What

Closes the final open `js/log-injection` alert (#42, `packages/chatwoot-bridge/src/index.ts:152`).

After #101 fixed `cleanLog()`, the CodeQL re-scan dropped 7 → 1. The survivor was **not** the phone value (already cleaned) but the adjacent `conversation.id`: `handleChatwootWebhook` destructures `conversation` directly from the untrusted Chatwoot webhook `payload`, so `Conv #${conversation.id}` was a raw taint sink. (The same interpolation on line 123 was already clean because there `conversation` comes from a Chatwoot **API response**, not the webhook body — which is why that alert closed.)

## Fix

Wrap `conversation.id` with `cleanLog()` on both bridge log lines (123 and 152) — the flagged one plus its twin, for uniformity and defence-in-depth if the source is ever refactored.

Expect code scanning to reach **0 open** on the post-merge `main` scan.