### PR TITLE
chore(release): unify all versions to 1.2.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-21
+
+Unified versioning: the app, all workspace packages, and every SDK now share a
+single version, matching the GitHub release tag.
+
+### Added
+
+- **Auto-reject incoming calls** — per-profile setting to auto-reject WhatsApp voice/video calls, with an optional canned reply, wired through the engine adapters, `@multiwa/engine-runtime`, the API, the worker, and an admin toggle on the profile settings page.
+- **Expiring API keys** — `expiresInDays` on key creation mints short-lived keys (the api-key strategy already rejects expired keys); keys remain non-expiring by default.
+- **Observability (P1)** — Prometheus alert rules, an Alertmanager config, and documented SLOs under `docs/monitoring/`.
+- **Inbound media cap** — inbound base64 media is size-capped via a shared `applyInboundMedia` helper used by both engine-managers.
+- **SDKs published** — the TypeScript SDK is live on npm (`@multiwa/sdk`), the Python SDK on PyPI (`multiwa`), and the n8n community node on npm (`n8n-nodes-multiwa`); docs updated accordingly. (PHP/Packagist still pending a split repo.)
+
+### Changed
+
+- **Engine-manager dedup (start)** — `serializeWaMessageId`, `isSystemMessageType`/`SYSTEM_MESSAGE_TYPES`, and `resolveEngineType` were promoted into `@multiwa/engine-runtime` as shared, unit-tested helpers so the API and worker engine-managers no longer maintain divergent copies.
+- CI: SDK/n8n publish workflows run on Node 22 (npm 12 requires Node ≥ 22).
+
+### Fixed
+
+- **Worker: @lid group messages no longer silently dropped** — the worker built the persisted message id inline and passed the raw id object into a String column for `@lid` group messages, throwing and dropping the message with no `message.received` webhook. It now uses the shared `serializeWaMessageId`.
+- **Worker: system/protocol messages filtered** — the worker persisted `e2e_notification`/`protocol`/`gp2`/`ciphertext`/`call_log`/etc. as bogus conversations with noisy notifications; it now applies the same `isSystemMessageType` filter the API had.
+- **Worker: `connectProfile` path-traversal guard** — a non-UUID `profileId` is rejected before it can reach the `SESSIONS_DIR/<id>` filesystem paths (mirrors the API guard).
+- **Worker: operator alert on exhausted auto-reconnect** — a profile that burns through all auto-retries now notifies org users instead of going silently offline.
+
+### Security
+
+- **Code scanning cleared to 0 open** — resolved the CodeQL `js/log-injection` findings (the recognised sanitizer is an empty-string CR/LF strip, `.replace(/[\r\n]/g, '')`) across the Chatwoot bridge and the webhook-receiver script, sanitized the untrusted `conversation.id` in bridge logs, and removed an unused import flagged by `js/unused-local-variable`.
+
 ## [1.1.0] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.0.0-green.svg" alt="Version" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.2.0-green.svg" alt="Version" /></a>
   <a href="https://ribato22.github.io/MultiWA/"><img src="https://img.shields.io/badge/🌐_Website-Live-brightgreen.svg" alt="Website" /></a>
   <a href="docker-compose.yml"><img src="https://img.shields.io/badge/docker-one--click-2496ED.svg" alt="Docker" /></a>
   <a href="https://hub.docker.com/r/ribato/multiwa-api"><img src="https://img.shields.io/docker/pulls/ribato/multiwa-api.svg" alt="Docker Pulls" /></a>

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/admin",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "MultiWA Admin Dashboard (Next.js 14)",
   "scripts": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/api",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "MultiWA Gateway REST API (NestJS + Fastify)",
   "scripts": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/worker",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "MultiWA Background Worker (BullMQ)",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiwa",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Open Source WhatsApp Business API Gateway - Multi-engine, Self-hosted, Enterprise-ready",
   "keywords": [

--- a/packages/chatwoot-bridge/package.json
+++ b/packages/chatwoot-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/chatwoot-bridge",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Bridge between MultiWA WhatsApp Gateway and Chatwoot",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/core",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "MultiWA Core Domain Layer",
   "main": "./dist/index.js",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/database",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "MultiWA Database Layer (Prisma)",
   "main": "./dist/index.js",

--- a/packages/engine-runtime/package.json
+++ b/packages/engine-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/engine-runtime",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "MultiWA shared WhatsApp engine runtime (used by apps/api and apps/worker)",
   "main": "./dist/index.js",

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/engines",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "MultiWA WhatsApp Engine Adapters",
   "main": "./dist/index.js",

--- a/packages/n8n-nodes-multiwa/package.json
+++ b/packages/n8n-nodes-multiwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-multiwa",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "n8n nodes for MultiWA WhatsApp Business API Gateway",
   "keywords": [
     "n8n-community-node-package",

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiwa"
-version = "1.0.0"
+version = "1.2.0"
 description = "Official Python SDK for the MultiWA WhatsApp Business API Gateway."
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiwa/sdk",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Official TypeScript SDK for the MultiWA WhatsApp Business API Gateway. Send messages, manage profiles, automate flows, and consume webhooks against a self-hosted MultiWA server.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## What

Aligns the **GitHub release tag, the app, every workspace package, and all SDKs on a single version** — `1.0.0` → `1.2.0` — so they stay in lockstep going forward (previously the release was at v1.1.0 while all package.json/SDKs sat at 1.0.0, and the README badge was stale at 1.0.0).

- 11 `package.json` (root + `packages/*` + `apps/*`) → `1.2.0`
- `packages/sdk-python/pyproject.toml` → `1.2.0`
- README version badge → `1.2.0`
- `CHANGELOG.md` — new `[1.2.0] - 2026-07-21` section covering everything since v1.1.0: auto-reject calls (+admin toggle), expiring API keys, observability alert rules/SLOs, inbound-media cap, SDKs published (npm/PyPI/n8n), the four worker engine-manager drift fixes (#103–#106), the `resolveEngineType`/`serializeWaMessageId`/`isSystemMessageType` dedup, and code-scanning cleared to **0 open**.

## After merge
Tag `v1.2.0` + GitHub release, then publish the SDKs at 1.2.0 (`sdk-v1.2.0`, `sdk-python-v1.2.0`, `n8n-v1.2.0`) so the registry versions match the release.

## Notes
Pure version/changelog change — no code, no controllers touched (api-contract unchanged). Verified locally: version consistency across all manifests, `pnpm check:api-contract` passes.