### PR TITLE
chore(deps): restrict dev-dependency group to minor/patch + ignore coordinated-migration majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,11 @@ version: 2
 # Automated dependency updates. Grouped to avoid PR spam; security updates are
 # opened by Dependabot regardless of schedule. This is the mechanism that
 # actually burns down the `pnpm audit` high/critical backlog over time.
+#
+# Both groups are restricted to minor/patch so a group PR always installs +
+# builds cleanly. MAJOR bumps arrive as their own individual PRs so each
+# breaking upgrade is reviewed on its own — except the framework majors below
+# that need a coordinated migration (kept ignored until we do that work).
 updates:
   - package-ecosystem: npm # covers the pnpm workspace (pnpm-lock.yaml)
     directory: /
@@ -12,11 +17,37 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+        update-types:
+          - minor
+          - patch
       production-dependencies:
         dependency-type: production
         update-types:
           - minor
           - patch
+    ignore:
+      # React 19 requires Next.js 15 — a coordinated framework migration, not a
+      # drop-in bump. Revisit when the admin moves to Next 15.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      # tailwind-merge 3.x targets Tailwind CSS v4; the admin is on Tailwind v3.
+      - dependency-name: "tailwind-merge"
+        update-types: ["version-update:semver-major"]
+      # lucide-react 1.x renames/removes icons — needs an icon-usage reconciliation.
+      - dependency-name: "lucide-react"
+        update-types: ["version-update:semver-major"]
+      # TypeScript 7 (native/Go preview) and Node 26 types outrun the pinned
+      # runtime (Node 20/22, TS 5.x). Bump these deliberately, not automatically.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Why

Triaging the 11 open Dependabot PRs surfaced two config gaps:

1. **The `dev-dependencies` group had no `update-types` restriction** — so it bundled MAJOR breaking bumps (`eslint 8→10`, `typescript 5→7`, `@types/node 20→26`, `globals 15→17`) into one group PR (#115) that can't build. The production group already restricts to minor/patch; this makes the dev group match, so major dev bumps split into individual, reviewable PRs.

2. **Framework majors that need a coordinated migration kept re-opening broken PRs** (react 19, tailwind-merge 3, lucide 1.x). Added `ignore` rules for `version-update:semver-major` on:
   - `react` / `react-dom` / `@types/react` / `@types/react-dom` — need Next.js 15
   - `tailwind-merge` — 3.x targets Tailwind v4 (admin is v3)
   - `lucide-react` — 1.x renames/removes icons
   - `typescript` / `@types/node` — TS 7 (native preview) and Node 26 types outrun the pinned Node 20/22 + TS 5.x runtime

Removing an ignore entry re-enables that upgrade when we do the migration.

## Result
Group PRs always install + build cleanly; non-ignored majors still get individual PRs; the "can never merge as-is" churn stops.

Part of the Dependabot triage: the breaking/not-ready PRs (#115, #118, #119, #123, #124) are being closed with reasons; the safe green ones (#114 setup-python, #116 prod-group, #117 framer-motion, #120 bcrypt, #121 nodemailer, #122 pino) are being merged.