### PR TITLE
fix(worker): validate profileId shape in connectProfile (path-traversal guard)

### DIFF
--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -538,6 +538,13 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
    * Initialize and connect a WhatsApp engine for a profile
    */
   async connectProfile(profileId: string): Promise<{ status: string; message: string }> {
+    // Defense-in-depth: profileId is server-generated (uuid) and the DB lookup below
+    // already rejects unknown ids, but validate the shape up front so it can NEVER
+    // reach the SESSIONS_DIR/<profileId> filesystem paths (path traversal) even if a
+    // future caller skips the lookup.
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(profileId)) {
+      throw new Error('Invalid profileId');
+    }
     this.logger.log(`Connecting profile: ${profileId}`);
 
     // A (re)connect intent clears any manual-disconnect flag so the watchdog and


### PR DESCRIPTION
## What

Adds the UUID-shape guard to the worker's `connectProfile`, mirroring the API engine-manager exactly:

```ts
if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(profileId)) {
  throw new Error('Invalid profileId');
}
```

## Why

`connectProfile` joins `profileId` into `SESSIONS_DIR/<profileId>` filesystem paths (stale-lock cleanup, session dir). The API validates the shape up front as path-traversal defense-in-depth; the worker copy drifted and performs the same `fs` operations **without** the guard. The DB lookup already rejects unknown ids, but this holds even if a future caller skips it.

## Verification
- `tsc --noEmit` on **worker** ✓
- Guard now present in both engine-managers (parity).

Third bug from the fix-first engine-manager dedup track (after #103, #104). Next: `onDisconnected` exhaustion alert.