### PR TITLE
refactor(dedup): extract API onMessage into handleInboundMessage + characterization suite (step A)

### DIFF
--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -550,255 +550,17 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
   /**
    * Initialize and connect a WhatsApp engine for a profile
    */
-  async connectProfile(profileId: string): Promise<{ status: string; message: string }> {
-    // Defense-in-depth: profileId is server-generated (uuid) and the DB lookup below
-    // already rejects unknown ids, but validate the shape up front so it can NEVER
-    // reach the SESSIONS_DIR/<profileId> filesystem paths (path traversal) even if a
-    // future caller skips the lookup.
-    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(profileId)) {
-      throw new Error('Invalid profileId');
-    }
-    this.logger.log(`Connecting profile: ${profileId}`);
-    // A (re)connect clears any "manually disconnected" marker so the reconnect
-    // sweep watches this profile again.
-    this.manuallyDisconnected.delete(profileId);
 
-    // Check if already connected
-    const existing = this.engines.get(profileId);
-    if (existing && existing.status === 'connected') {
-      return { status: 'already_connected', message: 'Profile already connected' };
-    }
-
-    // Destroy any existing engine instance (e.g. from a failed previous attempt)
-    if (existing) {
-      this.logger.log(`Destroying stale engine instance for ${profileId}`);
-      try {
-        await existing.engine.destroy?.();
-      } catch (e) {
-        this.logger.warn(`Error destroying stale engine: ${(e as Error).message}`);
-      }
-      this.engines.delete(profileId);
-    }
-
-    // Get profile from database
-    const profile = await prisma.profile.findUnique({
-      where: { id: profileId },
-    });
-
-    if (!profile) {
-      throw new Error('Profile not found');
-    }
-
-    // Update status to connecting
-    await prisma.profile.update({
-      where: { id: profileId },
-      data: { status: 'connecting' },
-    });
-
-    // Create engine config with callbacks
-    const sessionsBase = process.env.SESSIONS_DIR || './sessions';
-    const sessionDir = path.join(sessionsBase, profileId);
-
-    // Clean up stale Chromium lock files from previous container runs
-    // Without this, Puppeteer refuses to launch: "The profile appears to be in use by another Chromium process"
-    await this.cleanupStaleLockFiles(sessionDir);
-    
-    const engineConfig: EngineConfig = {
-      profileId,
-      sessionDir,
-      onQR: async (qr: string) => {
-        this.logger.log(`QR code received for profile ${profileId}`);
-        
-        try {
-          // Convert QR string to data URL for frontend <img> display
-          const qrDataUrl = await QRCode.toDataURL(qr, {
-            width: 256,
-            margin: 2,
-            color: { dark: '#000000', light: '#ffffff' },
-          });
-          
-          // Emit QR data URL to WebSocket clients
-          this.realtime.emitQrUpdate(profileId, qrDataUrl);
-          this.emitEvent(AppEvents.CONNECTION.QR, { profileId, qr: qrDataUrl });
-          this.logger.log(`QR code emitted via WebSocket for profile ${profileId}`);
-        } catch (error) {
-          this.logger.error(`Error generating QR data URL:`, error);
-          // Fallback: send raw QR string
-          this.realtime.emitQrUpdate(profileId, qr);
-        }
-      },
-      onReady: async (phone: string, pushName: string) => {
-        this.logger.log(`Profile ${profileId} connected: ${phone} (${pushName})`);
-        // Reached 'ready' — cancel the watchdog and reset its retry counter.
-        this.clearReadyTimer(profileId);
-        this.readyTimeoutRetries.delete(profileId);
-
-        // Phone number guard: if user initially registered the profile with a
-        // specific phone number, refuse to silently overwrite it with a
-        // different WhatsApp account. The frontend listens for
-        // 'connection:status' status='error' and shows the toast.
-        const existing = await prisma.profile.findUnique({
-          where: { id: profileId },
-          select: { phoneNumber: true, displayName: true },
-        });
-        const expected = (existing?.phoneNumber || '').replace(/\D/g, '');
-        const actual = (phone || '').replace(/\D/g, '');
-        if (expected && expected !== actual) {
-          this.logger.warn(
-            `Profile ${profileId}: scanned WA number ${actual} does not match expected ${expected}. Disconnecting.`,
-          );
-          this.realtime.emitConnectionStatus(
-            profileId,
-            'error',
-            `Scanned number does not match this profile. Expected ${expected}, got ${actual}.`,
-          );
-          // Disconnect the just-linked engine; user can rescan with the correct device.
-          try {
-            const instance2 = this.engines.get(profileId);
-            await instance2?.engine.disconnect();
-          } catch (err) {
-            this.logger.warn(`Failed to disconnect mismatched engine: ${(err as Error).message}`);
-          }
-          this.engines.delete(profileId);
-          await prisma.profile.update({
-            where: { id: profileId },
-            data: { status: 'disconnected' },
-          });
-          return;
-        }
-
-        // Update engine instance status
-        const instance = this.engines.get(profileId);
-        if (instance) {
-          instance.status = 'connected';
-        }
-
-        // Update database
-        await prisma.profile.update({
-          where: { id: profileId },
-          data: {
-            status: 'connected',
-            phoneNumber: phone,
-            lastConnectedAt: new Date(),
-          },
-        });
-
-        // Emit connection status via WebSocket
-        this.realtime.emitConnectionStatus(profileId, 'connected', phone);
-        this.emitEvent(AppEvents.CONNECTION.READY, { profileId, phone, pushName });
-
-        // === Notification: profile connected ===
-        this.notifyOrgUsers(profileId, NotificationType.CONNECTION,
-          '✅ Profile Connected',
-          `${profile.displayName || phone} is now connected`,
-          { profileId, phone },
-        ).catch(err => this.logger.warn(`Notification error (connection): ${err.message}`));
-
-        // Background, best-effort: pull recent chats + their latest messages so
-        // existing conversations show up in the dashboard (whatsapp-web.js only
-        // streams NEW messages from connect onward). Bounded + deduped; never blocks
-        // connect. Disable with HISTORY_SYNC_ON_CONNECT=false.
-        if (process.env.HISTORY_SYNC_ON_CONNECT !== 'false') {
-          this.syncRecentHistory(profileId).catch(err =>
-            this.logger.warn(`History sync failed for ${profileId}: ${(err as Error).message}`));
-        }
-      },
-      onDisconnected: async (reason: string) => {
-        this.logger.log(`Profile ${profileId} disconnected: ${reason}`);
-        this.clearReadyTimer(profileId);
-
-        // Update engine instance status
-        const instance = this.engines.get(profileId);
-        if (instance) {
-          instance.status = 'disconnected';
-        }
-
-        // Only clear session folder for actual session invalidation (logged out, expired)
-        // Do NOT clear for temporary errors like 'Stream Errored' or 'Connection Failure'
-        // as these may recover on reconnect
-        const sessionInvalidReasons = ['Session Expired', 'Logged Out', 'loggedOut'];
-        const isSessionInvalid = sessionInvalidReasons.some(r => reason.includes(r));
-        
-        if (isSessionInvalid) {
-          this.logger.warn(`Session invalidated for ${profileId}, clearing session folder for fresh QR`);
-          try {
-            const fs = await import('fs/promises');
-            await fs.rm(sessionDir, { recursive: true, force: true });
-            this.logger.log(`Session folder cleared for ${profileId}`);
-          } catch (err) {
-            this.logger.error(`Failed to clear session folder:`, err);
-          }
-          
-          // Update database
-          await prisma.profile.update({
-            where: { id: profileId },
-            data: { status: 'disconnected' },
-          });
-          this.realtime.emitConnectionStatus(profileId, 'disconnected');
-          this.emitEvent(AppEvents.CONNECTION.DISCONNECTED, { profileId, reason });
-
-          // === Notification: session invalidated ===
-          this.notifyOrgUsers(profileId, NotificationType.DISCONNECTION,
-            '⚠️ Profile Disconnected',
-            `${profile.displayName || profileId} was disconnected: ${reason}`,
-            { profileId, reason },
-          ).catch(err => this.logger.warn(`Notification error (disconnection): ${err.message}`));
-        } else {
-
-          // Temporary disconnect — attempt auto-retry with exponential backoff
-          const maxRetries = 3;
-          const baseDelay = 5000; // 5 seconds
-          
-          // Clean up the failed engine instance first
-          try {
-            await instance?.engine?.destroy?.();
-          } catch (e) {
-            this.logger.warn(`Error destroying engine before retry: ${(e as Error).message}`);
-          }
-          this.engines.delete(profileId);
-
-          for (let attempt = 1; attempt <= maxRetries; attempt++) {
-            const delay = baseDelay * Math.pow(3, attempt - 1); // 5s, 15s, 45s
-            this.logger.log(`Auto-retry ${attempt}/${maxRetries} for ${profileId} in ${delay / 1000}s (reason: ${reason})`);
-            
-            // Emit reconnecting status so frontend shows progress
-            await prisma.profile.update({
-              where: { id: profileId },
-              data: { status: 'connecting' },
-            });
-            this.realtime.emitConnectionStatus(profileId, `reconnecting (${attempt}/${maxRetries})`);
-            
-            await new Promise(resolve => setTimeout(resolve, delay));
-            
-            try {
-              const result = await this.connectProfile(profileId);
-              if (result.status === 'connecting' || result.status === 'already_connected') {
-                this.logger.log(`Auto-retry successful for ${profileId} on attempt ${attempt}`);
-                return; // Success, exit the retry loop
-              }
-            } catch (retryErr: any) {
-              this.logger.warn(`Auto-retry attempt ${attempt}/${maxRetries} failed for ${profileId}: ${retryErr.message}`);
-            }
-          }
-          
-          // All retries exhausted
-          this.logger.error(`All ${maxRetries} auto-retry attempts failed for ${profileId}`);
-          await prisma.profile.update({
-            where: { id: profileId },
-            data: { status: 'disconnected' },
-          });
-          this.realtime.emitConnectionStatus(profileId, 'disconnected');
-          this.emitEvent(AppEvents.CONNECTION.DISCONNECTED, { profileId, reason: 'max retries exhausted' });
-          // A transient disconnect that never recovered is a terminal state an operator
-          // should act on — notify org users (previously only session-invalidation did).
-          this.notifyOrgUsers(profileId, NotificationType.DISCONNECTION,
-            '⚠️ Profile Disconnected',
-            `${profile.displayName || profileId} disconnected (${reason}) and auto-recovery failed after ${maxRetries} attempts. Manual reconnect needed.`,
-            { profileId, reason: 'max-retries-exhausted' },
-          ).catch(err => this.logger.warn(`Notification error (retry-exhausted): ${err.message}`));
-        }
-      },
-      onMessage: async (message: any) => {
+  /**
+   * Handle one inbound WhatsApp message: skip own/system messages, dedup the
+   * conversation (incl. @lid resolution + group-subject), build the content
+   * object, persist the message, update the conversation (+ optional auto-read),
+   * emit realtime + app-bus + notification, auto-create the contact, and run
+   * automation. Extracted verbatim from the onMessage engine callback so the API
+   * and worker can share one implementation; behaviour is identical.
+   * See architecture/engine-worker-migration-sop.md.
+   */
+  private async handleInboundMessage(message: any, profileId: string): Promise<void> {
         // Skip bot's own messages to prevent reply loops
         if (message.fromMe) {
           this.logger.debug(`Skipping own message for profile ${profileId}`);
@@ -1134,7 +896,256 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
         } catch (error) {
           this.logger.error(`Error processing incoming message:`, error);
         }
+  }
+  async connectProfile(profileId: string): Promise<{ status: string; message: string }> {
+    // Defense-in-depth: profileId is server-generated (uuid) and the DB lookup below
+    // already rejects unknown ids, but validate the shape up front so it can NEVER
+    // reach the SESSIONS_DIR/<profileId> filesystem paths (path traversal) even if a
+    // future caller skips the lookup.
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(profileId)) {
+      throw new Error('Invalid profileId');
+    }
+    this.logger.log(`Connecting profile: ${profileId}`);
+    // A (re)connect clears any "manually disconnected" marker so the reconnect
+    // sweep watches this profile again.
+    this.manuallyDisconnected.delete(profileId);
+
+    // Check if already connected
+    const existing = this.engines.get(profileId);
+    if (existing && existing.status === 'connected') {
+      return { status: 'already_connected', message: 'Profile already connected' };
+    }
+
+    // Destroy any existing engine instance (e.g. from a failed previous attempt)
+    if (existing) {
+      this.logger.log(`Destroying stale engine instance for ${profileId}`);
+      try {
+        await existing.engine.destroy?.();
+      } catch (e) {
+        this.logger.warn(`Error destroying stale engine: ${(e as Error).message}`);
+      }
+      this.engines.delete(profileId);
+    }
+
+    // Get profile from database
+    const profile = await prisma.profile.findUnique({
+      where: { id: profileId },
+    });
+
+    if (!profile) {
+      throw new Error('Profile not found');
+    }
+
+    // Update status to connecting
+    await prisma.profile.update({
+      where: { id: profileId },
+      data: { status: 'connecting' },
+    });
+
+    // Create engine config with callbacks
+    const sessionsBase = process.env.SESSIONS_DIR || './sessions';
+    const sessionDir = path.join(sessionsBase, profileId);
+
+    // Clean up stale Chromium lock files from previous container runs
+    // Without this, Puppeteer refuses to launch: "The profile appears to be in use by another Chromium process"
+    await this.cleanupStaleLockFiles(sessionDir);
+    
+    const engineConfig: EngineConfig = {
+      profileId,
+      sessionDir,
+      onQR: async (qr: string) => {
+        this.logger.log(`QR code received for profile ${profileId}`);
+        
+        try {
+          // Convert QR string to data URL for frontend <img> display
+          const qrDataUrl = await QRCode.toDataURL(qr, {
+            width: 256,
+            margin: 2,
+            color: { dark: '#000000', light: '#ffffff' },
+          });
+          
+          // Emit QR data URL to WebSocket clients
+          this.realtime.emitQrUpdate(profileId, qrDataUrl);
+          this.emitEvent(AppEvents.CONNECTION.QR, { profileId, qr: qrDataUrl });
+          this.logger.log(`QR code emitted via WebSocket for profile ${profileId}`);
+        } catch (error) {
+          this.logger.error(`Error generating QR data URL:`, error);
+          // Fallback: send raw QR string
+          this.realtime.emitQrUpdate(profileId, qr);
+        }
       },
+      onReady: async (phone: string, pushName: string) => {
+        this.logger.log(`Profile ${profileId} connected: ${phone} (${pushName})`);
+        // Reached 'ready' — cancel the watchdog and reset its retry counter.
+        this.clearReadyTimer(profileId);
+        this.readyTimeoutRetries.delete(profileId);
+
+        // Phone number guard: if user initially registered the profile with a
+        // specific phone number, refuse to silently overwrite it with a
+        // different WhatsApp account. The frontend listens for
+        // 'connection:status' status='error' and shows the toast.
+        const existing = await prisma.profile.findUnique({
+          where: { id: profileId },
+          select: { phoneNumber: true, displayName: true },
+        });
+        const expected = (existing?.phoneNumber || '').replace(/\D/g, '');
+        const actual = (phone || '').replace(/\D/g, '');
+        if (expected && expected !== actual) {
+          this.logger.warn(
+            `Profile ${profileId}: scanned WA number ${actual} does not match expected ${expected}. Disconnecting.`,
+          );
+          this.realtime.emitConnectionStatus(
+            profileId,
+            'error',
+            `Scanned number does not match this profile. Expected ${expected}, got ${actual}.`,
+          );
+          // Disconnect the just-linked engine; user can rescan with the correct device.
+          try {
+            const instance2 = this.engines.get(profileId);
+            await instance2?.engine.disconnect();
+          } catch (err) {
+            this.logger.warn(`Failed to disconnect mismatched engine: ${(err as Error).message}`);
+          }
+          this.engines.delete(profileId);
+          await prisma.profile.update({
+            where: { id: profileId },
+            data: { status: 'disconnected' },
+          });
+          return;
+        }
+
+        // Update engine instance status
+        const instance = this.engines.get(profileId);
+        if (instance) {
+          instance.status = 'connected';
+        }
+
+        // Update database
+        await prisma.profile.update({
+          where: { id: profileId },
+          data: {
+            status: 'connected',
+            phoneNumber: phone,
+            lastConnectedAt: new Date(),
+          },
+        });
+
+        // Emit connection status via WebSocket
+        this.realtime.emitConnectionStatus(profileId, 'connected', phone);
+        this.emitEvent(AppEvents.CONNECTION.READY, { profileId, phone, pushName });
+
+        // === Notification: profile connected ===
+        this.notifyOrgUsers(profileId, NotificationType.CONNECTION,
+          '✅ Profile Connected',
+          `${profile.displayName || phone} is now connected`,
+          { profileId, phone },
+        ).catch(err => this.logger.warn(`Notification error (connection): ${err.message}`));
+
+        // Background, best-effort: pull recent chats + their latest messages so
+        // existing conversations show up in the dashboard (whatsapp-web.js only
+        // streams NEW messages from connect onward). Bounded + deduped; never blocks
+        // connect. Disable with HISTORY_SYNC_ON_CONNECT=false.
+        if (process.env.HISTORY_SYNC_ON_CONNECT !== 'false') {
+          this.syncRecentHistory(profileId).catch(err =>
+            this.logger.warn(`History sync failed for ${profileId}: ${(err as Error).message}`));
+        }
+      },
+      onDisconnected: async (reason: string) => {
+        this.logger.log(`Profile ${profileId} disconnected: ${reason}`);
+        this.clearReadyTimer(profileId);
+
+        // Update engine instance status
+        const instance = this.engines.get(profileId);
+        if (instance) {
+          instance.status = 'disconnected';
+        }
+
+        // Only clear session folder for actual session invalidation (logged out, expired)
+        // Do NOT clear for temporary errors like 'Stream Errored' or 'Connection Failure'
+        // as these may recover on reconnect
+        const sessionInvalidReasons = ['Session Expired', 'Logged Out', 'loggedOut'];
+        const isSessionInvalid = sessionInvalidReasons.some(r => reason.includes(r));
+        
+        if (isSessionInvalid) {
+          this.logger.warn(`Session invalidated for ${profileId}, clearing session folder for fresh QR`);
+          try {
+            const fs = await import('fs/promises');
+            await fs.rm(sessionDir, { recursive: true, force: true });
+            this.logger.log(`Session folder cleared for ${profileId}`);
+          } catch (err) {
+            this.logger.error(`Failed to clear session folder:`, err);
+          }
+          
+          // Update database
+          await prisma.profile.update({
+            where: { id: profileId },
+            data: { status: 'disconnected' },
+          });
+          this.realtime.emitConnectionStatus(profileId, 'disconnected');
+          this.emitEvent(AppEvents.CONNECTION.DISCONNECTED, { profileId, reason });
+
+          // === Notification: session invalidated ===
+          this.notifyOrgUsers(profileId, NotificationType.DISCONNECTION,
+            '⚠️ Profile Disconnected',
+            `${profile.displayName || profileId} was disconnected: ${reason}`,
+            { profileId, reason },
+          ).catch(err => this.logger.warn(`Notification error (disconnection): ${err.message}`));
+        } else {
+
+          // Temporary disconnect — attempt auto-retry with exponential backoff
+          const maxRetries = 3;
+          const baseDelay = 5000; // 5 seconds
+          
+          // Clean up the failed engine instance first
+          try {
+            await instance?.engine?.destroy?.();
+          } catch (e) {
+            this.logger.warn(`Error destroying engine before retry: ${(e as Error).message}`);
+          }
+          this.engines.delete(profileId);
+
+          for (let attempt = 1; attempt <= maxRetries; attempt++) {
+            const delay = baseDelay * Math.pow(3, attempt - 1); // 5s, 15s, 45s
+            this.logger.log(`Auto-retry ${attempt}/${maxRetries} for ${profileId} in ${delay / 1000}s (reason: ${reason})`);
+            
+            // Emit reconnecting status so frontend shows progress
+            await prisma.profile.update({
+              where: { id: profileId },
+              data: { status: 'connecting' },
+            });
+            this.realtime.emitConnectionStatus(profileId, `reconnecting (${attempt}/${maxRetries})`);
+            
+            await new Promise(resolve => setTimeout(resolve, delay));
+            
+            try {
+              const result = await this.connectProfile(profileId);
+              if (result.status === 'connecting' || result.status === 'already_connected') {
+                this.logger.log(`Auto-retry successful for ${profileId} on attempt ${attempt}`);
+                return; // Success, exit the retry loop
+              }
+            } catch (retryErr: any) {
+              this.logger.warn(`Auto-retry attempt ${attempt}/${maxRetries} failed for ${profileId}: ${retryErr.message}`);
+            }
+          }
+          
+          // All retries exhausted
+          this.logger.error(`All ${maxRetries} auto-retry attempts failed for ${profileId}`);
+          await prisma.profile.update({
+            where: { id: profileId },
+            data: { status: 'disconnected' },
+          });
+          this.realtime.emitConnectionStatus(profileId, 'disconnected');
+          this.emitEvent(AppEvents.CONNECTION.DISCONNECTED, { profileId, reason: 'max retries exhausted' });
+          // A transient disconnect that never recovered is a terminal state an operator
+          // should act on — notify org users (previously only session-invalidation did).
+          this.notifyOrgUsers(profileId, NotificationType.DISCONNECTION,
+            '⚠️ Profile Disconnected',
+            `${profile.displayName || profileId} disconnected (${reason}) and auto-recovery failed after ${maxRetries} attempts. Manual reconnect needed.`,
+            { profileId, reason: 'max-retries-exhausted' },
+          ).catch(err => this.logger.warn(`Notification error (retry-exhausted): ${err.message}`));
+        }
+      },
+      onMessage: async (message: any) => this.handleInboundMessage(message, profileId),
       onMessageAck: async (messageId: string, status: string) => {
         try {
           // Shared, guarded ack update: a null result means the ack had no resolvable

--- a/apps/api/src/modules/profiles/handle-inbound-message.spec.ts
+++ b/apps/api/src/modules/profiles/handle-inbound-message.spec.ts
@@ -1,0 +1,201 @@
+// Characterization suite for EngineManagerService.handleInboundMessage (the API,
+// prod-active inbound path). This LOCKS the current behaviour before it is
+// extracted into a shared @multiwa/engine-runtime helper: the same suite must
+// stay green after the extraction (PR-B) proving the move changed nothing.
+//
+// Strategy: mock prisma + the engine; construct the service with stub collaborators;
+// spy the private helpers it delegates to (resolveGroupName / emitEvent /
+// notifyOrgUsers) so the assertions focus on handleInboundMessage's own
+// orchestration (what it persists, emits, and skips).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@multiwa/database', () => ({
+  prisma: {
+    conversation: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    message: { create: vi.fn() },
+    contact: { findFirst: vi.fn(), create: vi.fn() },
+    profile: { findUnique: vi.fn() },
+  },
+}));
+
+import { prisma } from '@multiwa/database';
+import { EngineManagerService } from './engine-manager.service';
+
+const PROFILE = '1eb28399-5fe1-40ed-bd0a-39a4b8ad4858';
+
+function makeService() {
+  const realtime = { emitMessage: vi.fn(), emitConnectionStatus: vi.fn(), emitMessageAck: vi.fn(), emitQR: vi.fn() };
+  const ruleEngine = { processMessage: vi.fn().mockResolvedValue([]) };
+  const notifications = { createForOrg: vi.fn() };
+  const eventEmitter = { emit: vi.fn() };
+  const service = new EngineManagerService(realtime as any, ruleEngine as any, notifications as any, eventEmitter as any);
+
+  const engine = { resolveIdentity: vi.fn(), markAsRead: vi.fn(), getGroupInfo: vi.fn() };
+  (service as any).engines = new Map([[PROFILE, { engine, profileId: PROFILE, status: 'connected' }]]);
+
+  // Isolate handleInboundMessage from the helpers it delegates to.
+  const resolveGroupName = vi.spyOn(service as any, 'resolveGroupName').mockResolvedValue('Group Subject');
+  const emitEvent = vi.spyOn(service as any, 'emitEvent').mockImplementation(() => {});
+  const notifyOrgUsers = vi.spyOn(service as any, 'notifyOrgUsers').mockResolvedValue(undefined);
+
+  return { service, realtime, ruleEngine, engine, resolveGroupName, emitEvent, notifyOrgUsers };
+}
+
+function dm(overrides: Record<string, any> = {}): any {
+  return { fromMe: false, type: 'chat', from: '628111017195@c.us', body: 'hello', timestamp: 1700000000, _data: {}, ...overrides };
+}
+
+const call = (svc: any, message: any) => (svc as any).handleInboundMessage(message, PROFILE);
+const created = (m: any) => (m.mock.calls[0]?.[0] as any)?.data;
+
+describe('EngineManagerService.handleInboundMessage (characterization)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (prisma.conversation.findFirst as any).mockResolvedValue(null);
+    (prisma.conversation.create as any).mockImplementation(async ({ data }: any) => ({ id: 'conv-1', ...data }));
+    (prisma.conversation.update as any).mockResolvedValue({});
+    (prisma.message.create as any).mockImplementation(async ({ data }: any) => ({ id: 'msg-1', ...data }));
+    (prisma.contact.findFirst as any).mockResolvedValue(null);
+    (prisma.contact.create as any).mockResolvedValue({});
+    (prisma.profile.findUnique as any).mockResolvedValue({ id: PROFILE, dailyMessageLimit: null, dailyMessageCount: 0, dailyResetAt: null });
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('1) skips own (fromMe) messages — nothing persisted', async () => {
+    const { service } = makeService();
+    await call(service, dm({ fromMe: true }));
+    expect(prisma.message.create).not.toHaveBeenCalled();
+    expect(prisma.conversation.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('2) skips WhatsApp system/protocol messages', async () => {
+    const { service } = makeService();
+    for (const t of ['e2e_notification', 'protocol', 'gp2', 'ciphertext', 'call_log', 'revoked']) {
+      vi.clearAllMocks();
+      await call(service, dm({ type: t }));
+      expect(prisma.message.create).not.toHaveBeenCalled();
+    }
+  });
+
+  it('3) DM from a new sender: creates a user conversation, persists the message, bumps unread, emits + notifies + creates the contact', async () => {
+    const { service, realtime, emitEvent, notifyOrgUsers } = makeService();
+    await call(service, dm());
+    expect(created(prisma.conversation.create)).toMatchObject({ profileId: PROFILE, jid: '628111017195@s.whatsapp.net', type: 'user' });
+    const msg = created(prisma.message.create);
+    expect(msg).toMatchObject({ direction: 'incoming', type: 'text', status: 'received', conversationId: 'conv-1' });
+    expect(msg.content).toEqual({ text: 'hello' });
+    expect(msg.messageId).toBeTypeOf('string');
+    const convUpd = (prisma.conversation.update as any).mock.calls[0][0].data;
+    expect(convUpd.unreadCount).toEqual({ increment: 1 });
+    expect(realtime.emitMessage).toHaveBeenCalledOnce();
+    expect(emitEvent).toHaveBeenCalledWith('message.received', expect.objectContaining({ profileId: PROFILE }));
+    expect(notifyOrgUsers).toHaveBeenCalledOnce();
+    expect(prisma.contact.create).toHaveBeenCalledOnce();
+  });
+
+  it('4) DM @lid resolves to the real phone JID (dedups onto the phone conversation/contact)', async () => {
+    const { service, engine } = makeService();
+    engine.resolveIdentity.mockResolvedValue({ phoneJid: '628999@s.whatsapp.net', name: 'Real Name' });
+    await call(service, dm({ from: '11223344@lid' }));
+    expect(engine.resolveIdentity).toHaveBeenCalledWith('11223344@lid');
+    // conversation looked up + created under the resolved phone JID, not the @lid
+    expect((prisma.conversation.findFirst as any).mock.calls[0][0].where.jid).toBe('628999@s.whatsapp.net');
+    expect(created(prisma.message.create).senderJid).toBe('628999@s.whatsapp.net');
+    expect(created(prisma.conversation.create).name).toBe('Real Name');
+  });
+
+  it('5) group message uses the resolved group subject and does NOT create a contact', async () => {
+    const { service, resolveGroupName } = makeService();
+    await call(service, dm({ from: '120363@g.us', author: '628111017195@c.us' }));
+    expect(resolveGroupName).toHaveBeenCalled();
+    expect(created(prisma.conversation.create)).toMatchObject({ type: 'group', name: 'Group Subject' });
+    expect(prisma.contact.create).not.toHaveBeenCalled();
+  });
+
+  it('6) group with an existing conversation backfills the authoritative subject', async () => {
+    const { service } = makeService();
+    (prisma.conversation.findFirst as any).mockResolvedValue({ id: 'conv-9', name: 'Old pushName', jid: '120363@g.us' });
+    await call(service, dm({ from: '120363@g.us', author: '628111017195@c.us' }));
+    expect(prisma.conversation.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'conv-9' }, data: { name: 'Group Subject' } }));
+  });
+
+  it('7) media message downloads media and stores the body as caption', async () => {
+    const { service } = makeService();
+    const message = dm({ type: 'image', hasMedia: true, body: 'nice pic', downloadMedia: vi.fn().mockResolvedValue({ data: 'BASE64', mimetype: 'image/jpeg' }) });
+    await call(service, message);
+    expect(message.downloadMedia).toHaveBeenCalledOnce();
+    const content = created(prisma.message.create).content;
+    expect(content.caption).toBe('nice pic');
+    expect(content.mimetype).toBe('image/jpeg');
+  });
+
+  it('8) location message extracts latitude/longitude into content', async () => {
+    const { service } = makeService();
+    await call(service, dm({ type: 'location', location: { latitude: -6.2, longitude: 106.8, description: 'Jakarta' } }));
+    const content = created(prisma.message.create).content;
+    expect(content.latitude).toBe(-6.2);
+    expect(content.longitude).toBe(106.8);
+  });
+
+  it('9) AUTO_READ_ON_RECEIVE=true zeroes unread and marks the chat read on WhatsApp', async () => {
+    vi.stubEnv('AUTO_READ_ON_RECEIVE', 'true');
+    const { service, engine } = makeService();
+    await call(service, dm());
+    expect((prisma.conversation.update as any).mock.calls[0][0].data.unreadCount).toBe(0);
+    expect(engine.markAsRead).toHaveBeenCalledWith('628111017195@s.whatsapp.net');
+  });
+
+  it('10) AUTO_READ off (default): increments unread, never marks read', async () => {
+    const { service, engine } = makeService();
+    await call(service, dm());
+    expect((prisma.conversation.update as any).mock.calls[0][0].data.unreadCount).toEqual({ increment: 1 });
+    expect(engine.markAsRead).not.toHaveBeenCalled();
+  });
+
+  it('11) normalizes the WhatsApp timestamp (seconds → ms, ms kept, invalid → now)', async () => {
+    const { service } = makeService();
+    await call(service, dm({ timestamp: 1700000000 }));
+    expect(created(prisma.message.create).timestamp.getTime()).toBe(1700000000 * 1000);
+
+    vi.clearAllMocks();
+    (prisma.message.create as any).mockImplementation(async ({ data }: any) => ({ id: 'm', ...data }));
+    await call(service, dm({ timestamp: 1700000000000 }));
+    expect(created(prisma.message.create).timestamp.getTime()).toBe(1700000000000);
+
+    vi.clearAllMocks();
+    (prisma.message.create as any).mockImplementation(async ({ data }: any) => ({ id: 'm', ...data }));
+    const before = Date.now();
+    await call(service, dm({ timestamp: 0 }));
+    expect(created(prisma.message.create).timestamp.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('12) existing contact: does not re-create the contact', async () => {
+    const { service } = makeService();
+    (prisma.contact.findFirst as any).mockResolvedValue({ id: 'contact-1' });
+    await call(service, dm());
+    expect(prisma.contact.create).not.toHaveBeenCalled();
+  });
+
+  it('13) daily-cap reached (not yet reset): skips automation', async () => {
+    const { service, ruleEngine } = makeService();
+    (prisma.profile.findUnique as any).mockResolvedValue({ id: PROFILE, dailyMessageLimit: 10, dailyMessageCount: 10, dailyResetAt: new Date(Date.now() + 3600_000) });
+    await call(service, dm());
+    expect(ruleEngine.processMessage).not.toHaveBeenCalled();
+  });
+
+  it('14) under cap: runs automation with the built IncomingMessage', async () => {
+    const { service, ruleEngine } = makeService();
+    await call(service, dm());
+    expect(ruleEngine.processMessage).toHaveBeenCalledOnce();
+    expect(ruleEngine.processMessage.mock.calls[0][0]).toMatchObject({
+      profileId: PROFILE, conversationId: 'conv-1', senderJid: '628111017195@s.whatsapp.net', isGroup: false, isNewContact: true, messageType: 'text',
+    });
+  });
+
+  it('15) a persistence failure is caught and never throws out of the handler', async () => {
+    const { service } = makeService();
+    (prisma.message.create as any).mockRejectedValue(new Error('db down'));
+    await expect(call(service, dm())).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Step A of the onMessage dedup (test-first)

The API engine-manager's inbound handler was a **337-line inline arrow** inside `connectProfile`'s engine config — the single biggest chunk of the ~75% duplication between the API and worker engine-managers, and the **live prod-active path** (`ENGINE_HOST=api`).

This step makes it **testable without changing behaviour**, so the actual extraction (step B) can be proven safe.

### Changes
1. **Pure in-file move** — the inbound-handler body is relocated verbatim into a private `handleInboundMessage(message, profileId)` method; the callback becomes a one-line delegate `onMessage: async (message) => this.handleInboundMessage(message, profileId)`. No logic changed (mechanical relocation; only the closure `profileId` becomes a parameter).
2. **15-case characterization suite** (`handle-inbound-message.spec.ts`) that **locks the current behaviour**: `fromMe`/system skips, `@lid`→phone resolution + dedup, group-subject use + backfill, media/location extraction, timestamp normalization (sec→ms / ms / invalid→now), unread++ vs `AUTO_READ_ON_RECEIVE`, contact auto-create (DM only), daily-cap fast-fail, automation dispatch with the built `IncomingMessage`, and error-swallowing.

### Why this ordering
Step B extracts `handleInboundMessage`'s body into `@multiwa/engine-runtime`; **this same suite must stay green** after that move, proving it changed nothing on the prod path. Step C then repoints the worker to the shared handler.

### Verification
- `tsc --noEmit` api + worker ✓
- `handle-inbound-message.spec.ts` **15/15** ✓
- `profiles` + `messages` module specs **130/130** ✓ (no regression from the move)