### PR TITLE
refactor(dedup): extract resolveEngineType to @multiwa/engine-runtime

### DIFF
--- a/apps/api/src/modules/messages/engine-type.spec.ts
+++ b/apps/api/src/modules/messages/engine-type.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveEngineType } from '@multiwa/engine-runtime';
+
+describe('resolveEngineType', () => {
+  it('returns the profile engine when it is valid', () => {
+    expect(resolveEngineType('whatsapp-web-js')).toBe('whatsapp-web-js');
+    expect(resolveEngineType('mock')).toBe('mock');
+  });
+
+  it('falls back to DEFAULT_ENGINE when the profile engine is invalid, and warns', () => {
+    const warn = vi.fn();
+    expect(resolveEngineType('bogus', { defaultEngine: 'mock', warn })).toBe('mock');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("falling back to DEFAULT_ENGINE='mock'"));
+  });
+
+  it('defaults to whatsapp-web-js when neither profile engine nor DEFAULT_ENGINE is valid, and warns', () => {
+    const warn = vi.fn();
+    expect(resolveEngineType('bogus', { defaultEngine: 'also-bogus', warn })).toBe('whatsapp-web-js');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('defaulting to whatsapp-web-js'));
+  });
+
+  it('uses DEFAULT_ENGINE silently when the profile engine is empty (no invalid-engine warning)', () => {
+    const warn = vi.fn();
+    expect(resolveEngineType(null, { defaultEngine: 'mock', warn })).toBe('mock');
+    expect(resolveEngineType(undefined, { defaultEngine: 'mock', warn })).toBe('mock');
+    // no "invalid"/"not a known engine" warning when there was no engineField to reject
+    expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(/invalid|not a known engine/));
+  });
+
+  it('defaults to whatsapp-web-js when nothing is provided', () => {
+    expect(resolveEngineType(null)).toBe('whatsapp-web-js');
+    expect(resolveEngineType(undefined, {})).toBe('whatsapp-web-js');
+  });
+
+  it('warns about the experimental Baileys engine whenever it is selected', () => {
+    const warn = vi.fn();
+    expect(resolveEngineType('baileys', { warn })).toBe('baileys');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('EXPERIMENTAL Baileys'));
+  });
+
+  it('is safe when no warn sink is supplied', () => {
+    expect(() => resolveEngineType('baileys')).not.toThrow();
+    expect(() => resolveEngineType('bogus', { defaultEngine: 'x' })).not.toThrow();
+  });
+});

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType, resolveEngineType as resolveEngineTypeShared } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -541,32 +541,10 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
    * getOrCreate) — EngineManagerService.engines is the sole instance owner.
    */
   private resolveEngineType(engineField?: string | null): EngineType {
-    const valid: EngineType[] = ['whatsapp-web-js', 'baileys', 'mock'];
-    let selected: EngineType;
-
-    if (engineField && valid.includes(engineField as EngineType)) {
-      selected = engineField as EngineType;
-    } else {
-      const envDefault = process.env.DEFAULT_ENGINE;
-      if (envDefault && valid.includes(envDefault as EngineType)) {
-        if (engineField) {
-          this.logger.warn(`Profile engine '${engineField}' invalid; falling back to DEFAULT_ENGINE='${envDefault}'`);
-        }
-        selected = envDefault as EngineType;
-      } else {
-        if (engineField) {
-          this.logger.warn(`Profile engine '${engineField}' is not a known engine; defaulting to whatsapp-web-js`);
-        }
-        selected = 'whatsapp-web-js';
-      }
-    }
-
-    if (selected === 'baileys') {
-      this.logger.warn(
-        'Profile is using the EXPERIMENTAL Baileys engine — sendReaction is a no-op stub and getContacts may be unavailable. Use whatsapp-web-js for production.',
-      );
-    }
-    return selected;
+    return resolveEngineTypeShared(engineField, {
+      defaultEngine: process.env.DEFAULT_ENGINE,
+      warn: (m) => this.logger.warn(m),
+    });
   }
 
   /**

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType, resolveEngineType as resolveEngineTypeShared } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -506,32 +506,10 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
    * getOrCreate) — EngineManagerService.engines is the sole instance owner.
    */
   private resolveEngineType(engineField?: string | null): EngineType {
-    const valid: EngineType[] = ['whatsapp-web-js', 'baileys', 'mock'];
-    let selected: EngineType;
-
-    if (engineField && valid.includes(engineField as EngineType)) {
-      selected = engineField as EngineType;
-    } else {
-      const envDefault = process.env.DEFAULT_ENGINE;
-      if (envDefault && valid.includes(envDefault as EngineType)) {
-        if (engineField) {
-          this.logger.warn(`Profile engine '${engineField}' invalid; falling back to DEFAULT_ENGINE='${envDefault}'`);
-        }
-        selected = envDefault as EngineType;
-      } else {
-        if (engineField) {
-          this.logger.warn(`Profile engine '${engineField}' is not a known engine; defaulting to whatsapp-web-js`);
-        }
-        selected = 'whatsapp-web-js';
-      }
-    }
-
-    if (selected === 'baileys') {
-      this.logger.warn(
-        'Profile is using the EXPERIMENTAL Baileys engine — sendReaction is a no-op stub and getContacts may be unavailable. Use whatsapp-web-js for production.',
-      );
-    }
-    return selected;
+    return resolveEngineTypeShared(engineField, {
+      defaultEngine: process.env.DEFAULT_ENGINE,
+      warn: (m) => this.logger.warn(m),
+    });
   }
 
   /**

--- a/packages/engine-runtime/src/engine-type.ts
+++ b/packages/engine-runtime/src/engine-type.ts
@@ -1,0 +1,51 @@
+// packages/engine-runtime/src/engine-type.ts
+//
+// Resolve which engine adapter a profile should use, with a safe fallback chain:
+//   profile.engine (if valid) → DEFAULT_ENGINE env (if valid) → whatsapp-web-js.
+// Emits a warning for the experimental Baileys engine.
+//
+// Shared between apps/api and apps/worker so both engine-managers resolve the
+// engine type identically; see architecture/engine-worker-migration-sop.md.
+
+import type { EngineType } from '@multiwa/engines';
+
+const VALID_ENGINES: EngineType[] = ['whatsapp-web-js', 'baileys', 'mock'];
+
+export interface ResolveEngineTypeDeps {
+  /** Value of the DEFAULT_ENGINE env var (pass process.env.DEFAULT_ENGINE). */
+  defaultEngine?: string | null;
+  /** Sink for fallback/experimental warnings (pass a logger.warn). */
+  warn?: (message: string) => void;
+}
+
+export function resolveEngineType(
+  engineField: string | null | undefined,
+  deps: ResolveEngineTypeDeps = {},
+): EngineType {
+  const warn = deps.warn ?? (() => {});
+  let selected: EngineType;
+
+  if (engineField && VALID_ENGINES.includes(engineField as EngineType)) {
+    selected = engineField as EngineType;
+  } else {
+    const envDefault = deps.defaultEngine;
+    if (envDefault && VALID_ENGINES.includes(envDefault as EngineType)) {
+      if (engineField) {
+        warn(`Profile engine '${engineField}' invalid; falling back to DEFAULT_ENGINE='${envDefault}'`);
+      }
+      selected = envDefault as EngineType;
+    } else {
+      if (engineField) {
+        warn(`Profile engine '${engineField}' is not a known engine; defaulting to whatsapp-web-js`);
+      }
+      selected = 'whatsapp-web-js';
+    }
+  }
+
+  if (selected === 'baileys') {
+    warn(
+      'Profile is using the EXPERIMENTAL Baileys engine — sendReaction is a no-op stub and getContacts may be unavailable. Use whatsapp-web-js for production.',
+    );
+  }
+  return selected;
+}

