### PR TITLE
fix(engine): patch whatsapp-web.js for the WhatsApp Web $1 MsgKey rename (restores groups + history sync)

### DIFF
--- a/docker/Dockerfile.admin
+++ b/docker/Dockerfile.admin
@@ -8,6 +8,8 @@ RUN apk add --no-cache git && npm install -g pnpm
 
 # Copy workspace and pnpm config files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+# pnpm.patchedDependencies references patches/ — install fails without it.
+COPY patches ./patches
 COPY apps/admin/package.json ./apps/admin/
 COPY apps/api/package.json ./apps/api/
 COPY apps/worker/package.json ./apps/worker/

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y git && npm install -g pnpm
 
 # Copy workspace files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+# pnpm.patchedDependencies references patches/ — install fails without it.
+COPY patches ./patches
 
 # Copy all package.json files first (matching actual package structure)
 COPY apps/api/package.json ./apps/api/
@@ -19,6 +21,12 @@ COPY packages/sdk/package.json ./packages/sdk/
 
 # Install dependencies (allow lockfile updates for missing deps)
 RUN pnpm install --no-frozen-lockfile
+
+# Fail the build if the whatsapp-web.js patch did not apply. A silently-unpatched
+# image reintroduces the WhatsApp Web `$1` MsgKey break (getChats/getGroups/
+# getRecentChats all die with the minified `r`), so this must never ship quietly.
+RUN test "$(grep -c getMsgKeyId packages/engines/node_modules/whatsapp-web.js/src/util/Injected/Utils.js)" -ge 1 \
+    || (echo "::error::whatsapp-web.js patch NOT applied (patches/whatsapp-web.js@1.34.7.patch)" && exit 1)
 
 # Copy prisma schema first and generate
 COPY packages/database/prisma ./packages/database/prisma
@@ -80,6 +88,8 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* && n
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+# The prod install re-applies pnpm.patchedDependencies, so it needs patches/ too.
+COPY --from=builder /app/patches ./patches
 COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
 COPY --from=builder /app/packages/core/package.json ./packages/core/package.json
 COPY --from=builder /app/packages/database/package.json ./packages/database/package.json

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y git && npm install -g pnpm
 
 # Copy workspace files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+# pnpm.patchedDependencies references patches/ — install fails without it.
+COPY patches ./patches
 COPY apps/worker/package.json ./apps/worker/
 COPY packages/core/package.json ./packages/core/
 COPY packages/database/package.json ./packages/database/
@@ -26,6 +28,12 @@ COPY tsconfig.json ./tsconfig.json
 
 # Install dependencies
 RUN pnpm install --no-frozen-lockfile
+
+# Fail the build if the whatsapp-web.js patch did not apply. A silently-unpatched
+# image reintroduces the WhatsApp Web `$1` MsgKey break (getChats/getGroups/
+# getRecentChats all die with the minified `r`), so this must never ship quietly.
+RUN test "$(grep -c getMsgKeyId packages/engines/node_modules/whatsapp-web.js/src/util/Injected/Utils.js)" -ge 1 \
+    || (echo "::error::whatsapp-web.js patch NOT applied (patches/whatsapp-web.js@1.34.7.patch)" && exit 1)
 
 # Generate Prisma client FIRST (before worker build)
 RUN cd packages/database && npx prisma generate
@@ -61,6 +69,8 @@ RUN apt-get update && apt-get install -y \
 
 # Copy workspace definition and lockfile
 COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
+# The prod install re-applies pnpm.patchedDependencies, so it needs patches/ too.
+COPY --from=builder /app/patches ./patches
 COPY --from=builder /app/apps/worker/package.json ./apps/worker/
 COPY --from=builder /app/packages/core/package.json ./packages/core/
 COPY --from=builder /app/packages/database/package.json ./packages/database/

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     },
     "neverBuiltDependencies": [
       "isolated-vm"
-    ]
+    ],
+    "patchedDependencies": {
+      "whatsapp-web.js@1.34.7": "patches/whatsapp-web.js@1.34.7.patch"
+    }
   }
 }

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -17,7 +17,7 @@
     "@multiwa/core": "workspace:*",
     "@whiskeysockets/baileys": "^6.7.0",
     "qrcode-terminal": "^0.12.0",
