### PR TITLE
fix(worker): drop WhatsApp system/protocol messages (shared isSystemMessageType)

### DIFF
--- a/apps/api/src/modules/messages/messages.service.ts
+++ b/apps/api/src/modules/messages/messages.service.ts
@@ -24,6 +24,7 @@ import {
   effectiveCapForLane,
   isColdCircuitBlocking,
   COLD_CIRCUIT_COOLDOWN_MS,
+  isSystemMessageType,
 } from '@multiwa/engine-runtime';
 import { AppEvents, isWhatsAppRecipient } from '@multiwa/core';
 import {
@@ -624,7 +625,7 @@ export class MessagesService {
       const fetched = await engine.fetchChatMessages(conversation.jid, cap);
       for (const m of fetched || []) {
         const msgType: string = m?.type || 'chat';
-        if (EngineManagerService.SYSTEM_MESSAGE_TYPES.has(msgType)) continue;
+        if (isSystemMessageType(msgType)) continue;
         const messageId: string = m?.id || '';
         if (!messageId) continue;
         const exists = await prisma.message.findFirst({ where: { profileId, messageId }, select: { id: true } });

--- a/apps/api/src/modules/messages/system-message.spec.ts
+++ b/apps/api/src/modules/messages/system-message.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isSystemMessageType, SYSTEM_MESSAGE_TYPES } from '@multiwa/engine-runtime';
+
+describe('isSystemMessageType', () => {
+  it('flags every WhatsApp system/protocol type', () => {
+    for (const t of [
+      'e2e_notification', 'notification_template', 'notification',
+      'call_log', 'gp2', 'ciphertext', 'protocol', 'revoked',
+    ]) {
+      expect(isSystemMessageType(t)).toBe(true);
+    }
+  });
+
+  it('does NOT flag real chat content types', () => {
+    for (const t of ['chat', 'text', 'image', 'video', 'audio', 'ptt', 'document', 'sticker', 'location', 'vcard']) {
+      expect(isSystemMessageType(t)).toBe(false);
+    }
+  });
+
+  it('is null/undefined/empty safe (treated as non-system)', () => {
+    expect(isSystemMessageType(null)).toBe(false);
+    expect(isSystemMessageType(undefined)).toBe(false);
+    expect(isSystemMessageType('')).toBe(false);
+  });
+
+  it('exposes the canonical set (both engine-managers share exactly these)', () => {
+    expect(SYSTEM_MESSAGE_TYPES.size).toBe(8);
+    expect(SYSTEM_MESSAGE_TYPES.has('protocol')).toBe(true);
+    expect(SYSTEM_MESSAGE_TYPES.has('chat')).toBe(false);
+  });
+});

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -95,12 +95,6 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
     this.connectProfile(profileId).catch(err =>
       this.logger.warn(`Ready-timeout reconnect failed for ${profileId}: ${(err as Error).message}`));
   }
-  // WhatsApp system/protocol "message" types that are not real chat content.
-  static readonly SYSTEM_MESSAGE_TYPES = new Set<string>([
-    'e2e_notification', 'notification_template', 'notification',
-    'call_log', 'gp2', 'ciphertext', 'protocol', 'revoked',
-  ]);
-
   constructor(
     @Inject(REALTIME_EMITTER) private readonly realtime: RealtimeEmitter,
     @Inject(forwardRef(() => RuleEngineService))
@@ -212,7 +206,7 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           let lastTs: Date | null = null;
           for (const m of chat.messages || []) {
             const msgType: string = m?.type || 'chat';
-            if (EngineManagerService.SYSTEM_MESSAGE_TYPES.has(msgType)) continue;
+            if (isSystemMessageType(msgType)) continue;
             const messageId: string = m?.id || '';
             if (!messageId) continue;
             const exists = await prisma.message.findFirst({
@@ -836,7 +830,7 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
         // (E2E-encryption notices, business notification templates, call logs,
         // group-system events, deleted-message markers). Persisting them produced
         // bogus "conversations" with unresolved @lid numbers and noisy notifications.
-        if (EngineManagerService.SYSTEM_MESSAGE_TYPES.has(message.type)) {
+        if (isSystemMessageType(message.type)) {
           this.logger.debug(`Skipping system message (type=${message.type}) for profile ${profileId}`);
           return;
         }

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -772,6 +772,14 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
         // Skip bot's own messages to prevent reply loops
         if (message.fromMe) {
           this.logger.debug(`Skipping own message for profile ${profileId}`);
+          return;
+        }
+        // Skip WhatsApp system/protocol messages — these are not real chat content
+        // (E2E-encryption notices, business notification templates, call logs,
+        // group-system events, deleted-message markers). Persisting them produced
+        // bogus "conversations" with unresolved @lid numbers and noisy notifications.
+        if (isSystemMessageType(message.type)) {
+          this.logger.debug(`Skipping system message (type=${message.type}) for profile ${profileId}`);
           return;
         }
         this.logger.log(`📨 Incoming message for profile ${profileId} from ${message.from}: type=${message.type}, body=${(message.body || '').substring(0, 50)}`);

--- a/packages/engine-runtime/src/index.ts
+++ b/packages/engine-runtime/src/index.ts
@@ -15,3 +15,4 @@ export * from './db-retry';
 export * from './inbound-media';
 export * from './auto-reject-call';
 export * from './wa-message-id';
+export * from './system-message';

--- a/packages/engine-runtime/src/system-message.ts
+++ b/packages/engine-runtime/src/system-message.ts
@@ -1,0 +1,20 @@
+// packages/engine-runtime/src/system-message.ts
+//
+// WhatsApp system/protocol message types that are NOT real chat content:
+// E2E-encryption notices, business notification templates, call logs,
+// group-system events (gp2), ciphertext placeholders, protocol frames, and
+// deleted-message markers. Persisting them produced bogus "conversations" with
+// unresolved @lid numbers and fired noisy "New message" notifications.
+//
+// Shared between apps/api (ENGINE_HOST=api) and apps/worker (ENGINE_HOST=worker)
+// so both engine-managers drop the same set; see
+// architecture/engine-worker-migration-sop.md.
+
+export const SYSTEM_MESSAGE_TYPES = new Set<string>([
+  'e2e_notification', 'notification_template', 'notification',
+  'call_log', 'gp2', 'ciphertext', 'protocol', 'revoked',
+]);
+
+export function isSystemMessageType(type: string | null | undefined): boolean {
+  return !!type && SYSTEM_MESSAGE_TYPES.has(type);
+}


### PR DESCRIPTION
## The bug (live on prod)

The worker `onMessage` (the `ENGINE_HOST=worker` production path) had **no system-message filter**. Every WhatsApp system/protocol frame — `e2e_notification`, `notification_template`, `notification`, `call_log`, `gp2`, `ciphertext`, `protocol`, `revoked` — was persisted as a real inbound message: a **bogus "conversation" with an unresolved `@lid` sender** plus a noisy **"New message" notification**.

The API engine-manager already filtered these (documented fix), but the worker copy drifted and never received it — the same parallel-copy drift as PR #103.

## The fix

Promote the type set + `isSystemMessageType()` into **`@multiwa/engine-runtime`**, then:
- **worker `onMessage`** skips system messages right after the `fromMe` guard (the fix), mirroring the API comment/log
- **API engine-manager** (2 call sites) and **`messages.service` history-sync** (1 call site) now call the shared helper; the static `EngineManagerService.SYSTEM_MESSAGE_TYPES` set is removed
- new spec `apps/api/src/modules/messages/system-message.spec.ts`

Behavior change is **additive filtering on the worker only** — it stops persisting non-chat frames; real chat types (`chat`/`text`/`image`/…) are unaffected. No gate needed; this is the documented-correct behavior the API already had.

## Verification
- `pnpm --filter @multiwa/engine-runtime build` ✓
- `system-message.spec.ts` 4/4 ✓ · `messages` + `profiles` module specs **108/108** ✓
- `tsc --noEmit` on **api** and **worker** ✓

Third bug from the fix-first engine-manager dedup track (after #103). Next: worker `connectProfile` UUID guard; `onDisconnected` exhaustion alert.