--- a/packages/engine-runtime/src/index.ts
+++ b/packages/engine-runtime/src/index.ts
@@ -16,3 +16,4 @@ export * from './inbound-media';
 export * from './auto-reject-call';
 export * from './wa-message-id';
 export * from './system-message';
+export * from './engine-type';


### PR DESCRIPTION
## What

First safe extraction of the engine-manager dedup (the two ~1300-line `engine-manager.service.ts` are ~75% identical). `resolveEngineType` was **byte-for-byte duplicated** in `apps/api` and `apps/worker`.

Promote it to a pure, DI helper `packages/engine-runtime/src/engine-type.ts`:
```ts
resolveEngineType(engineField, { defaultEngine, warn })
```
Both engine-managers keep a thin private `resolveEngineType()` that delegates (`defaultEngine: process.env.DEFAULT_ENGINE`, `warn: this.logger.warn`) — **call sites unchanged, behaviour identical** (pure relocation, no logic change).

## Why this is safe (API engine-manager is the live prod path on wagw, ENGINE_HOST=api)
- The shared function is a line-for-line move of the original logic (same fallback precedence: `profile.engine` → `DEFAULT_ENGINE` → `whatsapp-web-js`; same Baileys warning; same warning strings).
- The private method signature and its two call sites (`this.resolveEngineType(profile.engine)`) are untouched.
- New unit spec `engine-type.spec.ts` (7 cases) locks the fallback precedence, the empty-`engineField` silent path, the Baileys warning, and no-warn-sink safety.

## Verification
- `pnpm --filter @multiwa/engine-runtime build` ✓
- `engine-type.spec.ts` 7/7 ✓
- `tsc --noEmit` api + worker ✓
- grep confirms the duplicated logic (`valid.includes` / `EXPERIMENTAL Baileys`) is **gone from both** engine-managers.