-    "whatsapp-web.js": "^1.34.7"
+    "whatsapp-web.js": "1.34.7"
   },
   "devDependencies": {
     "@types/hapi__boom": "^9.0.1",

--- a/patches/whatsapp-web.js@1.34.7.patch
+++ b/patches/whatsapp-web.js@1.34.7.patch
@@ -1,0 +1,161 @@
+diff --git a/src/util/Injected/Utils.js b/src/util/Injected/Utils.js
+index 540078a9d07b3df07ccd51b030556a72af4cf650..0cdb316abc5b8bc44aab8150ec97037af8efc976 100644
+--- a/src/util/Injected/Utils.js
++++ b/src/util/Injected/Utils.js
+@@ -582,7 +582,7 @@ exports.LoadUtils = () => {
+ 
+         return window
+             .require('WAWebCollections')
+-            .Msg.get(newMsgKey._serialized);
++            .Msg.get(window.WWebJS.getMsgKeyId(newMsgKey));
+     };
+ 
+     window.WWebJS.editMessage = async (msg, content, options = {}) => {
+@@ -625,7 +625,9 @@ exports.LoadUtils = () => {
+         await window
+             .require('WAWebSendMessageEditAction')
+             .sendMessageEdit(msg, content, internalOptions);
+-        return window.require('WAWebCollections').Msg.get(msg.id._serialized);
++        return window
++            .require('WAWebCollections')
++            .Msg.get(window.WWebJS.getMsgKeyId(msg.id));
+     };
+ 
+     window.WWebJS.toStickerData = async (mediaInfo) => {
+@@ -800,9 +802,32 @@ exports.LoadUtils = () => {
+         return mediaData;
+     };
+ 
++    /**
++     * MultiWA patch: WhatsApp Web >= 2.3000.1042401057 renamed the cached
++     * serialized value on WAWebMsgKey from `_serialized` to the minified `$1`.
++     * Reading `_serialized` now yields undefined, which reaches
++     * `Msg.getMessagesById([undefined])` and throws a DOM `DataError`
++     * ("Failed to execute 'get' on 'IDBObjectStore'"), surfacing as the minified
++     * `r`. `_serialized` stays preferred so nothing changes where it survives.
++     */
++    window.WWebJS.getMsgKeyId = (key) =>
++        key?._serialized ?? key?.$1 ?? undefined;
++
+     window.WWebJS.getMessageModel = (message) => {
+         const msg = message.serialize();
+ 
++        // MultiWA patch: mirror the renamed `$1` back onto `id._serialized` so every
++        // downstream consumer (Message.id._serialized, ack correlation, DB rows)
++        // keeps working unchanged.
++        if (
++            msg.id &&
++            typeof msg.id === 'object' &&
++            msg.id._serialized == null &&
++            typeof msg.id.$1 === 'string'
++        ) {
++            msg.id = Object.assign({}, msg.id, { _serialized: msg.id.$1 });
++        }
++
+         const { findLinks } = window.require('WALinkify');
+ 
+         msg.isEphemeral = message.isEphemeral;
+@@ -919,10 +944,20 @@ exports.LoadUtils = () => {
+ 
+     window.WWebJS.getChats = async () => {
+         const chats = window.require('WAWebCollections').Chat.getModelsArray();
+-        const chatPromises = chats.map((chat) =>
+-            window.WWebJS.getChatModel(chat),
+-        );
+-        return await Promise.all(chatPromises);
++        // MultiWA patch: `Promise.all` is fail-fast, so ONE unreadable chat
++        // discarded the entire chat list (and with it getGroups / getRecentChats).
++        // Isolate per chat and count what we skipped instead.
++        const results = [];
++        for (const chat of chats) {
++            try {
++                const model = await window.WWebJS.getChatModel(chat);
++                if (model) results.push(model);
++            } catch (err) {
++                window.WWebJS.__multiwaChatModelErrors =
++                    (window.WWebJS.__multiwaChatModelErrors || 0) + 1;
++            }
++        }
++        return results;
+     };
+ 
+     window.WWebJS.getChannels = async () => {
+@@ -950,21 +985,46 @@ exports.LoadUtils = () => {
+         }
+ 
+         if (chat.groupMetadata) {
++            // MultiWA patch: guard the whole group block. `isGroup` must stay true
++            // (ChatFactory dispatches on it) and `groupMetadata` must never be left
++            // undefined (GroupChat's participants/description/owner getters
++            // dereference it unconditionally), so degrade to an empty stub.
+             model.isGroup = true;
+-            const chatWid = window
+-                .require('WAWebWidFactory')
+-                .createWid(chat.id._serialized);
+-            const groupMetadata =
+-                window.require('WAWebCollections').GroupMetadata ||
+-                window.require('WAWebCollections').WAWebGroupMetadataCollection;
+-            await groupMetadata.update(chatWid);
+-            const { toPn } = window.require('WAWebLidMigrationUtils');
+-            const serializedMetadata = chat.groupMetadata.serialize();
+-            for (const p of serializedMetadata.participants || []) {
+-                p.id = toPn(p.id) ?? p.id;
++            try {
++                const chatWid = window
++                    .require('WAWebWidFactory')
++                    .createWid(chat.id._serialized);
++                const groupMetadata =
++                    window.require('WAWebCollections').GroupMetadata ||
++                    window.require('WAWebCollections')
++                        .WAWebGroupMetadataCollection;
++                await groupMetadata.update(chatWid);
++                const serializedMetadata = chat.groupMetadata.serialize();
++                // The LID->phone mapper is a newer module; if it is absent, keep the
++                // raw participant ids rather than losing the whole group.
++                let toPn = null;
++                try {
++                    toPn = window.require('WAWebLidMigrationUtils')?.toPn ?? null;
++                } catch (e) {
++                    toPn = null;
++                }
++                if (typeof toPn === 'function') {
++                    for (const p of serializedMetadata.participants || []) {
++                        p.id = toPn(p.id) ?? p.id;
++                    }
++                }
++                model.groupMetadata = serializedMetadata;
++                model.isReadOnly = chat.groupMetadata.announce;
++            } catch (err) {
++                model.groupMetadata = {
++                    participants: [],
++                    desc: '',
++                    owner: undefined,
++                    creation: 0,
++                };
++                model.isReadOnly = false;
++                model.__multiwaDegraded = String(err?.message || err);
+             }
+-            model.groupMetadata = serializedMetadata;
+-            model.isReadOnly = chat.groupMetadata.announce;
+         }
+ 
+         if (chat.newsletterMetadata) {
+@@ -984,12 +1044,16 @@ exports.LoadUtils = () => {
+             const lastMessage = chat.lastReceivedKey
+                 ? window
+                       .require('WAWebCollections')
+-                      .Msg.get(chat.lastReceivedKey._serialized) ||
++                      .Msg.get(
++                          window.WWebJS.getMsgKeyId(chat.lastReceivedKey),
++                      ) ||
+                   (
+                       await window
+                           .require('WAWebCollections')
+                           .Msg.getMessagesById([
+-                              chat.lastReceivedKey._serialized,
++                              window.WWebJS.getMsgKeyId(
++                                  chat.lastReceivedKey,
++                              ),
+                           ])
+                   )?.messages?.[0]
+                 : null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,11 @@ overrides:
   '@whiskeysockets/eslint-config': https://codeload.github.com/whiskeysockets/eslint-config/tar.gz/299e8389baf62f9aa3034de18ff0d62cc0a5e838
   libsignal: https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
 
+patchedDependencies:
+  whatsapp-web.js@1.34.7:
+    hash: zlba2mg5cqyu7nc5sjbgdbzlo4
+    path: patches/whatsapp-web.js@1.34.7.patch
+
 importers:
 
   .:
@@ -485,8 +490,8 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       whatsapp-web.js:
-        specifier: ^1.34.7
-        version: 1.34.7(typescript@5.9.3)
+        specifier: 1.34.7
+        version: 1.34.7(patch_hash=zlba2mg5cqyu7nc5sjbgdbzlo4)(typescript@5.9.3)
     devDependencies:
       '@types/hapi__boom':
         specifier: ^9.0.1
@@ -14456,7 +14461,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  whatsapp-web.js@1.34.7(typescript@5.9.3):
+  whatsapp-web.js@1.34.7(patch_hash=zlba2mg5cqyu7nc5sjbgdbzlo4)(typescript@5.9.3):
     dependencies:
       fluent-ffmpeg: 2.1.3
       mime: 3.0.0


### PR DESCRIPTION
Restores `getChats` / `getGroups` / `getRecentChats` / `getChatById` on current WhatsApp Web builds. All four have been failing on wagw with the minified `r` since ~2026-07-20 — that's why the group picker fell back to DB rows (raw JIDs, `participantsCount: 0`) and history sync silently returned `[]` while logging *"+0 conversations"*.

## Root cause (verified, and not what it looked like)

WhatsApp Web **≥ 2.3000.1042401057** renamed the cached serialized value on `WAWebMsgKey` from `_serialized` to the minified **`$1`**.

The throwing line in `getChatModel` is the **`lastMessage` block — which is not group-gated at all**:

```js
Msg.getMessagesById([ chat.lastReceivedKey._serialized ])   // ← undefined after the rename
// → DataError: Failed to execute 'get' on 'IDBObjectStore'  → minified `r`
```

Because `getChats` wraps every chat in a **fail-fast `Promise.all`**, one unreadable chat discards the entire list. Groups only *looked* implicated because the group picker is the loudest consumer. `createWid(chat.id._serialized)` and `WAWebLidMigrationUtils.toPn` are innocent — chat WIDs are unaffected by the rename.

**No upstream fix to wait for:** `main` is byte-identical to the 1.34.7 tag, and 1.34.7 (2026-04-24) is still npm `latest`.

## The patch

`patches/whatsapp-web.js@1.34.7.patch`:

| Change | Why |
|---|---|
| `window.WWebJS.getMsgKeyId(key)` = `_serialized ?? $1`, used by the 3 key reads (lastMessage ×2, sendMessage result, editMessage result) | The actual fix. `_serialized` stays preferred so nothing changes where it survives |
| `getMessageModel` mirrors `$1` back onto `id._serialized` | Downstream consumers (`Message.id._serialized`, ack correlation) keep working unchanged |
| `getChats` isolates per chat instead of fail-fast `Promise.all`, counting skips in `__multiwaChatModelErrors` | One bad chat must never empty the whole list again — defence in depth for the *next* rename |
| Group block guarded, degrading to an empty metadata stub | `isGroup` stays true (ChatFactory dispatches on it) and `groupMetadata` is never left undefined (GroupChat's getters dereference it). The LID→phone mapper is optional, so a missing module keeps raw participant ids instead of losing the group |

## Shipping it safely

- `pnpm.patchedDependencies` + the patch file
- **`whatsapp-web.js` pinned to exact `1.34.7`** so `^` cannot drift past the patch (a drift would fail loudly, not silently)
- **`COPY patches` added to every install stage** of `Dockerfile.{api,worker,admin}` — the prod stages re-run `pnpm install` and would otherwise fail
- **Build assertion**: an image where the patch didn't apply **fails the build** instead of shipping quietly and silently reintroducing the break

## Verification
- Patch re-applies after a fresh install (**5** `getMsgKeyId` occurrences) ✓
- `core` / `engines` / `engine-runtime` build · `api` + `worker` typecheck ✓
- Lockfile still **air-gap safe** (0 `ssh://` refs) ✓
- **Real `docker build` of `Dockerfile.api` passes the assertion**, and inside the built image: `getMsgKeyId`=5, per-chat isolation present, group guard present, fail-fast `Promise.all` **gone** ✓

## What this does NOT fix
- **Ack correlation** — that's #144 (app-side id resolution). This patch's `getMessageModel` mirror helps, but #144 is the layer that survives the next rename **without an image rebuild**. Both are wanted.
- `getChannels` still uses fail-fast `Promise.all` — deliberately untouched, we don't consume newsletters.
- **The next rename.** This is a minified, unversioned moving target; the patch buys correctness, not immunity. A synthetic "list groups and assert participantCount > 0" health probe is the follow-up so monitoring catches it before a user does.