### PR TITLE
fix(worker): alert operators when auto-reconnect is exhausted

### DIFF
--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -773,6 +773,13 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           });
           this.realtime.emitConnectionStatus(profileId, 'disconnected');
           this.emitEvent(AppEvents.CONNECTION.DISCONNECTED, { profileId, reason: 'max retries exhausted' });
+          // A transient disconnect that never recovered is a terminal state an operator
+          // should act on — notify org users (previously only session-invalidation did).
+          this.notifyOrgUsers(profileId, NotificationType.DISCONNECTION,
+            '⚠️ Profile Disconnected',
+            `${profile.displayName || profileId} disconnected (${reason}) and auto-recovery failed after ${maxRetries} attempts. Manual reconnect needed.`,
+            { profileId, reason: 'max-retries-exhausted' },
+          ).catch(err => this.logger.warn(`Notification error (retry-exhausted): ${err.message}`));
         }
       },
       onMessage: async (message: any) => {


### PR DESCRIPTION
## What

Adds the operator notification to the worker `onDisconnected` **retry-exhausted** branch, mirroring the API engine-manager:

```ts
this.notifyOrgUsers(profileId, NotificationType.DISCONNECTION,
  '⚠️ Profile Disconnected',
  `${profile.displayName || profileId} disconnected (${reason}) and auto-recovery failed after ${maxRetries} attempts. Manual reconnect needed.`,
  { profileId, reason: 'max-retries-exhausted' },
).catch(err => this.logger.warn(`Notification error (retry-exhausted): ${err.message}`));
```

## Why

The worker's exhaustion branch already marked the profile disconnected and emitted status/events, but — unlike the API copy — sent **no notification**. In `ENGINE_HOST=worker` prod mode, a profile that transient-disconnects and burns through all 3 auto-retries went **silently offline**; the operator only found out when messages stopped. `notifyOrgUsers` and `profile` are already in scope in the worker (used by the session-invalidation branch), so this is a faithful mirror.

## Verification
- `tsc --noEmit` on **worker** ✓
- Both engine-managers now notify on `max-retries-exhausted` (parity).

Fourth and final of the verified worker drift bugs from the fix-first engine-manager dedup track (#103 @lid drop, #104 system-msg filter, #105 UUID guard, this).