### PR TITLE
fix(worker): stop silently dropping @lid group messages (shared serializeWaMessageId)

### DIFF
--- a/apps/api/src/modules/messages/wa-message-id.spec.ts
+++ b/apps/api/src/modules/messages/wa-message-id.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { serializeWaMessageId } from './wa-message-id';
+import { serializeWaMessageId } from '@multiwa/engine-runtime';
 
 describe('serializeWaMessageId', () => {
   it('passes through a plain string id', () => {

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -18,7 +18,6 @@ import * as path from 'path';
 import * as QRCode from 'qrcode';
 import { RuleEngineService, IncomingMessage } from '../automation/rule-engine.service';
 import { NotificationsService, NotificationType } from '../notifications/notifications.service';
-import { serializeWaMessageId } from './wa-message-id';
 
 
 interface EngineInstance {

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -953,7 +953,7 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
             data: {
               profileId,
               conversationId: conversation.id,
-              messageId: message.id?._serialized || message.id || `in_${Date.now()}`,
+              messageId: serializeWaMessageId(message),
               direction: 'incoming',
               senderJid,
               type: msgType === 'chat' ? 'text' : msgType,

--- a/packages/engine-runtime/src/index.ts
+++ b/packages/engine-runtime/src/index.ts
@@ -14,3 +14,4 @@ export * from './ack-status';
 export * from './db-retry';
 export * from './inbound-media';
 export * from './auto-reject-call';
+export * from './wa-message-id';

--- a/packages/engine-runtime/src/wa-message-id.ts
+++ b/packages/engine-runtime/src/wa-message-id.ts
@@ -1,4 +1,4 @@
-// apps/api/src/modules/profiles/wa-message-id.ts
+// packages/engine-runtime/src/wa-message-id.ts
 //
 // The WhatsApp engine normally hands us a message whose id is the serialized string,
 // but for GROUP messages from @lid participants (and across some engine/serialization
@@ -9,6 +9,10 @@
 // `message.received` webhook fired → downstream bots/integrations stopped responding.
 //
 // This coerces any of those shapes to the canonical serialized id string.
+//
+// Shared between apps/api (ENGINE_HOST=api) and apps/worker (ENGINE_HOST=worker) so
+// both engine-managers serialize inbound ids identically; see
+// architecture/engine-worker-migration-sop.md.
 
 export function serializeWaMessageId(message: any): string {
   const fallback = () => `in_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;


### PR DESCRIPTION
## The bug (live on prod)

`ENGINE_HOST=worker` is the **production** engine path (wagw). The worker's `onMessage` built the persisted id inline:

```ts
messageId: message.id?._serialized || message.id || `in_${Date.now()}`,
```

For **group messages from `@lid` participants** the engine hands us `message.id` as a raw **object** (sometimes with `_serialized` renamed to `$1`, sometimes absent). That expression then passes the *object* into `prisma.message.create({ data: { messageId } })` — a `String` column — throwing `PrismaClientValidationError`. The inbound message is **silently dropped** and **no `message.received` webhook fires**, so bots/integrations stop responding. This is exactly the "bot not replying" class of incident.

The API engine-manager was already fixed (`serializeWaMessageId`), but the worker copy drifted and never got it — a direct consequence of the two ~1300-line engine-managers being maintained as parallel copies.

## The fix

Promote the existing `apps/api/.../wa-message-id.ts` helper into **`@multiwa/engine-runtime`** so both engine-managers serialize ids identically, then:
- worker `onMessage` → `serializeWaMessageId(message)` (the actual fix)
- API import repointed to the package (behavior unchanged)
- spec moved to `apps/api/src/modules/messages/wa-message-id.spec.ts` (co-located with the other engine-runtime helper specs), now importing from the package

`serializeWaMessageId` handles every shape: top-level `_serialized`, string id, `id._serialized`, `id.$1`, and reconstruction from `fromMe_remote_id[_participant]`; falls back to `in_…` only for genuine garbage — never returns a non-string.

## Verification
- `pnpm --filter @multiwa/engine-runtime build` ✓
- `wa-message-id.spec.ts` — 7/7 green (incl. the `@lid` object-id reconstruction case) ✓
- `tsc --noEmit` on **api** and **worker** ✓

## Context
First step of the **fix-first** engine-manager dedup track: a workflow analysis found the two engine-managers are ~75% identical and the worker (prod path) is missing several fixes that only landed in the API copy. This PR fixes the highest-impact one; follow-ups cover the system-message filter, the `connectProfile` UUID guard, and the `onDisconnected` exhaustion alert.