### PR TITLE
feat(observability): alert on silent engine degradation (group fallback + dropped acks)

### DIFF
--- a/apps/api/src/metrics/engine-degradation-probe.spec.ts
+++ b/apps/api/src/metrics/engine-degradation-probe.spec.ts
@@ -1,0 +1,82 @@
+// Locks the engine-degradation probes added after the 2026-07-30 incident, where a
+// WhatsApp Web message-key rename silently broke the chat Store (group list quietly
+// degraded to DB rows) and delivery acks (every outbound row froze at `pending`).
+// Both failures moved NO metric, so monitoring was blind for ~10 days. These tests
+// assert the counters move on the failure paths — and that the internal event names
+// can never reach a customer webhook.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MetricsEventsListener } from './metrics-events.listener';
+import { InternalEvents } from './internal-events';
+import { ALL_APP_EVENTS } from '@multiwa/core';
+
+const makeMetrics = () => ({
+  messagesSentTotal: { inc: vi.fn() },
+  messagesFailedTotal: { inc: vi.fn() },
+  connectedProfiles: { inc: vi.fn(), dec: vi.fn(), set: vi.fn() },
+  engineGroupFetchTotal: { inc: vi.fn() },
+  engineAckDroppedTotal: { inc: vi.fn() },
+});
+
+describe('engine-degradation probes', () => {
+  let metrics: ReturnType<typeof makeMetrics>;
+  let listener: MetricsEventsListener;
+
+  beforeEach(() => {
+    metrics = makeMetrics();
+    listener = new MetricsEventsListener(metrics as any);
+  });
+
+  describe('group-fetch source', () => {
+    it('counts a live fetch as source="live"', () => {
+      listener.onEngineGroupFetch({ profileId: 'p1', source: 'live', count: 12 });
+      expect(metrics.engineGroupFetchTotal.inc).toHaveBeenCalledWith({ source: 'live' });
+    });
+
+    // THE alert signal: the live engine call failed and stored groups were served.
+    it('counts a DB fallback as source="fallback"', () => {
+      listener.onEngineGroupFetch({ profileId: 'p1', source: 'fallback', count: 25 });
+      expect(metrics.engineGroupFetchTotal.inc).toHaveBeenCalledWith({ source: 'fallback' });
+    });
+
+    // A profile legitimately having zero groups must NOT look like degradation —
+    // that is why the probe keys on the SOURCE, not on the group/participant count.
+    it('still reports source="live" when a profile genuinely has no groups', () => {
+      listener.onEngineGroupFetch({ profileId: 'p1', source: 'live', count: 0 });
+      expect(metrics.engineGroupFetchTotal.inc).toHaveBeenCalledWith({ source: 'live' });
+    });
+
+    it('degrades to source="unknown" rather than throwing on a malformed payload', () => {
+      listener.onEngineGroupFetch({} as any);
+      expect(metrics.engineGroupFetchTotal.inc).toHaveBeenCalledWith({ source: 'unknown' });
+    });
+  });
+
+  describe('dropped acks', () => {
+    it('counts an ack that carried no resolvable message id', () => {
+      listener.onEngineAckDropped({ profileId: 'p1', status: 'read' });
+      expect(metrics.engineAckDroppedTotal.inc).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('telemetry must never break the request path', () => {
+    it('swallows a metrics backend failure', () => {
+      metrics.engineGroupFetchTotal.inc.mockImplementation(() => { throw new Error('registry exploded'); });
+      metrics.engineAckDroppedTotal.inc.mockImplementation(() => { throw new Error('registry exploded'); });
+      expect(() => listener.onEngineGroupFetch({ profileId: 'p', source: 'live', count: 1 })).not.toThrow();
+      expect(() => listener.onEngineAckDropped({ profileId: 'p', status: 'sent' })).not.toThrow();
+    });
+  });
+
+  // WebhookDispatcher.dispatch() only forwards events in APP_EVENT_SET. Keeping these
+  // names OUT of AppEvents is what guarantees internal telemetry is never delivered
+  // to a customer endpoint — assert it so a future refactor can't quietly leak them.
+  describe('internal events are not customer-facing', () => {
+    it('is absent from the canonical webhook event list', () => {
+      for (const name of Object.values(InternalEvents)) {
+        expect(ALL_APP_EVENTS).not.toContain(name as any);
+        expect(name.startsWith('internal.')).toBe(true);
+      }
+    });
+  });
+});

--- a/apps/api/src/metrics/internal-events.ts
+++ b/apps/api/src/metrics/internal-events.ts
@@ -1,0 +1,41 @@
+// MultiWA Gateway API - Internal diagnostic events
+// apps/api/src/metrics/internal-events.ts
+//
+// Event names published on the same EventEmitter2 bus as AppEvents, but
+// DELIBERATELY NOT part of AppEvents/APP_EVENT_SET. WebhookDispatcher.dispatch()
+// drops anything outside APP_EVENT_SET, so these stay internal telemetry and can
+// never be delivered to a customer webhook.
+//
+// They exist because the two failures behind the 2026-07-30 incident were both
+// SILENT: whatsapp-web.js's group Store broke (every getChats/getGroups threw, so
+// the group list quietly degraded to DB rows) and delivery acks arrived with no
+// resolvable message id (so every outbound row froze at `pending`). Neither moved
+// a metric, so monitoring could not see them — a user reported them ~10 days later.
+// Surfacing both as counters is what turns the next occurrence into an alert.
+
+export const InternalEvents = {
+  /**
+   * Emitted once per group-list fetch with `source: 'live' | 'fallback'`.
+   * `fallback` means the live engine call failed and the DB fallback served the
+   * request — i.e. the engine's chat Store is degraded.
+   */
+  ENGINE_GROUP_FETCH: 'internal.engine.group_fetch',
+
+  /**
+   * Emitted when a delivery ack could not be applied because it carried no
+   * resolvable message id — the signature of a WhatsApp Web key rename.
+   */
+  ENGINE_ACK_DROPPED: 'internal.engine.ack_dropped',
+} as const;
+
+export interface EngineGroupFetchPayload {
+  profileId: string;
+  source: 'live' | 'fallback';
+  /** Number of groups returned (0 is legitimate — a profile may have no groups). */
+  count: number;
+}
+
+export interface EngineAckDroppedPayload {
+  profileId: string;
+  status: string;
+}

--- a/apps/api/src/metrics/metrics-events.listener.ts
+++ b/apps/api/src/metrics/metrics-events.listener.ts
@@ -10,6 +10,11 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { prisma } from '@multiwa/database';
 import { AppEvents } from '@multiwa/core';
 import { MetricsService } from './metrics.service';
+import {
+  InternalEvents,
+  type EngineAckDroppedPayload,
+  type EngineGroupFetchPayload,
+} from './internal-events';
 
 @Injectable()
 export class MetricsEventsListener implements OnModuleInit {
@@ -61,6 +66,25 @@ export class MetricsEventsListener implements OnModuleInit {
       this.metrics.connectedProfiles.dec();
     } catch (err) {
       this.logger.debug(`connectedProfiles.dec failed: ${(err as Error).message}`);
+    }
+  }
+
+  // Engine-degradation probes (internal events — never delivered to webhooks).
+  @OnEvent(InternalEvents.ENGINE_GROUP_FETCH)
+  onEngineGroupFetch(payload: EngineGroupFetchPayload): void {
+    try {
+      this.metrics.engineGroupFetchTotal.inc({ source: payload?.source ?? 'unknown' });
+    } catch (err) {
+      this.logger.debug(`engineGroupFetch metric failed: ${(err as Error).message}`);
+    }
+  }
+
+  @OnEvent(InternalEvents.ENGINE_ACK_DROPPED)
+  onEngineAckDropped(_payload: EngineAckDroppedPayload): void {
+    try {
+      this.metrics.engineAckDroppedTotal.inc();
+    } catch (err) {
+      this.logger.debug(`engineAckDropped metric failed: ${(err as Error).message}`);
     }
   }
 }

--- a/apps/api/src/metrics/metrics.service.ts
+++ b/apps/api/src/metrics/metrics.service.ts
@@ -27,6 +27,14 @@ export class MetricsService {
   // startup, then adjusted by connection.ready / connection.disconnected events.
   readonly connectedProfiles: Gauge;
 
+  // Engine-degradation probes. Both failures behind the 2026-07-30 incident were
+  // silent — the group Store broke (list quietly served from the DB fallback) and
+  // acks lost their message id (every outbound row froze at `pending`) — so
+  // monitoring saw nothing for ~10 days. These make the next occurrence alertable.
+  // `source="fallback"` on any sustained rate means the live chat Store is broken.
+  readonly engineGroupFetchTotal: Counter<'source'>;
+  readonly engineAckDroppedTotal: Counter;
+
   constructor() {
     this.registry.setDefaultLabels({ app: 'multiwa-api' });
     collectDefaultMetrics({ register: this.registry });
@@ -82,6 +90,32 @@ export class MetricsService {
         new Gauge({
           name: 'multiwa_connected_profiles',
           help: 'WhatsApp profiles currently connected (approximate)',
+          registers: [this.registry],
+        }),
+    );
+
+    this.engineGroupFetchTotal = this.getOrCreate(
+      'multiwa_engine_group_fetch_total',
+      () =>
+        new Counter({
+          name: 'multiwa_engine_group_fetch_total',
+          help:
+            'Group-list fetches by source. source="fallback" means the live engine ' +
+            'call failed and stored groups were served — the engine chat Store is degraded.',
+          labelNames: ['source'] as const,
+          registers: [this.registry],
+        }),
+    );
+
+    this.engineAckDroppedTotal = this.getOrCreate(
+      'multiwa_engine_ack_dropped_total',
+      () =>
+        new Counter({
+          name: 'multiwa_engine_ack_dropped_total',
+          help:
+            'Delivery acks discarded because they carried no resolvable message id — ' +
+            'the signature of a WhatsApp Web message-key rename. Sustained non-zero ' +
+            'means outbound message status is frozen.',
           registers: [this.registry],
         }),
     );

--- a/apps/api/src/modules/groups/groups-getall.spec.ts
+++ b/apps/api/src/modules/groups/groups-getall.spec.ts
@@ -19,8 +19,18 @@ import { GroupsService } from './groups.service';
 function makeService(engine: any) {
   const engineManager = { getEngine: vi.fn(() => engine) } as any;
   const engineCommands = { groupOp: vi.fn() } as any;
-  return new GroupsService(engineManager, engineCommands);
+  // Captures the internal engine-degradation probe (live vs DB fallback).
+  const emitted: { event: string; payload: any }[] = [];
+  const eventEmitter = { emit: vi.fn((event: string, payload: any) => { emitted.push({ event, payload }); return true; }) } as any;
+  const service = new GroupsService(engineManager, engineCommands, eventEmitter);
+  (service as any).__emitted = emitted;
+  return service;
 }
+
+const emittedSources = (svc: any): string[] =>
+  (svc.__emitted as { event: string; payload: any }[])
+    .filter((e) => e.event === 'internal.engine.group_fetch')
+    .map((e) => e.payload.source);
 
 describe('GroupsService.getAll — resilient group list', () => {
   beforeEach(() => vi.mocked(prisma.conversation.findMany).mockReset());
@@ -57,5 +67,36 @@ describe('GroupsService.getAll — resilient group list', () => {
     const out = await svc.getAll('p1');
 
     expect(out[0].name).toBe('Group Chat');
+  });
+});
+
+// The engine-degradation probe: the alert keys on WHICH SOURCE served the list, so
+// the silent Store break behind the 2026-07-30 incident becomes visible to
+// monitoring instead of being just a log line.
+describe('GroupsService.getAll — degradation probe', () => {
+  beforeEach(() => vi.mocked(prisma.conversation.findMany).mockReset());
+
+  it('reports source="live" when the engine answers', async () => {
+    const svc = makeService({
+      getGroups: vi.fn().mockResolvedValue([{ id: '1@g.us', name: 'Live Group', participantCount: 3 }]),
+    });
+    await svc.getAll('p1');
+    expect(emittedSources(svc)).toEqual(['live']);
+  });
+
+  it('reports source="fallback" when the live call throws', async () => {
+    vi.mocked(prisma.conversation.findMany).mockResolvedValue([
+      { id: 'c1', jid: '1@g.us', name: 'Stored Group', createdAt: new Date() },
+    ] as any);
+    const svc = makeService({ getGroups: vi.fn().mockRejectedValue(new Error('r')) });
+    await svc.getAll('p1');
+    expect(emittedSources(svc)).toEqual(['fallback']);
+  });
+
+  it('reports source="fallback" when the engine returns an empty list', async () => {
+    vi.mocked(prisma.conversation.findMany).mockResolvedValue([] as any);
+    const svc = makeService({ getGroups: vi.fn().mockResolvedValue([]) });
+    await svc.getAll('p1');
+    expect(emittedSources(svc)).toEqual(['fallback']);
   });
 });

--- a/apps/api/src/modules/groups/groups.service.ts
+++ b/apps/api/src/modules/groups/groups.service.ts
@@ -14,6 +14,8 @@ import { EngineManagerService } from '../profiles/engine-manager.service';
 import { EngineCommandsService } from '../engine-commands/engine-commands.service';
 import { isWorkerEngine } from '../../common/engine-host';
 import { prisma } from '@multiwa/database';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InternalEvents } from '../../metrics/internal-events';
 
 export interface GroupInfo {
   id: string;
@@ -40,7 +42,22 @@ export class GroupsService {
     private readonly engineManager: EngineManagerService,
     // Routes group operations to the worker-hosted engine when ENGINE_HOST=worker.
     private readonly engineCommands: EngineCommandsService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
+
+  /**
+   * Report which source served a group list. `fallback` means the live engine call
+   * failed, which is the early-warning signal that the engine's chat Store broke —
+   * previously this degradation was silent (only a log line) and went unnoticed for
+   * ~10 days. Never allowed to affect the response.
+   */
+  private reportGroupFetch(profileId: string, source: 'live' | 'fallback', count: number): void {
+    try {
+      this.eventEmitter.emit(InternalEvents.ENGINE_GROUP_FETCH, { profileId, source, count });
+    } catch {
+      /* telemetry must never break the group list */
+    }
+  }
 
   /**
    * Get all groups for a profile
@@ -54,11 +71,16 @@ export class GroupsService {
       const live = isWorkerEngine()
         ? await this.engineCommands.groupOp(profileId, 'getAll', {})
         : await this.getFromLiveEngine(profileId);
-      if (Array.isArray(live) && live.length > 0) return live;
+      if (Array.isArray(live) && live.length > 0) {
+        this.reportGroupFetch(profileId, 'live', live.length);
+        return live;
+      }
     } catch (error: any) {
       this.logger.warn(`Live getGroups failed for ${profileId} (${error?.message}); using stored groups`);
     }
-    return this.getGroupsFromDb(profileId);
+    const stored = await this.getGroupsFromDb(profileId);
+    this.reportGroupFetch(profileId, 'fallback', stored.length);
+    return stored;
   }
 
   private async getFromLiveEngine(profileId: string): Promise<GroupInfo[]> {

--- a/apps/api/src/modules/profiles/engine-manager.service.ts
+++ b/apps/api/src/modules/profiles/engine-manager.service.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import * as QRCode from 'qrcode';
 import { RuleEngineService } from '../automation/rule-engine.service';
 import { NotificationsService, NotificationType } from '../notifications/notifications.service';
+import { InternalEvents } from '../../metrics/internal-events';
 
 
 interface EngineInstance {
@@ -830,6 +831,10 @@ export class EngineManagerService implements OnModuleDestroy, OnModuleInit {
           const ack = await applyAckStatusUpdate(messageId, status);
           if (!ack) {
             this.logger.warn(`[ACK] Ignoring ack with no message id (status: ${status})`);
+            // Surface it as a metric too: a WhatsApp Web key rename makes EVERY ack
+            // land here, freezing outbound status at `pending`, and a log line alone
+            // kept that invisible to monitoring for ~10 days.
+            this.emitEvent(InternalEvents.ENGINE_ACK_DROPPED, { profileId, status });
             return;
           }
           const { prior, count } = ack;

--- a/docs/monitoring/alert-rules.yml
+++ b/docs/monitoring/alert-rules.yml
@@ -16,6 +16,8 @@
 #   multiwa_messages_failed_total{type}  counter
 #   http_requests_total{method,route,status}          counter
 #   http_request_duration_seconds_bucket{...,le}      histogram
+#   multiwa_engine_group_fetch_total{source}          counter
+#   multiwa_engine_ack_dropped_total                  counter
 #   up{job}                              Prometheus target health
 
 groups:
@@ -92,3 +94,30 @@ groups:
         annotations:
           summary: "HTTP p95 latency above 1s"
           description: "95th-percentile request latency has exceeded 1 second for 10 minutes (value: {{ $value }}s)."
+
+  - name: multiwa-engine-degradation
+    # Both of these fired silently for ~10 days in July 2026: WhatsApp Web renamed a
+    # message-key property, which broke the whatsapp-web.js chat Store. The group list
+    # quietly degraded to database rows and every delivery ack lost its message id,
+    # freezing outbound status at `pending`. Neither moved a metric, so a user reported
+    # it before monitoring did. These rules close that gap.
+    rules:
+      # Keyed on the SOURCE, not on group/participant counts: a profile legitimately
+      # having zero groups must not look like an outage.
+      - alert: MultiWAGroupListDegraded
+        expr: increase(multiwa_engine_group_fetch_total{source="fallback"}[15m]) > 0
+        for: 15m
+        labels: { severity: warning }
+        annotations:
+          summary: "Group list is being served from the database fallback"
+          description: "The live engine group fetch has been failing for 15m, so stored groups are returned (raw JIDs, participantsCount 0). Usually the WhatsApp Web chat Store broke after a WhatsApp update. Check api logs for 'Get groups error' / 'Live getGroups failed'."
+
+      # A sustained non-zero rate means outbound status is frozen: acks arrive but
+      # carry no resolvable message id, so nothing ever leaves `pending`.
+      - alert: MultiWAAcksDropped
+        expr: increase(multiwa_engine_ack_dropped_total[15m]) > 10
+        for: 15m
+        labels: { severity: warning }
+        annotations:
+          summary: "Delivery acks are being dropped (outbound status frozen)"
+          description: "Acks are arriving without a resolvable WhatsApp message id, so message rows stay 'pending' forever even though delivery still works. Signature of a WhatsApp Web message-key rename."


### PR DESCRIPTION
## Why

Both failures behind the 2026-07-30 incident were **invisible to monitoring**. A WhatsApp Web message-key rename broke whatsapp-web.js's chat Store, so:

- the group list quietly degraded to database rows (raw JIDs, `participantsCount: 0`), and
- every delivery ack lost its message id, freezing outbound status at `pending` — **993 rows a day for ten days**.

Neither moved a metric. Only log lines existed, so **a user reported it before monitoring did**. This closes that gap.

## What

Two counters, incremented **off the request path** via the existing event-bus → `MetricsEventsListener` pattern (every handler guarded, so a metrics failure can never affect the response):

| metric | meaning |
|---|---|
| `multiwa_engine_group_fetch_total{source="live"\|"fallback"}` | `fallback` = the live engine call failed and stored groups were served → the chat Store is degraded |
| `multiwa_engine_ack_dropped_total` | acks arriving with no resolvable message id → outbound status is frozen |

**Design note:** the group probe keys on **which source served the list**, *not* on group/participant counts — a profile legitimately having zero groups must not look like an outage. (That's a refinement of the "assert participantCount > 0" idea, which would false-positive.)

### Internal events stay internal
The names live in a new `InternalEvents` map and are **deliberately not** in `AppEvents`. `WebhookDispatcher.dispatch()` only forwards names in `APP_EVENT_SET`, so this telemetry can never be delivered to a customer webhook — and a test asserts it, so a future refactor can't quietly leak them.

### Alerting
Adds `MultiWAGroupListDegraded` and `MultiWAAcksDropped` to `docs/monitoring/alert-rules.yml`, each documenting the triage path (which log lines / SQL to check).

## Verification
- `tsc --noEmit` on **api / worker / admin** ✓
- **api 338/338** (10 new) · **worker 34/34** ✓
- `alert-rules.yml` parses; 9 alerts total ✓
- New specs cover: live vs fallback counting, the zero-groups non-false-positive, malformed payloads, metrics-backend failure being swallowed, and the not-in-`ALL_APP_EVENTS` guarantee.