### PR TITLE
refactor(dedup): extract cleanupStaleLockFiles to @multiwa/engine-runtime

### DIFF
--- a/apps/api/src/modules/messages/lock-files.spec.ts
+++ b/apps/api/src/modules/messages/lock-files.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { cleanupStaleLockFiles } from '@multiwa/engine-runtime';
+
+// A minimal fs/promises stub. readdir returns Dirent-like entries with `name`
+// and `parentPath` so the helper can rebuild each lock path.
+function fakeFs(opts: {
+  accessThrows?: boolean;
+  entries?: { name: string; parentPath: string }[];
+  readdirThrows?: boolean;
+  unlinkThrowsFor?: string[];
+}) {
+  const unlinked: string[] = [];
+  const fs = {
+    access: vi.fn(async () => {
+      if (opts.accessThrows) throw new Error('ENOENT');
+    }),
+    readdir: vi.fn(async () => {
+      if (opts.readdirThrows) throw new Error('EACCES');
+      return (opts.entries ?? []) as any;
+    }),
+    unlink: vi.fn(async (p: string) => {
+      if (opts.unlinkThrowsFor?.some((s) => p.includes(s))) throw new Error('EBUSY');
+      unlinked.push(p);
+    }),
+  };
+  return { fs, unlinked };
+}
+
+describe('cleanupStaleLockFiles', () => {
+  it('no-ops silently when the session dir does not exist', async () => {
+    const { fs, unlinked } = fakeFs({ accessThrows: true });
+    const warn = vi.fn();
+    await cleanupStaleLockFiles('/data/sessions/x', { fs: fs as any, warn });
+    expect(fs.readdir).not.toHaveBeenCalled();
+    expect(unlinked).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('removes exactly the three Chromium Singleton lock files, ignoring other files', async () => {
+    const { fs, unlinked } = fakeFs({
+      entries: [
+        { name: 'SingletonLock', parentPath: '/s/p' },
+        { name: 'SingletonSocket', parentPath: '/s/p' },
+        { name: 'SingletonCookie', parentPath: '/s/p' },
+        { name: 'Default', parentPath: '/s' },
+        { name: 'session.json', parentPath: '/s/p' },
+      ],
+    });
+    const log = vi.fn();
+    await cleanupStaleLockFiles('/s', { fs: fs as any, log });
+    expect(unlinked.sort()).toEqual(['/s/p/SingletonCookie', '/s/p/SingletonLock', '/s/p/SingletonSocket']);
+    expect(log).toHaveBeenCalledTimes(3);
+  });
+
+  it('warns and continues when a single unlink fails (never throws)', async () => {
+    const { fs, unlinked } = fakeFs({
+      entries: [
+        { name: 'SingletonLock', parentPath: '/s/p' },
+        { name: 'SingletonSocket', parentPath: '/s/p' },
+      ],
+      unlinkThrowsFor: ['SingletonLock'],
+    });
+    const warn = vi.fn();
+    await expect(cleanupStaleLockFiles('/s', { fs: fs as any, warn })).resolves.toBeUndefined();
+    expect(unlinked).toEqual(['/s/p/SingletonSocket']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Could not remove lock file'));
+  });
+
+  it('warns (not throws) when the directory scan fails', async () => {
+    const { fs } = fakeFs({ readdirThrows: true });
+    const warn = vi.fn();
+    await expect(cleanupStaleLockFiles('/s', { fs: fs as any, warn })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Error scanning for lock files'));
+  });
+});

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType, resolveEngineType as resolveEngineTypeShared } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType, resolveEngineType as resolveEngineTypeShared, cleanupStaleLockFiles as cleanupStaleLockFilesShared } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -488,33 +488,10 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
    * These files prevent Puppeteer from launching a new browser.
    */
   private async cleanupStaleLockFiles(sessionDir: string): Promise<void> {
-    const fs = await import('fs/promises');
-    const lockFiles = ['SingletonLock', 'SingletonSocket', 'SingletonCookie'];
-    
-    // Recursively find and remove lock files in the session directory
-    try {
-      await fs.access(sessionDir);
-    } catch {
-      return; // Session dir doesn't exist yet, nothing to clean
-    }
-    
-    // Walk through known Chromium profile subdirectories
-    try {
-      const entries = await fs.readdir(sessionDir, { recursive: true, withFileTypes: true });
-      for (const entry of entries) {
-        if (lockFiles.includes(entry.name)) {
-          const lockPath = path.join(entry.parentPath || entry.path, entry.name);
-          try {
-            await fs.unlink(lockPath);
-            this.logger.log(`Removed stale Chromium lock file: ${lockPath}`);
-          } catch (e) {
-            this.logger.warn(`Could not remove lock file ${lockPath}: ${(e as Error).message}`);
-          }
-        }
-      }
-    } catch (e) {
-      this.logger.warn(`Error scanning for lock files: ${(e as Error).message}`);
-    }
+    await cleanupStaleLockFilesShared(sessionDir, {
+      log: (m) => this.logger.log(m),
+      warn: (m) => this.logger.warn(m),
+    });
   }
 
   async onModuleDestroy() {

--- a/apps/worker/src/engine/engine-manager.service.ts
+++ b/apps/worker/src/engine/engine-manager.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
 import { REALTIME_EMITTER, RealtimeEmitter } from '@multiwa/core';
 import { prisma } from '@multiwa/database';
-import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType, resolveEngineType as resolveEngineTypeShared } from '@multiwa/engine-runtime';
+import { evaluateColdCircuit, applyAckStatusUpdate, applyInboundMedia, handleAutoRejectCall, serializeWaMessageId, isSystemMessageType, resolveEngineType as resolveEngineTypeShared, cleanupStaleLockFiles as cleanupStaleLockFilesShared } from '@multiwa/engine-runtime';
 import { EngineFactory } from '@multiwa/engines';
 import type { IWhatsAppEngine, EngineConfig, EngineType } from '@multiwa/engines';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -453,33 +453,10 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
    * These files prevent Puppeteer from launching a new browser.
    */
   private async cleanupStaleLockFiles(sessionDir: string): Promise<void> {
-    const fs = await import('fs/promises');
-    const lockFiles = ['SingletonLock', 'SingletonSocket', 'SingletonCookie'];
-    
-    // Recursively find and remove lock files in the session directory
-    try {
-      await fs.access(sessionDir);
-    } catch {
-      return; // Session dir doesn't exist yet, nothing to clean
-    }
-    
-    // Walk through known Chromium profile subdirectories
-    try {
-      const entries = await fs.readdir(sessionDir, { recursive: true, withFileTypes: true });
-      for (const entry of entries) {
-        if (lockFiles.includes(entry.name)) {
-          const lockPath = path.join(entry.parentPath || entry.path, entry.name);
-          try {
-            await fs.unlink(lockPath);
-            this.logger.log(`Removed stale Chromium lock file: ${lockPath}`);
-          } catch (e) {
-            this.logger.warn(`Could not remove lock file ${lockPath}: ${(e as Error).message}`);
-          }
-        }
-      }
-    } catch (e) {
-      this.logger.warn(`Error scanning for lock files: ${(e as Error).message}`);
-    }
+    await cleanupStaleLockFilesShared(sessionDir, {
+      log: (m) => this.logger.log(m),
+      warn: (m) => this.logger.warn(m),
+    });
   }
 
   async onModuleDestroy() {

--- a/packages/engine-runtime/src/index.ts
+++ b/packages/engine-runtime/src/index.ts
@@ -17,3 +17,4 @@ export * from './auto-reject-call';
 export * from './wa-message-id';
 export * from './system-message';
 export * from './engine-type';
+export * from './lock-files';

--- a/packages/engine-runtime/src/lock-files.ts
+++ b/packages/engine-runtime/src/lock-files.ts
@@ -1,0 +1,60 @@
+// packages/engine-runtime/src/lock-files.ts
+//
+// whatsapp-web.js drives a Chromium user-data-dir under the session folder.
+// A hard crash/kill leaves Chromium "Singleton" lock files behind that block
+// the next launch. Before (re)connecting, sweep them out.
+//
+// Shared between apps/api and apps/worker so both engine-managers clean the
+// same lock set identically; see architecture/engine-worker-migration-sop.md.
+
+import * as path from 'path';
+
+const LOCK_FILES = ['SingletonLock', 'SingletonSocket', 'SingletonCookie'];
+
+type FsLike = Pick<typeof import('fs/promises'), 'access' | 'readdir' | 'unlink'>;
+
+export interface CleanupStaleLockFilesDeps {
+  /** Sink for removed-lock messages (pass a logger.log). */
+  log?: (message: string) => void;
+  /** Sink for warnings (pass a logger.warn). */
+  warn?: (message: string) => void;
+  /** Override the fs/promises implementation (tests inject a fake). */
+  fs?: FsLike;
+}
+
+/**
+ * Recursively remove stale Chromium Singleton lock files under `sessionDir`.
+ * No-op if the directory does not exist. Never throws — individual failures
+ * are warned and skipped.
+ */
+export async function cleanupStaleLockFiles(
+  sessionDir: string,
+  deps: CleanupStaleLockFilesDeps = {},
+): Promise<void> {
+  const log = deps.log ?? (() => {});
+  const warn = deps.warn ?? (() => {});
+  const fs = deps.fs ?? (await import('fs/promises'));
+
+  try {
+    await fs.access(sessionDir);
+  } catch {
+    return; // Session dir doesn't exist yet, nothing to clean
+  }
+
+  try {
+    const entries = await fs.readdir(sessionDir, { recursive: true, withFileTypes: true });
+    for (const entry of entries) {
+      if (LOCK_FILES.includes(entry.name)) {
+        const lockPath = path.join((entry as any).parentPath || (entry as any).path, entry.name);
+        try {
+          await fs.unlink(lockPath);
+          log(`Removed stale Chromium lock file: ${lockPath}`);
+        } catch (e) {
+          warn(`Could not remove lock file ${lockPath}: ${(e as Error).message}`);
+        }
+      }
+    }
+  } catch (e) {
+    warn(`Error scanning for lock files: ${(e as Error).message}`);
+  }
+}


### PR DESCRIPTION
## What

Second safe extraction of the engine-manager dedup. `cleanupStaleLockFiles` (the Chromium `Singleton{Lock,Socket,Cookie}` sweep before a (re)connect) was **byte-for-byte duplicated** in `apps/api` and `apps/worker`.

Promote it to `packages/engine-runtime/src/lock-files.ts` with injected `log`/`warn` sinks and an optional `fs` override for tests. Both engine-managers keep a thin private `cleanupStaleLockFiles()` that delegates — **call sites unchanged, behaviour identical** (pure relocation).

## Safety (API engine-manager is the live prod path, ENGINE_HOST=api)
- Line-for-line move: same lock-file set, same recursive `readdir`, same never-throws semantics (missing dir → no-op; per-file unlink failure → warn + continue; scan failure → warn).
- `path` import remains used in both files (5×/9×), so no unused-import fallout.

## Verification
- `pnpm --filter @multiwa/engine-runtime build` ✓
- `lock-files.spec.ts` 4/4 (missing-dir no-op, removes exactly 3 lock files, unlink-failure warned-and-continues, scan-failure warned-not-thrown) via injected fake fs ✓
- `tsc --noEmit` api + worker ✓
- grep confirms `SingletonLock`/`SingletonSocket` gone from both engine-managers.