### PR TITLE
fix(engine): resolve WhatsApp message ids through the $1 rename — unfreezes outbound ack status

### DIFF
--- a/apps/api/src/modules/messages/wa-message-id.spec.ts
+++ b/apps/api/src/modules/messages/wa-message-id.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { serializeWaMessageId } from '@multiwa/engine-runtime';
+import { serializeWaMessageId, resolveWaMessageId } from '@multiwa/engine-runtime';
 
 describe('serializeWaMessageId', () => {
   it('passes through a plain string id', () => {
@@ -35,5 +35,39 @@ describe('serializeWaMessageId', () => {
     expect(serializeWaMessageId(null)).toMatch(/^in_/);
     expect(serializeWaMessageId({ id: {} })).toMatch(/^in_/);
     expect(serializeWaMessageId({ id: 123 })).toMatch(/^in_/);
+  });
+});
+
+// resolveWaMessageId is the ack-correlation variant: it must return null instead of
+// fabricating an id, because a synthetic id can never match a stored outbound row —
+// "no id" has to stay "no id" so applyAckStatusUpdate hits its skip guard rather
+// than issuing a pointless (or, historically, table-wide) update.
+describe('resolveWaMessageId (ack correlation)', () => {
+  it('resolves the same real ids as serializeWaMessageId', () => {
+    expect(resolveWaMessageId({ id: 'false_628@c.us_ABC' })).toBe('false_628@c.us_ABC');
+    expect(resolveWaMessageId({ _serialized: 'TOP' })).toBe('TOP');
+    expect(resolveWaMessageId({ id: { _serialized: 'Y' } })).toBe('Y');
+  });
+
+  // WhatsApp Web >= 2.3000.1042401057 renamed the message key's cached serialized
+  // value to `$1`; reading `_serialized` yielded undefined, so every ack lost its id
+  // and all outbound rows froze at `pending`.
+  it('resolves the renamed $1 key (the frozen-pending root cause)', () => {
+    expect(resolveWaMessageId({ id: { $1: 'true_628@c.us_ACKME' } })).toBe('true_628@c.us_ACKME');
+    expect(resolveWaMessageId({ $1: 'true_628@c.us_TOPLEVEL' })).toBe('true_628@c.us_TOPLEVEL');
+  });
+
+  it('reconstructs from key parts when no serialized field survives', () => {
+    expect(resolveWaMessageId({ id: { fromMe: true, remote: '628@c.us', id: 'QQ' } })).toBe('true_628@c.us_QQ');
+  });
+
+  it('returns null (never a synthetic id) when the id is unresolvable', () => {
+    expect(resolveWaMessageId(null)).toBeNull();
+    expect(resolveWaMessageId(undefined)).toBeNull();
+    expect(resolveWaMessageId({})).toBeNull();
+    expect(resolveWaMessageId({ id: {} })).toBeNull();
+    expect(resolveWaMessageId({ id: 123 })).toBeNull();
+    // Not enough key parts to rebuild a canonical id.
+    expect(resolveWaMessageId({ id: { fromMe: true, remote: '628@c.us' } })).toBeNull();
   });
 });

--- a/packages/core/src/value-objects/index.ts
+++ b/packages/core/src/value-objects/index.ts
@@ -2,3 +2,4 @@
 export * from './phone-number';
 export * from './jid';
 export * from './whatsapp-recipient';
+export * from './wa-message-id';

--- a/packages/core/src/value-objects/wa-message-id.ts
+++ b/packages/core/src/value-objects/wa-message-id.ts
@@ -1,0 +1,68 @@
+// packages/core/src/value-objects/wa-message-id.ts
+//
+// Canonical WhatsApp message-id resolution — the single source of truth for
+// turning whatever shape the engine hands us into the serialized id string.
+//
+// WhatsApp Web keeps moving this target:
+//   * For GROUP messages from @lid participants the id arrives as the raw
+//     MessageId OBJECT instead of a string.
+//   * WhatsApp Web >= 2.3000.1042401057 renamed the cached serialized value on
+//     `WAWebMsgKey` from `_serialized` to the minified `$1`, so every
+//     `message.id._serialized` read silently became `undefined`.
+//
+// Reading `_serialized` blindly therefore yields either an object or undefined,
+// which (a) threw `PrismaClientValidationError` when written to the String
+// `messageId` column — silently dropping inbound messages and firing no
+// `message.received` webhook — and (b) made delivery acks unmatchable, freezing
+// every outbound row at `pending`.
+//
+// This lives in @multiwa/core (which has no workspace dependencies) so BOTH
+// packages/engines (the adapters, at the library boundary) and
+// packages/engine-runtime (the shared inbound handler) can use it — engines
+// cannot depend on engine-runtime without a cycle.
+
+/**
+ * Resolve the serialized WhatsApp message id, or `null` when it genuinely
+ * cannot be determined.
+ *
+ * Use this where a wrong id is worse than no id — e.g. delivery-ack
+ * correlation, where a fabricated id would never match a stored row.
+ */
+export function resolveWaMessageId(message: any): string | null {
+  if (!message) return null;
+
+  // Some adapters copy the serialized id to the top level.
+  if (typeof message._serialized === 'string' && message._serialized) return message._serialized;
+  if (typeof message.$1 === 'string' && message.$1) return message.$1;
+
+  const id = message.id;
+  if (typeof id === 'string' && id) return id;
+
+  if (id && typeof id === 'object') {
+    if (typeof id._serialized === 'string' && id._serialized) return id._serialized;
+    // WhatsApp Web >= 2.3000.1042401057 surfaces the serialized value as `$1`.
+    if (typeof id.$1 === 'string' && id.$1) return id.$1;
+    // Last resort: rebuild the canonical form `fromMe_remote_id[_participant]`.
+    const parts = [id.fromMe, id.remote, id.id, id.participant].filter(
+      (v) => v !== undefined && v !== null && v !== '',
+    );
+    if (parts.length >= 3) return parts.join('_');
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the serialized WhatsApp message id, falling back to a unique
+ * synthetic id.
+ *
+ * Use this where a value is REQUIRED — e.g. persisting an inbound message to a
+ * non-null String column. The synthetic id carries a random suffix so two
+ * unresolvable messages in the same millisecond cannot collide.
+ */
+export function serializeWaMessageId(message: any): string {
+  return (
+    resolveWaMessageId(message) ??
+    `in_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+  );
+}

--- a/packages/engine-runtime/package.json
+++ b/packages/engine-runtime/package.json
@@ -12,6 +12,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@multiwa/core": "workspace:*",
     "@multiwa/database": "workspace:*",
     "@multiwa/engines": "workspace:*",
     "@nestjs/common": "^11.0.0",

--- a/packages/engine-runtime/src/wa-message-id.ts
+++ b/packages/engine-runtime/src/wa-message-id.ts
@@ -1,39 +1,10 @@
 // packages/engine-runtime/src/wa-message-id.ts
 //
-// The WhatsApp engine normally hands us a message whose id is the serialized string,
-// but for GROUP messages from @lid participants (and across some engine/serialization
-// boundaries) `message.id` arrives as the raw MessageId OBJECT — sometimes with
-// `_serialized` renamed to `$1`, sometimes missing it entirely. Passing that object
-// into prisma.message.create({ data: { messageId } }) (a String column) throws a
-// PrismaClientValidationError, which silently dropped every such inbound message → no
-// `message.received` webhook fired → downstream bots/integrations stopped responding.
+// Re-export only. The implementation moved to @multiwa/core so that
+// packages/engines (the engine adapters — the boundary where the raw engine id
+// shapes actually arrive) can use the SAME resolver: engines cannot depend on
+// engine-runtime without a dependency cycle, but both may depend on core.
 //
-// This coerces any of those shapes to the canonical serialized id string.
-//
-// Shared between apps/api (ENGINE_HOST=api) and apps/worker (ENGINE_HOST=worker) so
-// both engine-managers serialize inbound ids identically; see
-// architecture/engine-worker-migration-sop.md.
+// Existing `@multiwa/engine-runtime` importers keep working unchanged.
 
-export function serializeWaMessageId(message: any): string {
-  const fallback = () => `in_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-  if (!message) return fallback();
-
-  // The adapter also copies the serialized id to the top level.
-  if (typeof message._serialized === 'string' && message._serialized) return message._serialized;
-
-  const id = message.id;
-  if (typeof id === 'string' && id) return id;
-
-  if (id && typeof id === 'object') {
-    if (typeof id._serialized === 'string' && id._serialized) return id._serialized;
-    // Some engine/serialization paths surface the serialized value under `$1`.
-    if (typeof id.$1 === 'string' && id.$1) return id.$1;
-    // Reconstruct the canonical form: fromMe_remote_id[_participant].
-    const parts = [id.fromMe, id.remote, id.id, id.participant].filter(
-      (v) => v !== undefined && v !== null && v !== '',
-    );
-    if (parts.length >= 3) return parts.join('_');
-  }
-
-  return fallback();
-}
+export { resolveWaMessageId, serializeWaMessageId } from '@multiwa/core';

--- a/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
+++ b/packages/engines/src/adapters/whatsapp-webjs.adapter.ts
@@ -3,6 +3,7 @@
 
 import { Client, LocalAuth, MessageMedia, Location, Poll } from 'whatsapp-web.js';
 import * as qrcode from 'qrcode-terminal';
+import { resolveWaMessageId } from '@multiwa/core';
 import type { 
   IWhatsAppEngine, 
   EngineConfig, 
@@ -138,11 +139,16 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
 
     // Message received
     this.client.on('message', async (message: any) => {
-      console.log(`[WhatsApp-WebJS] Message received: ${message.id._serialized}`);
-      
+      // Resolve the id defensively: WhatsApp Web >= 2.3000.1042401057 renamed the
+      // cached serialized value on the message key from `_serialized` to `$1`, and
+      // @lid group messages deliver `id` as a raw object. Reading `_serialized`
+      // directly yields undefined on current builds.
+      const serializedId = resolveWaMessageId(message);
+      console.log(`[WhatsApp-WebJS] Message received: ${serializedId ?? '(unresolved id)'}`);
+
       const transformedMessage = {
         id: message.id,
-        _serialized: message.id._serialized,
+        _serialized: serializedId ?? undefined,
         from: message.from,
         to: message.to,
         body: message.body,
@@ -169,11 +175,21 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
         3: 'read',
         4: 'played',
       };
-      
-      this.config?.onMessageAck?.(
-        message.id._serialized,
-        statusMap[ack] || 'unknown'
-      );
+
+      // Reading `message.id._serialized` here returned undefined on WhatsApp Web
+      // >= 2.3000.1042401057 (the `_serialized` -> `$1` key rename), so EVERY ack
+      // arrived without an id. `applyAckStatusUpdate` correctly skips those, which
+      // left every outbound row frozen at `pending` forever. Resolve the id the
+      // same way the inbound path does. `resolveWaMessageId` returns null rather
+      // than a synthetic id: for ack correlation a fabricated id could never match
+      // a stored row, so "no id" must stay "no id" and hit the skip guard.
+      const ackId = resolveWaMessageId(message);
+      if (!ackId) {
+        console.warn(`[WhatsApp-WebJS] Ack (${statusMap[ack] || 'unknown'}) has no resolvable message id; skipping`);
+        return;
+      }
+
+      this.config?.onMessageAck?.(ackId, statusMap[ack] || 'unknown');
     });
 
     // Incoming voice/video call — surface it so the engine-manager can auto-reject.
@@ -253,7 +269,8 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
         // let that fail the whole send: warn and send unquoted.
         try {
           const quotedMsg = await this.client?.getMessageById(options.quotedMessageId);
-          if (quotedMsg) opts.quotedMessageId = quotedMsg.id._serialized;
+          const quotedId = quotedMsg ? resolveWaMessageId(quotedMsg) : null;
+          if (quotedId) opts.quotedMessageId = quotedId;
         } catch (e: any) {
           console.warn(
             `[WhatsApp-WebJS] Ignoring unresolvable quotedMessageId "${options.quotedMessageId}": ${e?.message}`,
@@ -265,7 +282,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
       
       return {
         success: true,
-        messageId: result?.id._serialized,
+        messageId: resolveWaMessageId(result) ?? undefined,
         timestamp: new Date(),
       };
     } catch (error: any) {
@@ -333,7 +350,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
       
       return {
         success: true,
-        messageId: result?.id._serialized,
+        messageId: resolveWaMessageId(result) ?? undefined,
         timestamp: new Date(),
       };
     } catch (error: any) {
@@ -358,7 +375,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
       
       return {
         success: true,
-        messageId: result?.id._serialized,
+        messageId: resolveWaMessageId(result) ?? undefined,
         timestamp: new Date(),
       };
     } catch (error: any) {
@@ -382,7 +399,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
         const result = await this.client?.sendMessage(chatId, vcard, { parseVCards: true });
         return {
           success: true,
-          messageId: result?.id._serialized,
+          messageId: resolveWaMessageId(result) ?? undefined,
           timestamp: new Date(),
         };
       }
@@ -394,7 +411,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
         const result = await this.client?.sendMessage(chatId, vcard, { parseVCards: true });
         return {
           success: true,
-          messageId: result?.id._serialized,
+          messageId: resolveWaMessageId(result) ?? undefined,
           timestamp: new Date(),
         };
       }
@@ -441,7 +458,7 @@ export class WhatsAppWebJsAdapter implements IWhatsAppEngine {
       
       return {
         success: true,
-        messageId: result?.id._serialized,
+        messageId: resolveWaMessageId(result) ?? undefined,
         timestamp: new Date(),
       };
     } catch (error: any) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
 
   packages/engine-runtime:
     dependencies:
+      '@multiwa/core':
+        specifier: workspace:*
+        version: link:../core
       '@multiwa/database':
         specifier: workspace:*
         version: link:../database


### PR DESCRIPTION
## The bug (live on wagw)

WhatsApp Web **≥ 2.3000.1042401057** renamed the cached serialized value on the message key from `_serialized` to the minified **`$1`**. Every `message.id._serialized` read in the whatsapp-web.js adapter silently became `undefined`.

That broke **ack correlation**: the adapter called `onMessageAck(undefined, status)`, `applyAckStatusUpdate` correctly skipped it (its guard exists so an undefined id can't become a table-wide `WHERE 1=1` status rewrite), and so **every outbound row stayed `pending` forever**.

Measured on production:

| | |
|---|---|
| Outbound rows stuck `pending` | **993 in 24h** |
| Last real ack | **2026-07-19** — the day the `WWEBJS_WEB_VERSION` pin was bumped across that build |
| Acks actually arriving | 766 in 6h, with `sent` / `delivered` / `read` |

**Delivery never broke** — the acks prove messages are delivered. Only their *id* was lost, so the status column went blind. (Before 2026-07-19 the table showed 100% `read`, which was itself the old mass-rewrite bug faking success.)

## The fix

The repo **already had** the resolver: `serializeWaMessageId` (PR #103) handles `$1` — because the very same rename had broken inbound `@lid` group ids. It was just wired only into the inbound DB-write path.

- Promote it to **`@multiwa/core`** so `packages/engines` can use it too. `engines` cannot depend on `engine-runtime` (dependency cycle), but both may depend on `core`. `engine-runtime/src/wa-message-id.ts` becomes a re-export → **existing importers untouched**.
- New **`resolveWaMessageId`** returns `null` instead of fabricating an id. For ack correlation a synthetic id could never match a stored row, so *no id* must stay *no id* and hit the skip guard.
- Hardened adapter sites: inbound log + transformed `_serialized`, the **`message_ack` handler**, **all six send-result `messageId` reads** (so the outbound row records the REAL WhatsApp id and acks can match it), and the `quotedMessageId` lookup.

## Why this layer matters
Per the investigation, a library patch would also mask this — but the app-side resolution is **the layer that survives the next rename without an image rebuild**. WhatsApp Web is a minified, unversioned moving target; this is the second time this exact rename has bitten us.

## Verification
- `core` / `engines` / `engine-runtime` build ✓
- `tsc --noEmit` on **api / worker / admin** ✓
- **api 328/328**, **worker 34/34** ✓ (spec extended to 11 cases incl. the `$1` key and the null-not-synthetic contract)
- Lockfile still **air-gap safe** (0 `ssh://` refs) ✓

## Not in this PR
The group/history side (`getChats` → `getGroups` / `getRecentChats` failing with minified `r`) is a **separate** break in whatsapp-web.js's injected browser JS — the fail-fast `Promise.all` plus the unguarded `lastMessage`/group blocks. That needs a library-level patch and lands next. Upstream `main` is byte-identical to 1.34.7, so there is no release to wait for.