### PR TITLE
fix(deploy): route /api/v1 via nginx, align port 3333, sync docs-site from docs/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,8 +72,8 @@ PUPPETEER_NO_SANDBOX=false
 # WEBHOOKS
 # ==============================================
 WEBHOOK_TIMEOUT_MS=30000
-WEBHOOK_RETRY_ATTEMPTS=3
-WEBHOOK_RETRY_DELAY_MS=5000
+WEBHOOK_RETRY_ATTEMPTS=5
+WEBHOOK_RETRY_DELAY_MS=30000
 # SSRF guard: by default webhook/custom-AI targets that resolve to loopback,
 # private, or link-local addresses are BLOCKED (cloud metadata is always
 # blocked). Self-hosted deployments that deliver to internal services on the

--- a/.env.production.example
+++ b/.env.production.example
@@ -16,7 +16,9 @@ JWT_REFRESH_SECRET=CHANGE_ME
 ENCRYPTION_KEY=CHANGE_ME
 
 # ─── API ──────────────────────────────────────────
-API_PORT=3000
+# The API container listens on 3333 in docker-compose.production.yml — this
+# must match the API upstream port in docker/nginx/nginx.conf (api:3333).
+API_PORT=3333
 API_HOST=0.0.0.0
 NODE_ENV=production
 CORS_ORIGINS=https://wa.yourdomain.com
@@ -39,6 +41,20 @@ S3_REGION=us-east-1
 # Options: whatsapp-web-js (default, production) | baileys (EXPERIMENTAL) | mock (testing only)
 DEFAULT_ENGINE=whatsapp-web-js
 CHROMIUM_PATH=/usr/bin/chromium
+
+# Where the WhatsApp engine runs: 'api' (default) keeps it in the API process;
+# 'worker' moves it to apps/worker (API delegates via BullMQ).
+# ENGINE_HOST=api
+
+# Durable outbound sends: when true, sends are enqueued in Redis (BullMQ) and
+# delivered with retry; the API returns 202 "queued" instead of sending inline.
+# DURABLE_SEND=true
+# OUTBOUND_SEND_CONCURRENCY=10
+
+# ─── Webhooks (SSRF guard) ───────────────────────
+# Loopback/private/link-local webhook targets are blocked by default. Set to
+# true only if you deliver webhooks to internal services on the same network.
+# WEBHOOK_ALLOW_PRIVATE_TARGETS=false
 
 # ─── Database Credentials (for docker-compose) ───
 DB_USER=multiwa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,26 @@ jobs:
             --build-arg NEXT_PUBLIC_API_URL=http://localhost:3000 \
             -t multiwa-admin:test .
 
+  nginx-config:
+    name: Validate nginx reverse-proxy config
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install nginx
+        run: sudo apt-get update && sudo apt-get install -y nginx
+
+      # nginx resolves upstream hostnames at startup; make `api`/`admin`
+      # resolvable so `nginx -t` can validate the config in CI.
+      - name: Add compose upstream hosts
+        run: |
+          sudo sh -c 'echo "127.0.0.1 api" >> /etc/hosts'
+          sudo sh -c 'echo "127.0.0.1 admin" >> /etc/hosts'
+
+      - name: Check reverse-proxy config (nginx -t)
+        run: sudo nginx -t -c "$PWD/docker/nginx/nginx.conf"
+
   test:
     name: Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -39,6 +39,12 @@ jobs:
         working-directory: docs-site
         run: npm ci
 
+      - name: Sync docs into docs-site
+        # docs/ is the single source of truth; regenerate the Docusaurus pages
+        # (frontmatter + link rewriting) so the published site always matches
+        # the repo docs. No-op when already in sync.
+        run: node scripts/sync-docsite.mjs
+
       - name: Build Docusaurus (baseUrl /MultiWA/docs/)
         working-directory: docs-site
         run: npx docusaurus build

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+# MultiWA gitleaks configuration.
+#
+# Extends the default gitleaks rule set. Only the `curl-auth-header` rule is
+# customized: documentation curl examples use placeholder tokens
+# (e.g. `YOUR_TOKEN`), which the stock rule flags despite being non-secrets.
+# The allowlist is scoped by path to the two documentation trees so real
+# secrets anywhere else are still detected.
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "curl-auth-header"
+description = "Discovered a potential authorization token provided in a curl command header, which could compromise the curl accessed resource."
+regex = '''\bcurl\b(?:.*?|.*?(?:[\r\n]{1,2}.*?){1,5})[ \t\n\r](?:-H|--header)(?:=|[ \t]{0,5})(?:"(?i)(?:Authorization:[ \t]{0,5}(?:Basic[ \t]([a-z0-9+/]{8,}={0,3})|(?:Bearer|(?:Api-)?Token)[ \t]([\w=~@.+/-]{8,})|([\w=~@.+/-]{8,}))|(?:(?:X-(?:[a-z]+-)?)?(?:Api-?)?(?:Key|Token)):[ \t]{0,5}([\w=~@.+/-]{8,}))"|'(?i)(?:Authorization:[ \t]{0,5}(?:Basic[ \t]([a-z0-9+/]{8,}={0,3})|(?:Bearer|(?:Api-)?Token)[ \t]([\w=~@.+/-]{8,})|([\w=~@.+/-]{8,}))|(?:(?:X-(?:[a-z]+-)?)?(?:Api-?)?(?:Key|Token)):[ \t]{0,5}([\w=~@.+/-]{8,}))')(?:\B|\s|\z)'''
+entropy = 2.75
+keywords = ["curl"]
+
+[rules.allowlist]
+description = "Documentation curl examples with placeholder tokens"
+paths = ["^docs/.*\\.(md|markdown|mdx|rst|txt)$", "^docs-site/.*\\.(md|markdown|mdx|rst|txt)$"]

--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ pnpm --filter admin dev   # Admin on http://localhost:3001
 - 🛡️ **Security** — Helmet, CSP, rate limiting, encryption at rest
 - 🐳 **Docker** — Production-ready containers with health checks
 - 📈 **Metrics** — Prometheus `/metrics` (API, root path) + `/metrics` on the worker health port: default Node/process metrics plus BullMQ queue depth. Public like `/health` — restrict at your proxy/firewall
-- ⚙️ **Background Worker** — BullMQ worker scaffolding (a durable async send queue is on the roadmap; today message sending and scheduling run in the API process)
+- ⚙️ **Background Worker** — BullMQ worker for durable webhook delivery and
+  background jobs; with `DURABLE_SEND=true` outbound sends are enqueued (Redis)
+  and delivered with retry, and with `ENGINE_HOST=worker` the worker can host
+  the WhatsApp engine itself (default: engine runs in the API process)
 - 🔒 **GDPR** — Data export and deletion endpoints
 - 🔌 **Plugin System** — Extend with custom plugins
 
@@ -279,17 +282,23 @@ MultiWA/
 ├── apps/
 │   ├── api/             # NestJS backend API
 │   ├── admin/           # Next.js admin dashboard
-│   └── worker/          # BullMQ background worker
+│   └── worker/          # BullMQ background worker (can host the engine)
 ├── packages/
 │   ├── core/            # Shared types and utilities
 │   ├── database/        # Prisma schema and migrations
-│   ├── engines/         # WhatsApp engine adapters
+│   ├── engines/         # WhatsApp engine adapters (whatsapp-web.js, Baileys, mock)
+│   ├── engine-runtime/  # Shared engine helpers (ack status, media, send gate, …)
 │   ├── sdk/             # TypeScript SDK (`@multiwa/sdk`)
 │   ├── sdk-python/      # Python SDK (`multiwa`)
-│   └── sdk-php/         # PHP SDK (`multiwa/multiwa-php`)
-├── plugins/             # Plugin directory
-├── docker/              # Dockerfiles (api, admin, worker)
-├── docs/                # Public documentation
+│   ├── sdk-php/         # PHP SDK (`multiwa/multiwa-php`)
+│   ├── n8n-nodes-multiwa/ # n8n community node (`n8n-nodes-multiwa`)
+│   ├── chatwoot-bridge/ # Chatwoot integration
+│   └── wordpress-plugin/# WordPress contact-form plugin
+├── plugins/             # Plugin directory (runtime loadable)
+├── docker/              # Dockerfiles + nginx reverse-proxy config
+├── docs/                # Public documentation (mirrored into docs-site)
+├── docs-site/           # Docusaurus documentation site (+ GitHub Pages build)
+├── landing/             # Static landing page assets
 ├── scripts/             # Release-gate scripts and utilities
 └── .github/workflows/   # CI, release-gate, docker-publish, docs-deploy
 ```

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -91,7 +91,8 @@ services:
       NODE_ENV: production
       DATABASE_URL: postgresql://${DB_USER:-multiwa}:${DB_PASSWORD}@postgres:5432/${DB_NAME:-multiwa}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
-      API_PORT: 3000
+      # Must match the API upstream port in docker/nginx/nginx.conf (api:3333).
+      API_PORT: 3333
       API_HOST: 0.0.0.0
       JWT_SECRET: ${JWT_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
@@ -113,7 +114,7 @@ services:
     volumes:
       - wa_sessions:/data/sessions
     healthcheck:
-      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/api/v1/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3333/api/v1/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/entrypoint-api.sh
+++ b/docker/entrypoint-api.sh
@@ -26,7 +26,9 @@ is_weak() {
     | "change-this-refresh-secret" \
     | "change-this-to-a-random-secret" \
     | "your-secure-generated-secret-key-here" \
-    | "your-super-secret-jwt-key-change-in-production")
+    | "your-super-secret-jwt-key-change-in-production" \
+    | "your-super-secret-refresh-key-change-in-production" \
+    | "CHANGE_ME")
       return 0 ;;
     *) return 1 ;;
   esac

--- a/docker/nginx/example.conf
+++ b/docker/nginx/example.conf
@@ -3,9 +3,10 @@
 # Replace your-domain.com with your actual domain
 # ================================
 
-# Upstream server (Docker container)
+# Upstream server (Docker container). The API container listens on 3333
+# (API_PORT) in both docker-compose.yml and docker-compose.production.yml.
 upstream multiwa_api {
-    server 127.0.0.1:3100;
+    server 127.0.0.1:3333;
     keepalive 64;
 }
 
@@ -59,8 +60,8 @@ server {
     # API Routes (MUST BE BEFORE static files!)
     # ================
 
-    # API Documentation (Swagger UI)
-    location = /docs {
+    # API Documentation (Swagger UI) — the app serves it at /api/docs
+    location ^~ /api/docs {
         proxy_pass http://multiwa_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -69,18 +70,9 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Swagger JSON/YAML
-    location ^~ /docs-json {
-        proxy_pass http://multiwa_api;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # All API routes (/v1/*) - prefix match
-    location ^~ /v1/ {
+    # All API routes (/api/v1/*) - prefix match.
+    # proxy_pass has NO URI so the /api/v1 global prefix is forwarded unchanged.
+    location ^~ /api/v1/ {
         proxy_pass http://multiwa_api;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -17,9 +17,14 @@ http {
     gzip on;
     gzip_types text/plain application/json application/javascript text/css;
 
-    # API upstream
+    # API upstream. The API container listens on 3333 (API_PORT) in BOTH the
+    # main docker-compose.yml and docker-compose.production.yml, and serves:
+    #   /api/v1/*   REST API (global prefix)
+    #   /api/docs   Swagger UI
+    #   /metrics    Prometheus metrics
+    #   /           root info route
     upstream api {
-        server api:3000;
+        server api:3333;
     }
 
     # Admin upstream
@@ -49,11 +54,26 @@ http {
             proxy_send_timeout 86400s;
         }
 
-        # API
+        # Auth endpoints (stricter rate limiting).
+        # The API serves auth under the /api/v1 prefix; keep the path intact
+        # (proxy_pass with NO URI preserves the original request path).
+        location /api/v1/auth/ {
+            limit_req zone=auth burst=10 nodelay;
+
+            proxy_pass http://api;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # API — REST (/api/v1/*), Swagger (/api/docs), metrics (/metrics).
+        # proxy_pass has NO trailing slash / URI so the incoming request path
+        # (including the api/v1 global prefix) is forwarded unchanged.
         location /api/ {
             limit_req zone=api burst=50 nodelay;
 
-            proxy_pass http://api/;
+            proxy_pass http://api;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -69,11 +89,10 @@ http {
             proxy_send_timeout 86400s;
         }
 
-        # Auth endpoints (stricter rate limiting)
-        location /api/auth/ {
-            limit_req zone=auth burst=10 nodelay;
-
-            proxy_pass http://api/auth/;
+        # Health endpoint — the API serves it at /api/v1/health, so map the
+        # public /health probe onto that upstream path.
+        location = /health {
+            proxy_pass http://api/api/v1/health;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -92,22 +111,6 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-        }
-
-        # Health check endpoint
-        location /health {
-            proxy_pass http://api/health;
-        }
-
-        # Media files (served via API from MinIO)
-        location /media/ {
-            limit_req zone=api burst=100 nodelay;
-            proxy_pass http://api/media/;
-            proxy_set_header Host $host;
-
-            # Cache static media
-            proxy_cache_valid 200 1h;
-            expires 1h;
         }
     }
 

--- a/docs-site/docs/api/api-specification.md
+++ b/docs-site/docs/api/api-specification.md
@@ -5,34 +5,47 @@ title: "API Specification"
 
 # 07 - API Specification
 
+> This document is source-verified against the controllers in `apps/api/src/**/*.controller.ts` as of MultiWA `1.0.0` (2026-05-24). For interactive exploration, use Swagger UI at `<API base host>:<API port>/api/docs`.
+
 ## 7.1 Overview
 
 | Property | Value |
 |----------|-------|
-| Base URL | `http://localhost:3001/api` |
-| API Version | v1 |
+| Base URL (Docker) | `http://localhost:3333/api/v1` |
+| Base URL (local dev) | `http://localhost:3000/api/v1` |
+| Swagger UI | `<API host>:<port>/api/docs` |
+| Global prefix | `api/v1` (from `app.setGlobalPrefix('api/v1')` in `apps/api/src/main.ts`) |
 | Format | JSON |
-| Auth | Bearer Token or X-API-Key header |
+| Auth | Bearer Token or `x-api-key` header |
+
+All endpoint paths in this document are relative to the base URL. For example, `POST /messages/text` resolves to `POST http://localhost:3333/api/v1/messages/text` under the Docker default.
 
 ---
 
 ## 7.2 Authentication
 
 ### Bearer Token
+
 ```
 Authorization: Bearer YOUR_JWT_TOKEN
 ```
 
+Issued by `POST /auth/register` and `POST /auth/login`. Refresh with `POST /auth/refresh`.
+
 ### API Key
+
 ```
-X-API-Key: YOUR_API_KEY
+x-api-key: YOUR_API_KEY
 ```
+
+The Swagger UI registers the API key under the `api-key` security scheme; the header name is lowercase `x-api-key`. Create keys with `POST /api-keys`.
 
 ---
 
 ## 7.3 Response Format
 
 ### Success Response
+
 ```json
 {
   "success": true,
@@ -42,6 +55,7 @@ X-API-Key: YOUR_API_KEY
 ```
 
 ### Error Response
+
 ```json
 {
   "success": false,
@@ -56,32 +70,127 @@ X-API-Key: YOUR_API_KEY
 
 ## 7.4 Endpoints
 
-### Messages
+The tables below mirror the `@Controller(...)` decorators in `apps/api/src/`. Use them as the authoritative endpoint list; if Swagger and this document diverge, Swagger wins.
+
+### Auth (`/auth`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/auth/register` | Register an account and receive tokens |
+| `POST` | `/auth/login` | Log in and receive tokens |
+| `POST` | `/auth/2fa/verify` | Verify a 2FA challenge during login |
+| `POST` | `/auth/refresh` | Exchange refresh token for a new access token |
+| `POST` | `/auth/logout` | Invalidate the current session |
+| `GET` | `/auth/me` | Get the current user |
+| `GET` | `/auth/preferences` | Get user preferences |
+| `PATCH` | `/auth/preferences` | Update user preferences |
+| `POST` | `/auth/change-password` | Change the current user's password |
+| `DELETE` | `/auth/account` | Delete the current user account |
+| `POST` | `/auth/2fa/setup` | Begin 2FA enrollment |
+| `POST` | `/auth/2fa/enable` | Confirm and enable 2FA |
+| `POST` | `/auth/2fa/disable` | Disable 2FA |
+| `POST` | `/auth/2fa/backup-codes` | Generate 2FA backup codes |
+| `GET` | `/auth/sessions` | List active sessions |
+| `DELETE` | `/auth/sessions/:id` | Revoke a specific session |
+| `DELETE` | `/auth/sessions` | Revoke all sessions except current |
+
+### Health (`/health`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/health` | Liveness probe |
+| `GET` | `/health/ready` | Readiness probe |
+
+### Accounts (`/accounts`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/accounts` | List accounts |
+| `POST` | `/accounts` | Create account |
+| `GET` | `/accounts/:id` | Get account |
+| `PUT` | `/accounts/:id` | Update account |
+| `DELETE` | `/accounts/:id` | Delete account |
+| `GET` | `/accounts/:accountId/profiles` | List profiles inside an account |
+| `POST` | `/accounts/:accountId/profiles` | Create a profile in an account |
+| `GET` | `/accounts/:accountId/profiles/:profileId` | Get profile (account-scoped) |
+| `DELETE` | `/accounts/:accountId/profiles/:profileId` | Delete profile (account-scoped) |
+| `POST` | `/accounts/:accountId/profiles/:profileId/connect` | Start WhatsApp connection |
+| `POST` | `/accounts/:accountId/profiles/:profileId/disconnect` | Disconnect |
+| `GET` | `/accounts/:accountId/profiles/:profileId/qr` | Retrieve current QR code |
+
+### Profiles (`/profiles`) — flat alternative to the account-scoped routes
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/profiles` | List profiles |
+| `POST` | `/profiles` | Create profile |
+| `GET` | `/profiles/:id` | Get profile |
+| `PUT` | `/profiles/:id` | Update profile |
+| `DELETE` | `/profiles/:id` | Delete profile |
+| `POST` | `/profiles/:id/connect` | Start WhatsApp connection |
+| `POST` | `/profiles/:id/disconnect` | Disconnect |
+| `GET` | `/profiles/:id/status` | Get connection status |
+
+> The QR endpoint lives under the account-scoped `/accounts/.../qr` route, not on the flat `/profiles` resource.
+
+### Messages (`/messages`)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/messages/text` | Send text message |
+| `POST` | `/messages/otp` | Send an OTP with delivery-confirmed failover to a secondary channel |
 | `POST` | `/messages/image` | Send image |
 | `POST` | `/messages/video` | Send video |
+| `POST` | `/messages/audio` | Send audio/voice |
 | `POST` | `/messages/document` | Send document |
 | `POST` | `/messages/location` | Send location |
 | `POST` | `/messages/contact` | Send contact card |
+| `POST` | `/messages/reaction` | Send a reaction |
+| `POST` | `/messages/reply` | Send a quoted reply |
 | `POST` | `/messages/poll` | Send poll |
+| `POST` | `/messages/typing` | Set typing presence |
+| `POST` | `/messages/mark-read` | Mark messages read |
+| `POST` | `/messages/delete-for-everyone` | Delete message for everyone |
+| `POST` | `/messages/schedule` | Schedule a message |
+| `GET` | `/messages/schedule/:profileId` | List scheduled messages for a profile |
+| `DELETE` | `/messages/schedule/:id` | Cancel a scheduled message |
+| `GET` | `/messages/profile/:profileId` | List messages for a profile |
+| `GET` | `/messages/conversation/:conversationId` | List messages in a conversation |
+| `GET` | `/messages/conversation/:conversationId/load-older` | Fetch older messages from WhatsApp and persist them |
+| `GET` | `/messages/:id` | Get a single message |
+| `DELETE` | `/messages/:id` | Delete a message locally |
 
-### Bulk Messaging
+### Bulk Messaging (`/bulk`)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/bulk/send` | Send bulk messages with variables |
-| `GET` | `/bulk/batches` | List all batches |
+| `GET` | `/bulk/batches` | List batches |
 | `GET` | `/bulk/batch/:batchId` | Get batch status |
 | `POST` | `/bulk/batch/:batchId/cancel` | Cancel batch |
 
-### Groups
+### Broadcast (`/broadcast`)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/groups/profile/:profileId` | List all groups |
+| `POST` | `/broadcast` | Create a broadcast campaign |
+| `GET` | `/broadcast` | List broadcasts |
+| `GET` | `/broadcast/:id` | Get broadcast |
+| `PUT` | `/broadcast/:id` | Update broadcast |
+| `DELETE` | `/broadcast/:id` | Delete broadcast |
+| `POST` | `/broadcast/:id/schedule` | Schedule broadcast |
+| `POST` | `/broadcast/:id/start` | Start broadcast immediately |
+| `POST` | `/broadcast/:id/pause` | Pause broadcast |
+| `POST` | `/broadcast/:id/resume` | Resume broadcast |
+| `POST` | `/broadcast/:id/cancel` | Cancel broadcast |
+| `GET` | `/broadcast/:id/stats` | Broadcast delivery stats |
+| `GET` | `/broadcast/:id/recipients` | Broadcast recipient list |
+
+### Groups (`/groups`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/groups/profile/:profileId` | List groups for a profile |
 | `GET` | `/groups/:groupId` | Get group info |
 | `POST` | `/groups` | Create group |
 | `PATCH` | `/groups/:groupId` | Update group |
@@ -91,46 +200,238 @@ X-API-Key: YOUR_API_KEY
 | `POST` | `/groups/:groupId/participants/demote` | Demote from admin |
 | `POST` | `/groups/:groupId/leave` | Leave group |
 | `GET` | `/groups/:groupId/invite-link` | Get invite link |
+| `POST` | `/groups/:groupId/invite-link/revoke` | Revoke invite link |
 
-### Profiles
+### Conversations (`/conversations`)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/profiles` | List all profiles |
-| `POST` | `/profiles` | Create profile |
-| `GET` | `/profiles/:id` | Get profile |
-| `DELETE` | `/profiles/:id` | Delete profile |
-| `POST` | `/profiles/:id/connect` | Start connection |
-| `GET` | `/profiles/:id/qr` | Get QR code |
-| `POST` | `/profiles/:id/disconnect` | Disconnect |
+| `GET` | `/conversations` | List conversations |
+| `GET` | `/conversations/unread-count` | Total unread message count across the org |
+| `GET` | `/conversations/:id` | Get conversation |
+| `GET` | `/conversations/:id/messages` | List messages in conversation |
+| `PUT` | `/conversations/:id/read` | Mark conversation read |
+| `PUT` | `/conversations/:id/archive` | Archive |
+| `PUT` | `/conversations/:id/unarchive` | Unarchive |
+| `PUT` | `/conversations/:id/mute` | Mute |
+| `PUT` | `/conversations/:id/pin` | Pin |
+| `DELETE` | `/conversations/:id` | Delete conversation |
+| `DELETE` | `/conversations/:id/messages` | Clear messages in conversation |
 
-### Contacts
+### Contacts (`/contacts`)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/contacts` | List contacts |
 | `POST` | `/contacts` | Create contact |
 | `GET` | `/contacts/:id` | Get contact |
-| `PATCH` | `/contacts/:id` | Update contact |
+| `PUT` | `/contacts/:id` | Update contact |
 | `DELETE` | `/contacts/:id` | Delete contact |
+| `POST` | `/contacts/import` | Import contacts |
+| `POST` | `/contacts/import/csv` | Import contacts from CSV |
+| `GET` | `/contacts/export/csv` | Export contacts as CSV |
 | `POST` | `/contacts/:id/tags` | Add tags |
+| `DELETE` | `/contacts/:id/tags` | Remove tags |
+| `GET` | `/contacts/profile/:profileId/validate/:phone` | Validate a single phone number on WhatsApp |
+| `POST` | `/contacts/profile/:profileId/validate` | Validate a batch of phone numbers |
+| `POST` | `/contacts/sync/whatsapp` | Sync contacts from WhatsApp |
+| `POST` | `/contacts/profile/:profileId/save-to-whatsapp` | Save a contact into the WhatsApp account addressbook (whatsapp-web-js only) |
+| `DELETE` | `/contacts/profile/:profileId/whatsapp/:phone` | Delete a contact from the WhatsApp account addressbook (whatsapp-web-js only) |
 
-### Webhooks
+### Templates (`/templates`)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/webhooks` | List webhooks |
+| `POST` | `/templates` | Create template |
+| `GET` | `/templates` | List templates |
+| `GET` | `/templates/:id` | Get template |
+| `PUT` | `/templates/:id` | Update template |
+| `DELETE` | `/templates/:id` | Delete template |
+| `POST` | `/templates/:id/preview` | Render preview with variables |
+| `POST` | `/templates/:id/duplicate` | Duplicate template |
+
+### Webhooks (`/webhooks`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
 | `POST` | `/webhooks` | Create webhook |
+| `GET` | `/webhooks` | List webhooks |
+| `GET` | `/webhooks/:id` | Get webhook |
+| `PUT` | `/webhooks/:id` | Update webhook |
 | `DELETE` | `/webhooks/:id` | Delete webhook |
+| `POST` | `/webhooks/:id/test` | Send a test event |
+
+> **Removed:** the legacy global `/hooks` registry has been retired. Use the
+> organization-scoped `/webhooks` endpoints above — they sign every delivery with
+> an HMAC `X-MultiWA-Signature` header and are isolated per tenant.
+
+### Automation (`/automation`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/automation` | Create automation flow |
+| `GET` | `/automation` | List automation flows |
+| `GET` | `/automation/:id` | Get flow |
+| `PUT` | `/automation/:id` | Update flow |
+| `DELETE` | `/automation/:id` | Delete flow |
+| `PUT` | `/automation/:id/toggle` | Toggle active flag |
+| `POST` | `/automation/:id/test` | Test a flow with sample input |
+| `GET` | `/automation/:id/stats` | Flow execution stats |
+| `POST` | `/automation/reorder` | Reorder flows |
+
+### Auto-reply (`/autoreply`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/autoreply/quick-replies` | Create a quick reply |
+| `GET` | `/autoreply/quick-replies` | List quick replies |
+| `DELETE` | `/autoreply/quick-replies/:id` | Delete a quick reply |
+| `POST` | `/autoreply` | Create an auto-reply rule |
+| `GET` | `/autoreply` | List auto-reply rules |
+| `GET` | `/autoreply/:id` | Get rule |
+| `PUT` | `/autoreply/:id` | Update rule |
+| `DELETE` | `/autoreply/:id` | Delete rule |
+| `PUT` | `/autoreply/:id/toggle` | Toggle active flag |
+| `POST` | `/autoreply/webhook-reply` | Configure webhook-driven reply |
+| `GET` | `/autoreply/webhook-reply/:profileId` | Get webhook-reply config |
+| `POST` | `/autoreply/ai-hook` | Configure AI-driven reply |
+| `GET` | `/autoreply/ai-hook/:profileId` | Get AI-hook config |
+
+### AI (`/ai` and `/ai/knowledge`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/ai/status` | AI provider status |
+| `POST` | `/ai/complete` | Generic completion |
+| `POST` | `/ai/auto-reply` | Generate an auto-reply suggestion |
+| `POST` | `/ai/sentiment` | Sentiment scoring |
+| `POST` | `/ai/translate` | Translate text |
+| `POST` | `/ai/knowledge/:profileId/text` | Ingest text into the knowledge base |
+| `GET` | `/ai/knowledge/:profileId` | List knowledge documents |
+| `DELETE` | `/ai/knowledge/:id` | Delete a knowledge document |
+| `POST` | `/ai/knowledge/:profileId/search` | Search the knowledge base |
+
+### API Keys (`/api-keys`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api-keys` | List API keys |
+| `POST` | `/api-keys` | Create API key |
+| `DELETE` | `/api-keys/:id` | Revoke API key |
+
+### Settings (`/settings`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/settings/storage` | Get storage settings |
+| `PUT` | `/settings/storage` | Update storage settings |
+| `POST` | `/settings/storage/test` | Test storage configuration |
+| `GET` | `/settings/smtp` | Get SMTP settings |
+| `PUT` | `/settings/smtp` | Update SMTP settings |
+| `POST` | `/settings/smtp/test` | Test SMTP configuration |
+
+### Uploads (`/uploads`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/uploads/media` | Upload media for use in messages |
+
+### Integrations (`/integrations`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/integrations/config` | Get integration config |
+| `PUT` | `/integrations/config` | Update integration config |
+| `POST` | `/integrations/test` | Test integration connectivity |
+
+### Statistics (`/statistics`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/statistics/dashboard` | Dashboard summary |
+| `GET` | `/statistics/messages` | Message totals |
+| `GET` | `/statistics/messages/trend` | Message volume trend |
+| `GET` | `/statistics/contacts` | Contact stats |
+| `GET` | `/statistics/broadcasts` | Broadcast stats |
+| `GET` | `/statistics/automations` | Automation stats |
+| `GET` | `/statistics/response-time` | Response-time stats |
+
+### Audit (`/audit`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/audit/logs` | List audit log entries |
+| `GET` | `/audit/summary` | Audit summary |
+| `GET` | `/audit/actions` | Audit action catalog |
+
+### Notifications (`/notifications`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/notifications` | List notifications |
+| `GET` | `/notifications/unread-count` | Unread count |
+| `PATCH` | `/notifications/:id/read` | Mark a notification read |
+| `PATCH` | `/notifications/read-all` | Mark all read |
+| `DELETE` | `/notifications/:id` | Delete one |
+| `DELETE` | `/notifications` | Delete all |
+| `GET` | `/notifications/push/vapid-key` | Web Push VAPID public key |
+| `GET` | `/notifications/push/subscriptions` | List push subscriptions |
+| `POST` | `/notifications/push/subscribe` | Register a push subscription |
+| `POST` | `/notifications/push/unsubscribe` | Remove a push subscription |
+| `POST` | `/notifications/push/test` | Send a test push notification |
+
+### Organizations (`/organizations`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/organizations/current` | Get current organization |
+| `PUT` | `/organizations/current` | Update current organization |
+| `GET` | `/organizations/members` | List members |
+| `POST` | `/organizations/members` | Invite a member |
+| `PUT` | `/organizations/members/:id/role` | Change member role |
+| `DELETE` | `/organizations/members/:id` | Remove member |
+
+### Workspaces (`/workspaces`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/workspaces` | List workspaces |
+| `POST` | `/workspaces` | Create workspace |
+| `GET` | `/workspaces/:id` | Get workspace |
+| `PUT` | `/workspaces/:id` | Update workspace |
+| `DELETE` | `/workspaces/:id` | Delete workspace |
+
+### RBAC (`/rbac`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/rbac/permissions` | List permissions |
+| `POST` | `/rbac/roles` | Create role |
+| `GET` | `/rbac/roles` | List roles |
+| `GET` | `/rbac/roles/:id` | Get role |
+| `PUT` | `/rbac/roles/:id` | Update role |
+| `DELETE` | `/rbac/roles/:id` | Delete role |
+| `POST` | `/rbac/assign` | Assign role to user |
+| `DELETE` | `/rbac/users/:userId/organizations/:orgId` | Unassign user from organization |
+| `GET` | `/rbac/users/:userId/roles` | List user roles |
+| `GET` | `/rbac/users/:userId/permissions` | List user permissions |
+| `POST` | `/rbac/organizations/:id/seed` | Seed default roles for an organization |
+
+### GDPR (`/account`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/account/export` | Export personal data |
+| `DELETE` | `/account/delete` | Delete account and personal data |
 
 ---
 
 ## 7.5 Example: Send Bulk with Variables
 
 ```bash
-curl -X POST http://localhost:3001/api/bulk/send \
+curl -X POST http://localhost:3333/api/v1/bulk/send \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_API_KEY" \
+  -H "x-api-key: YOUR_API_KEY" \
   -d '{
     "profileId": "profile-123",
     "messages": [
@@ -156,4 +457,4 @@ curl -X POST http://localhost:3001/api/bulk/send \
 
 ---
 
-[← Engine Abstraction](/architecture/engine-abstraction) · [Documentation Index](/getting-started/project-overview) · [WebSocket API →](/api/websocket-api)
+[← Engine Abstraction](<../architecture/engine-abstraction.md>) · [Documentation Index](<../intro.md>) · [WebSocket API →](<websocket-api.md>)

--- a/docs-site/docs/api/webhook-events.md
+++ b/docs-site/docs/api/webhook-events.md
@@ -13,19 +13,21 @@ MultiWA delivers real-time events to your HTTP endpoints via webhooks.
 
 ## Configuration
 
+All paths use the API base URL described in [API Specification](<api-specification.md#71-overview>): Docker default is `http://localhost:3333/api/v1`.
+
 ### Per-Profile Webhook
 ```bash
-POST /api/profiles/:id/webhook
+POST /api/v1/profiles/:id/webhook
 {
   "url": "https://yourserver.com/webhook",
   "secret": "optional-hmac-secret",
-  "events": ["message.received", "session.status"]
+  "events": ["message.received", "connection.ready"]
 }
 ```
 
 ### Global Webhook
 ```bash
-POST /api/webhooks
+POST /api/v1/webhooks
 {
   "url": "https://yourserver.com/webhook",
   "secret": "your-secret",
@@ -43,9 +45,10 @@ POST /api/webhooks
 | `message.sent` | Outgoing message confirmed |
 | `message.delivered` | Message delivered (✓✓) |
 | `message.read` | Message read (blue ✓✓) |
-| `session.connected` | WhatsApp connected |
-| `session.disconnected` | WhatsApp disconnected |
-| `session.qr` | New QR code generated |
+| `message.failed` | Message delivery failed |
+| `connection.qr` | New QR code generated |
+| `connection.ready` | WhatsApp connected |
+| `connection.disconnected` | WhatsApp disconnected |
 
 ---
 
@@ -70,23 +73,28 @@ POST /api/webhooks
 
 ## HMAC Verification
 
-If you set a `secret`, verify the signature:
+If you set a `secret`, verify the signature over the **raw request body** (the exact bytes MultiWA sent), not a re-serialized object:
 
 ```javascript
 const crypto = require('crypto');
 
-function verifyWebhook(body, signature, secret) {
-  const expected = crypto
-    .createHmac('sha256', secret)
-    .update(JSON.stringify(body))
-    .digest('hex');
-  return `sha256=${expected}` === signature;
+// Capture the RAW request body so the HMAC matches byte-for-byte. MultiWA signs
+// the exact bytes it sends, so verify against the raw body — a re-serialized
+// object (JSON.stringify(req.body)) is NOT guaranteed to match.
+app.use(express.json({ verify: (req, _res, buf) => { req.rawBody = buf; } }));
+
+function verifyWebhook(rawBody, signature, secret) {
+  const expected =
+    'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  const got = signature || '';
+  return expected.length === got.length &&
+    crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(got));
 }
 
 // In your handler
 app.post('/webhook', (req, res) => {
   const signature = req.headers['x-multiwa-signature'];
-  if (!verifyWebhook(req.body, signature, 'your-secret')) {
+  if (!verifyWebhook(req.rawBody, signature, 'your-secret')) {
     return res.status(401).send('Invalid signature');
   }
   // Process event...
@@ -95,18 +103,33 @@ app.post('/webhook', (req, res) => {
 
 ---
 
-## Retry Policy
+## Delivery & Retry
 
-| Attempt | Delay |
-|---------|-------|
+Webhook delivery is **durable**: events are enqueued to a BullMQ queue and
+delivered by the worker, so deliveries survive an API restart and a slow or failing
+endpoint never blocks the WhatsApp pipeline. Each delivery is signed with
+`X-MultiWA-Signature: sha256=<hmac>` and carries `X-MultiWA-Event`. A 30s per-request
+timeout applies.
+
+Failed deliveries (non-2xx, network error, or timeout) are retried with BullMQ
+exponential backoff (`delay: 30s`):
+
+| Attempt | Approx. delay before it runs |
+|---------|------------------------------|
 | 1 | Immediate |
-| 2 | 30 seconds |
-| 3 | 2 minutes |
-| 4 | 10 minutes |
-| 5 | 1 hour |
+| 2 | ~30 seconds |
+| 3 | ~1 minute |
+| 4 | ~2 minutes |
+| 5 | ~4 minutes |
 
-After 5 failed attempts, the webhook is marked as failing.
+Retry delays are approximate BullMQ exponential-backoff values. After 5 failed
+attempts the job enters the BullMQ failed state. Every attempt (success or failure)
+writes a `WebhookLog` row, so the rows for a webhook give the full delivery history.
+
+> Payload logging: the worker honours `WEBHOOK_LOG_PAYLOAD_MAX_BYTES` (default 512;
+> `0` omits the payload; `-1` keeps it in full) to control how much of each event
+> body is persisted in `WebhookLog`.
 
 ---
 
-[← WebSocket API](/api/websocket-api) · [Documentation Index](/getting-started/project-overview) · [Messaging →](/features/messaging)
+[← WebSocket API](<websocket-api.md>) · [Documentation Index](<../intro.md>) · [Messaging →](<../features/messaging.md>)

--- a/docs-site/docs/api/websocket-api.md
+++ b/docs-site/docs/api/websocket-api.md
@@ -165,4 +165,4 @@ ws.onclose = () => {
 
 ---
 
-[← API Specification](/api/api-specification) · [Documentation Index](/getting-started/project-overview) · [Webhook Events →](/api/webhook-events)
+[← API Specification](<api-specification.md>) · [Documentation Index](<../intro.md>) · [Webhook Events →](<webhook-events.md>)

--- a/docs-site/docs/architecture/database-design.md
+++ b/docs-site/docs/architecture/database-design.md
@@ -41,8 +41,8 @@ model Profile {
   id          String    @id @default(cuid())
   name        String
   phone       String?
-  status      SessionStatus @default(DISCONNECTED)
-  engine      EngineType    @default(BAILEYS)
+  status      String        @default("disconnected")
+  engine      String        @default("whatsapp-web-js") // whatsapp-web-js | baileys | mock
   webhookUrl  String?
   createdAt   DateTime  @default(now())
   
@@ -95,10 +95,8 @@ enum SessionStatus {
   CONNECTED
 }
 
-enum EngineType {
-  BAILEYS
-  WHATSAPP_WEB_JS
-}
+// Engine is stored as a plain String on Profile (not a DB enum). Valid values are
+// validated at the application layer: whatsapp-web-js (default) | baileys | mock.
 
 enum MessageType {
   TEXT
@@ -125,4 +123,4 @@ enum MessageType {
 
 ---
 
-[← System Architecture](/architecture/system-architecture) · [Documentation Index](/getting-started/project-overview) · [Engine Abstraction →](/architecture/engine-abstraction)
+[← System Architecture](<system-architecture.md>) · [Documentation Index](<../intro.md>) · [Engine Abstraction →](<engine-abstraction.md>)

--- a/docs-site/docs/architecture/engine-abstraction.md
+++ b/docs-site/docs/architecture/engine-abstraction.md
@@ -13,10 +13,14 @@ MultiWA supports multiple WhatsApp client libraries through an abstraction layer
 
 ## Supported Engines
 
-| Engine | Status | Description |
-|--------|--------|-------------|
-| **Baileys** | ✅ Default | Pure Node.js, fastest |
-| **WhatsApp-Web.js** | ✅ Supported | Puppeteer-based, more stable |
+| Engine | Key | Status | Notes |
+|--------|-----|--------|-------|
+| **WhatsApp-Web.js** | `whatsapp-web-js` | ✅ Default (production) | Puppeteer-based, most stable, best group support |
+| **Baileys** | `baileys` | ⚠️ Experimental | Pure Node.js; `sendReaction` is a no-op stub and `getContacts` may be unavailable — not validated for production |
+| **Mock** | `mock` | 🧪 Testing only | Simulated adapter for local/dev and tests |
+
+Each `Profile` has an `engine` column selecting its adapter. The engine is
+instantiated through `EngineFactory.create()` when the profile connects.
 
 ---
 
@@ -52,16 +56,29 @@ interface IWhatsAppEngine {
 
 ## Configuration
 
-```typescript
-// .env
-ENGINE_TYPE=baileys  // or whatsapp-web.js
+Engine selection precedence (resolved in `EngineManagerService.resolveEngineType`):
 
-// Per-profile override
+1. The profile's `engine` field (validated: `whatsapp-web-js` | `baileys` | `mock`)
+2. The `DEFAULT_ENGINE` environment variable (if a valid engine key)
+3. `whatsapp-web-js` (fallback)
+
+```bash
+# .env — default engine for profiles that don't set one explicitly
+# Options: whatsapp-web-js (default) | baileys (EXPERIMENTAL) | mock (testing only)
+DEFAULT_ENGINE=whatsapp-web-js
+```
+
+```jsonc
+// Per-profile selection — POST/PUT /profiles
 {
-  "profileId": "abc123",
-  "engine": "WHATSAPP_WEB_JS"
+  "engine": "whatsapp-web-js"
 }
 ```
+
+> Changing a profile's engine takes effect on the **next reconnect**; the API
+> returns a warning when the engine changes. Clear the engine-specific session
+> directory (`.wwebjs_auth` for whatsapp-web-js, `creds.json` for Baileys) before
+> reconnecting to avoid a stale session.
 
 ---
 
@@ -77,10 +94,12 @@ Engine Event → EngineManager → EventsGateway → WebSocket/Webhook
 
 ## Adding New Engines
 
-1. Implement `IWhatsAppEngine` interface
-2. Register in `EngineFactory`
-3. Add to `EngineType` enum in Prisma
+1. Implement the `IWhatsAppEngine` interface (`packages/engines`)
+2. Register the new key in `EngineFactory.create()`
+3. Add the key to the `EngineType` union (`packages/engines/src/types.ts`) and the
+   `EngineType` DTO enum (`apps/api/.../profiles/dto`). The Prisma `Profile.engine`
+   column is a plain `String`, so no schema enum change is needed.
 
 ---
 
-[← Database Design](/architecture/database-design) · [Documentation Index](/getting-started/project-overview) · [API Specification →](/api/api-specification)
+[← Database Design](<database-design.md>) · [Documentation Index](<../intro.md>) · [API Specification →](<../api/api-specification.md>)

--- a/docs-site/docs/architecture/system-architecture.md
+++ b/docs-site/docs/architecture/system-architecture.md
@@ -87,4 +87,4 @@ Organization (Tenant)
 
 ---
 
-[← Quick Start](/getting-started/quick-start) · [Documentation Index](/getting-started/project-overview) · [Database Design →](/architecture/database-design)
+[← Quick Start](<../getting-started/quick-start.md>) · [Documentation Index](<../intro.md>) · [Database Design →](<database-design.md>)

--- a/docs-site/docs/features/automation.md
+++ b/docs-site/docs/features/automation.md
@@ -7,20 +7,24 @@ title: "Automation"
 
 ## Overview
 
-MultiWA provides powerful automation capabilities:
+All paths use the global `/api/v1` prefix (Docker default base URL: `http://localhost:3333/api/v1`). Endpoints below are source-verified from `apps/api/src/modules/autoreply/autoreply.controller.ts` and `apps/api/src/modules/automation/automation.controller.ts`.
 
-- **Auto-Reply**: AI-powered automatic responses
-- **Visual Flow Builder**: Drag-and-drop workflow designer
-- **Scheduled Messages**: Time-based sending
+MultiWA provides three layers of automation:
+
+- **Auto-Reply** — keyword, exact, or AI-generated replies driven by an incoming message.
+- **Visual Flow Builder** — drag-and-drop multi-step workflows on top of the same engine.
+- **Scheduled Messages** — time-based sending via the messages module.
 
 ---
 
 ## Auto-Reply
 
-### AI-Powered Replies
+The auto-reply controller is mounted at `/autoreply`. Rules live directly under that prefix — there is no `/rules` segment.
+
+### Create an AI-Powered Rule
 
 ```bash
-POST /api/autoreply/rules
+POST /api/v1/autoreply
 {
   "profileId": "profile-123",
   "name": "Support Bot",
@@ -37,10 +41,10 @@ POST /api/autoreply/rules
 }
 ```
 
-### Keyword-Based Replies
+### Create a Keyword-Based Rule
 
 ```bash
-POST /api/autoreply/rules
+POST /api/v1/autoreply
 {
   "profileId": "profile-123",
   "name": "Price List",
@@ -55,11 +59,52 @@ POST /api/autoreply/rules
 }
 ```
 
+### Manage Rules
+
+```bash
+# List
+GET    /api/v1/autoreply
+
+# Get one
+GET    /api/v1/autoreply/:id
+
+# Update
+PUT    /api/v1/autoreply/:id
+
+# Delete
+DELETE /api/v1/autoreply/:id
+
+# Toggle active flag
+PUT    /api/v1/autoreply/:id/toggle
+```
+
+### Quick Replies
+
+A separate sub-resource for canned replies surfaced in the Admin UI:
+
+```bash
+POST   /api/v1/autoreply/quick-replies
+GET    /api/v1/autoreply/quick-replies
+DELETE /api/v1/autoreply/quick-replies/:id
+```
+
+### Webhook-Driven and AI-Hook Replies
+
+For more advanced setups you can wire an HTTP webhook or an AI hook per profile:
+
+```bash
+POST /api/v1/autoreply/webhook-reply
+GET  /api/v1/autoreply/webhook-reply/:profileId
+
+POST /api/v1/autoreply/ai-hook
+GET  /api/v1/autoreply/ai-hook/:profileId
+```
+
 ---
 
 ## Visual Flow Builder
 
-Create complex automation workflows visually:
+Create complex automation workflows visually. The controller is mounted at `/automation`; flows live directly under that prefix — there is no `/flows` segment.
 
 ### Node Types
 
@@ -82,11 +127,8 @@ Create complex automation workflows visually:
 ### API
 
 ```bash
-# List flows
-GET /api/automation/flows?profileId=xxx
-
 # Create flow
-POST /api/automation/flows
+POST   /api/v1/automation
 {
   "profileId": "profile-123",
   "name": "Order Flow",
@@ -94,27 +136,54 @@ POST /api/automation/flows
   "edges": [...]
 }
 
-# Activate/deactivate
-PATCH /api/automation/flows/:id
-{
-  "isActive": true
-}
+# List flows (filter by profile via query string)
+GET    /api/v1/automation?profileId=xxx
+
+# Get one
+GET    /api/v1/automation/:id
+
+# Update
+PUT    /api/v1/automation/:id
+
+# Delete
+DELETE /api/v1/automation/:id
+
+# Toggle active flag
+PUT    /api/v1/automation/:id/toggle
+
+# Test a flow with a sample payload
+POST   /api/v1/automation/:id/test
+
+# Read execution stats
+GET    /api/v1/automation/:id/stats
+
+# Reorder flows
+POST   /api/v1/automation/reorder
 ```
 
 ---
 
 ## Scheduled Messages
 
+Scheduling is part of the messages module, not the automation module:
+
 ```bash
-POST /api/messages/schedule
+# Schedule
+POST   /api/v1/messages/schedule
 {
   "profileId": "profile-123",
   "to": "628123456789",
   "text": "Happy Birthday!",
   "scheduledAt": "2026-02-14T00:00:00Z"
 }
+
+# List scheduled messages for a profile
+GET    /api/v1/messages/schedule/:profileId
+
+# Cancel a scheduled message
+DELETE /api/v1/messages/schedule/:id
 ```
 
 ---
 
-[← Groups](/features/groups) · [Documentation Index](/getting-started/project-overview) · [Python SDK →](/sdks/python-sdk)
+[← Groups](<groups.md>) · [Documentation Index](<../intro.md>) · [Python SDK →](<../sdks/python-sdk.md>)

--- a/docs-site/docs/features/groups.md
+++ b/docs-site/docs/features/groups.md
@@ -180,7 +180,7 @@ Returns new invite link after revoking the old one.
 ```python
 from multiwa import MultiWA
 
-client = MultiWA("http://localhost:3001/api", "YOUR_API_KEY")
+client = MultiWA("http://localhost:3333/api/v1", "YOUR_API_KEY")
 
 # List all groups
 groups = client.groups.get_all("profile-123")
@@ -202,4 +202,4 @@ client.groups.add_participants(
 
 ---
 
-[← Messaging](/features/messaging) · [Documentation Index](/getting-started/project-overview) · [Automation →](/features/automation)
+[← Messaging](<messaging.md>) · [Documentation Index](<../intro.md>) · [Automation →](<automation.md>)

--- a/docs-site/docs/features/messaging.md
+++ b/docs-site/docs/features/messaging.md
@@ -13,25 +13,27 @@ Send and receive all types of WhatsApp messages.
 
 ## Message Types
 
+All paths use the global `/api/v1` prefix (Docker default base URL: `http://localhost:3333/api/v1`).
+
 | Type | Endpoint | Description |
 |------|----------|-------------|
-| Text | `POST /messages/text` | Plain text messages |
-| Image | `POST /messages/image` | Images with caption |
-| Video | `POST /messages/video` | Videos with caption |
-| Audio | `POST /messages/audio` | Voice/audio files |
-| Document | `POST /messages/document` | Files/PDFs |
-| Location | `POST /messages/location` | Map locations |
-| Contact | `POST /messages/contact` | Contact cards |
-| Poll | `POST /messages/poll` | Interactive polls |
+| Text | `POST /api/v1/messages/text` | Plain text messages |
+| Image | `POST /api/v1/messages/image` | Images with caption |
+| Video | `POST /api/v1/messages/video` | Videos with caption |
+| Audio | `POST /api/v1/messages/audio` | Voice/audio files |
+| Document | `POST /api/v1/messages/document` | Files/PDFs |
+| Location | `POST /api/v1/messages/location` | Map locations |
+| Contact | `POST /api/v1/messages/contact` | Contact cards |
+| Poll | `POST /api/v1/messages/poll` | Interactive polls |
 
 ---
 
 ## Send Text
 
 ```bash
-curl -X POST http://localhost:3001/api/messages/text \
+curl -X POST http://localhost:3333/api/v1/messages/text \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
+  -H "x-api-key: YOUR_KEY" \
   -d '{
     "profileId": "profile-123",
     "to": "628123456789",
@@ -44,9 +46,9 @@ curl -X POST http://localhost:3001/api/messages/text \
 ## Send Image
 
 ```bash
-curl -X POST http://localhost:3001/api/messages/image \
+curl -X POST http://localhost:3333/api/v1/messages/image \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
+  -H "x-api-key: YOUR_KEY" \
   -d '{
     "profileId": "profile-123",
     "to": "628123456789",
@@ -60,9 +62,9 @@ curl -X POST http://localhost:3001/api/messages/image \
 ## Send Poll
 
 ```bash
-curl -X POST http://localhost:3001/api/messages/poll \
+curl -X POST http://localhost:3333/api/v1/messages/poll \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
+  -H "x-api-key: YOUR_KEY" \
   -d '{
     "profileId": "profile-123",
     "to": "628123456789",
@@ -102,11 +104,58 @@ For groups, use the full JID: `123456789-123456@g.us`
 
 ---
 
-## Rate Limits
+## Send Gate (pacing & daily limit)
 
-- **Per profile**: 30 messages/minute (adjustable)
-- **Bulk API**: Use `/bulk/send` for high-volume
+Every outbound send — direct API, automation, broadcast, scheduled, and bulk —
+passes through a **per-profile send gate** that enforces anti-ban pacing:
+
+| Profile field | Meaning | Default |
+|---------------|---------|---------|
+| `messageDelayMs` | Minimum delay between consecutive messages for the profile. The gate serializes sends per profile and waits out the remaining delay (block-and-wait). | `1500` |
+| `dailyMessageLimit` | Daily outbound cap for the profile. `null` = unlimited. | `null` (unlimited) |
+| `dailyMessageCount` | Messages sent so far in the current window (read-only). | `0` |
+| `dailyResetAt` | When the counter next resets (00:00 WIB / Asia-Jakarta). | — |
+
+Set `messageDelayMs` / `dailyMessageLimit` via `PUT /profiles/:id`.
+
+When a profile reaches its `dailyMessageLimit`, further sends are rejected with
+**HTTP 429**:
+
+```json
+{ "error": "DAILY_LIMIT_REACHED", "limit": 1000, "count": 1000, "resetAt": "2026-06-17T00:00:00+07:00" }
+```
+
+Counters reset daily at **midnight WIB (Asia/Jakarta, UTC+7)**.
+
+## Durable Sending (optional)
+
+By default, `POST /messages/...` sends synchronously and returns the result
+(`status: "sent"`). Set **`DURABLE_SEND=true`** to make sending durable:
+
+- The API enqueues the send to a Redis-backed queue and returns **`202`** with
+  `{ "success": true, "status": "queued", "messageId": "<id>" }` immediately.
+- An in-process consumer drains the queue and performs the actual send through the
+  send gate. Jobs survive an API restart and are retried (3 attempts, exponential
+  backoff) on transient failure.
+- The final outcome surfaces via the message's `status` (`sent` / `failed`) and
+  the `message.sent` / `message.failed` webhook events.
+- The daily limit is still enforced synchronously where possible: an over-limit
+  send is rejected with the same **`429 DAILY_LIMIT_REACHED`** before enqueue. In
+  a rare race, a queued send can instead end as `status: "failed"` with a
+  `message.failed` event.
+
+> Contract note: when `DURABLE_SEND=true`, send endpoints return `202 queued`
+> rather than a synchronous `sent` result. Consumers should track delivery via
+> `message.status` or webhook events. `OUTBOUND_SEND_CONCURRENCY` (default 10)
+> tunes throughput; per-profile ordering and pacing are preserved regardless.
+
+## Global Rate Limit
+
+- **API throttle**: 120 requests/minute per IP (global `ThrottlerGuard`).
+- **Bulk API**: use `POST /api/v1/bulk/send` for high-volume sends — it routes
+  through the same per-profile send gate (so `messageDelayMs` and the daily limit
+  apply) plus its own configurable inter-message delay.
 
 ---
 
-[← Webhook Events](/api/webhook-events) · [Documentation Index](/getting-started/project-overview) · [Groups →](/features/groups)
+[← Webhook Events](<../api/webhook-events.md>) · [Documentation Index](<../intro.md>) · [Groups →](<groups.md>)

--- a/docs-site/docs/getting-started/project-overview.md
+++ b/docs-site/docs/getting-started/project-overview.md
@@ -52,7 +52,7 @@ Provide a robust, scalable, and developer-friendly WhatsApp API that rivals comm
 2. **Enterprise-Ready** - Multi-tenant, RBAC, audit logging
 3. **Developer Experience** - SDKs, Swagger docs, WebSocket real-time
 4. **Automation** - Visual flow builder, auto-reply, n8n integration
-5. **Scalability** - Redis queues, horizontal scaling ready
+5. **Reliability** - Redis-backed queues for durable webhook delivery and background jobs
 
 ### Success Metrics
 
@@ -72,9 +72,9 @@ Provide a robust, scalable, and developer-friendly WhatsApp API that rivals comm
 | **Backend** | NestJS + Fastify |
 | **Database** | PostgreSQL + Prisma ORM |
 | **Cache** | Redis |
-| **Queue** | BullMQ |
+| **Queue** | BullMQ (durable webhook delivery + background jobs) |
 | **Frontend** | Next.js 14 + Shadcn UI |
-| **WhatsApp** | Baileys + WhatsApp-Web.js |
+| **WhatsApp** | WhatsApp-Web.js (default) + Baileys (experimental) |
 | **Real-time** | Socket.IO |
 | **Containerization** | Docker + Docker Compose |
 
@@ -104,4 +104,4 @@ Provide a robust, scalable, and developer-friendly WhatsApp API that rivals comm
 
 ---
 
-[← Documentation Index](/getting-started/project-overview) · [Next: Requirements →](/getting-started/requirements)
+[← Documentation Index](<../intro.md>) · [Next: Requirements →](<requirements.md>)

--- a/docs-site/docs/getting-started/quick-start.md
+++ b/docs-site/docs/getting-started/quick-start.md
@@ -11,8 +11,8 @@ Get MultiWA running in under 5 minutes.
 
 ## Prerequisites
 
-- Docker & Docker Compose installed
-- OR Node.js 20+ and PostgreSQL
+- Docker & Docker Compose installed (recommended)
+- OR Node.js 20+, pnpm 9+, PostgreSQL 16+, and Redis 7+ for local development
 
 ---
 
@@ -20,20 +20,28 @@ Get MultiWA running in under 5 minutes.
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/ribato22/multiwa.git
-cd multiwa
+git clone https://github.com/ribato22/MultiWA.git
+cd MultiWA
 
-# 2. Copy environment file
-cp .env.example .env
+# 2. Copy the Docker environment template
+cp .env.docker .env
 
-# 3. Start with Docker Compose
+# 3. Start the stack
 docker compose up -d
 
-# 4. Access the services
-# Dashboard: http://localhost:3000
-# API:       http://localhost:3001/api
-# Swagger:   http://localhost:3001/api/docs
+# 4. Watch logs until the API is ready (Ctrl+C to detach)
+docker compose logs -f api
 ```
+
+Once the API logs print `MultiWA Gateway API running on http://0.0.0.0:3333`, the stack is ready.
+
+| Service | URL |
+|---------|-----|
+| Admin Dashboard | http://localhost:3001 |
+| API base | http://localhost:3333/api/v1 |
+| Swagger UI | http://localhost:3333/api/docs |
+
+> The full stack profile (S3-compatible storage + Nginx) is `docker compose --profile full up -d`.
 
 ---
 
@@ -41,54 +49,82 @@ docker compose up -d
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/ribato22/multiwa.git
-cd multiwa
+git clone https://github.com/ribato22/MultiWA.git
+cd MultiWA
 
-# 2. Install dependencies
+# 2. Install workspace dependencies
 pnpm install
 
-# 3. Setup environment
+# 3. Configure environment
 cp .env.example .env
-# Edit .env with your PostgreSQL connection
+# Edit .env: at minimum set DATABASE_URL, REDIS_URL, and JWT_SECRET
 
-# 4. Sync the database schema (no migrations dir → db push)
-pnpm prisma db push
+# 4. Generate the Prisma client and sync the schema (no migrations dir → db push)
+pnpm --filter database exec prisma generate
+pnpm --filter database exec prisma db push
 
-# 5. Start development servers
-pnpm dev
+# 5. Build workspace packages used by the API
+pnpm --filter database build
+pnpm --filter engines build
 
-# Dashboard: http://localhost:3000
-# API:       http://localhost:3001/api
+# 6. Start the dev servers in two terminals
+pnpm --filter api dev     # API on http://localhost:3000  (local dev default)
+pnpm --filter admin dev   # Admin on http://localhost:3001
 ```
+
+> Note: in local-dev mode the API defaults to port `3000`. The Docker stack uses port `3333` because that is what `docker-compose.yml` sets via `API_PORT`. The Swagger UI is always at `<API base host>:<API port>/api/docs`.
 
 ---
 
 ## First Steps
 
-### 1. Create a Profile
+Replace `http://localhost:3333` with your API base if you are not using the default Docker port. The global API prefix is always `/api/v1`.
+
+### 1. Register an account
 
 ```bash
-curl -X POST http://localhost:3001/api/profiles \
+curl -X POST http://localhost:3333/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "admin@example.com",
+    "password": "ChangeMe1!",
+    "name": "Admin"
+  }'
+```
+
+The response includes an `accessToken`. Use it as `Authorization: Bearer ...` for the next calls.
+
+### 2. Create a Profile
+
+```bash
+curl -X POST http://localhost:3333/api/v1/profiles \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{"name": "My WhatsApp"}'
 ```
 
-### 2. Get QR Code
+### 3. Connect and Fetch the QR
+
+The recommended path is the Admin Dashboard at http://localhost:3001 — it polls the API and renders the QR for you. If you prefer raw API calls, use the account-scoped endpoints:
 
 ```bash
-curl http://localhost:3001/api/profiles/{profileId}/qr \
+# Start the engine for the profile (account-scoped path)
+curl -X POST http://localhost:3333/api/v1/accounts/{accountId}/profiles/{profileId}/connect \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Retrieve the QR (account-scoped)
+curl http://localhost:3333/api/v1/accounts/{accountId}/profiles/{profileId}/qr \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
-### 3. Scan QR with WhatsApp
+> The QR endpoint is exposed under `/accounts/:accountId/profiles/:profileId/qr` because profiles live inside an account in MultiWA's multi-tenant model. The Admin UI handles the account resolution for you. To list your accounts: `GET /api/v1/accounts`.
 
-Open WhatsApp on your phone → Linked Devices → Scan the QR code
+Open WhatsApp on your phone → **Linked devices** → **Link a device** → scan the QR.
 
-### 4. Send a Message
+### 4. Send a Text Message
 
 ```bash
-curl -X POST http://localhost:3001/api/messages/text \
+curl -X POST http://localhost:3333/api/v1/messages/text \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{
@@ -98,14 +134,28 @@ curl -X POST http://localhost:3001/api/messages/text \
   }'
 ```
 
+The Admin Dashboard at http://localhost:3001 also has a guided onboarding for the same flow if you prefer a UI.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `docker compose up -d` exits, no containers | Ports `3001` / `3333` / `5432` / `6379` already in use | Stop the conflicting service or override ports in `.env` (`API_PORT`, `ADMIN_PORT`) |
+| Swagger at `/api/docs` returns 404 | API still booting | Wait for the `MultiWA Gateway API running` log line, then retry |
+| `401 Unauthorized` | Missing or expired token | Re-run step 1 to get a fresh `accessToken` and re-send with `Authorization: Bearer ...` |
+| QR endpoint returns 404 | Profile not started yet | Call `POST /api/v1/profiles/{id}/connect` first |
+
 ---
 
 ## Next Steps
 
-- [API Specification](/api/api-specification) - Full API reference
-- [Python SDK](/sdks/python-sdk) - Python integration
-- [Docker Deployment](/operations/deployment-docker) - Production setup
+- [API Specification](<../api/api-specification.md>) — full endpoint reference
+- [Webhook Events](<../api/webhook-events.md>) — receive real-time events
+- [Python SDK](<../sdks/python-sdk.md>) — integrate from Python
+- [Docker Deployment](<../operations/deployment-docker.md>) — production setup
 
 ---
 
-[← Requirements](/getting-started/requirements) · [Documentation Index](/getting-started/project-overview) · [System Architecture →](/architecture/system-architecture)
+[← Requirements](<requirements.md>) · [Documentation Index](<../intro.md>) · [System Architecture →](<../architecture/system-architecture.md>)

--- a/docs-site/docs/getting-started/requirements.md
+++ b/docs-site/docs/getting-started/requirements.md
@@ -70,4 +70,4 @@ S3_SECRET_KEY=...
 
 ---
 
-[← Project Overview](/getting-started/project-overview) · [Documentation Index](/getting-started/project-overview) · [Quick Start →](/getting-started/quick-start)
+[← Project Overview](<project-overview.md>) · [Documentation Index](<../intro.md>) · [Quick Start →](<quick-start.md>)

--- a/docs-site/docs/guides/examples.md
+++ b/docs-site/docs/guides/examples.md
@@ -1,9 +1,9 @@
 ---
-title: "Examples & Recipes"
 sidebar_position: 1
+title: "Examples & Recipes"
 ---
 
-# Examples & Recipes
+# 20 - Examples & Recipes
 
 Practical, copy-pasteable examples for the most common MultiWA integrations:
 webhook receivers in three languages, advanced automation rules, and scheduling
@@ -21,7 +21,7 @@ X-API-Key: <your-api-key>
 
 ## 1. Webhook integration
 
-MultiWA delivers events (`message.received`, `session.status`, …) as `POST`
+MultiWA delivers events (`message.received`, `message.sent`, …) as `POST`
 requests to your endpoint. When the webhook has a `secret`, each request carries
 an HMAC-SHA256 signature header so you can verify it came from MultiWA:
 
@@ -48,7 +48,6 @@ function verify(req) {
   const expected =
     'sha256=' + crypto.createHmac('sha256', SECRET).update(req.rawBody).digest('hex');
   const got = req.headers['x-multiwa-signature'] || '';
-  // timing-safe compare
   return expected.length === got.length &&
     crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(got));
 }
@@ -127,7 +126,7 @@ curl -X POST https://your-multiwa-host/api/v1/webhooks \
   -d '{
     "url": "https://yourserver.com/webhook",
     "secret": "a-long-random-string",
-    "events": ["message.received", "session.status"]
+    "events": ["message.received", "connection.ready"]
   }'
 ```
 
@@ -142,9 +141,6 @@ Automations pair a **trigger** with an **action**. Create them via
 `POST /api/v1/automation` (or visually in the dashboard's Flow Builder).
 
 ### Keyword → AI reply
-
-Reply with an AI-generated answer whenever an inbound message contains "price"
-or "pricing":
 
 ```json
 {
@@ -161,8 +157,6 @@ or "pricing":
 ```
 
 ### Regex trigger → tag + templated reply
-
-Detect an order number like `#12345`, tag the contact, then send a template:
 
 ```json
 {
@@ -199,8 +193,7 @@ Detect an order number like `#12345`, tag the contact, then send a template:
 
 ## 3. Schedule a broadcast via the API
 
-Sending a scheduled broadcast is a two-step flow: **create** the broadcast, then
-**schedule** it for a future time.
+A scheduled broadcast is a two-step flow: **create**, then **schedule**.
 
 ### Step 1 — Create the broadcast
 
@@ -247,9 +240,9 @@ You can `pause`, `resume`, or `cancel` a running broadcast with the matching
 
 ---
 
-## Where to next
+## See also
 
-- [API Specification](/api/api-specification) — every endpoint and payload
-- [Webhook Events](/api/webhook-events) — full event catalog
-- [Automation](/features/automation) — the Flow Builder in depth
-- [SDKs](/sdks/python-sdk) — typed clients for TypeScript, Python, and PHP
+- [07 - API Specification](<../api/api-specification.md>)
+- [09 - Webhook Events](<../api/webhook-events.md>)
+- [12 - Automation](<../features/automation.md>)
+- [13 - Python SDK](<../sdks/python-sdk.md>) · [14 - PHP SDK](<../sdks/php-sdk.md>)

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 0
+title: "Documentation Index"
+---
+
+# MultiWA Documentation
+
+Welcome to the MultiWA documentation. MultiWA is a free, open-source WhatsApp API Gateway designed for developers who need full control over their messaging infrastructure.
+
+## 📚 Documentation Index
+
+### Getting Started
+- [01 - Project Overview](<getting-started/project-overview.md>) - Vision, mission, and architecture
+- [02 - Requirements](<getting-started/requirements.md>) - System requirements and dependencies
+- [03 - Quick Start](<getting-started/quick-start.md>) - Get up and running in 5 minutes
+
+### Architecture
+- [04 - System Architecture](<architecture/system-architecture.md>) - Technical design and components
+- [05 - Database Design](<architecture/database-design.md>) - Prisma schema and relationships
+- [06 - Engine Abstraction](<architecture/engine-abstraction.md>) - Baileys and WhatsApp-Web.js adapters
+
+### API Reference
+- [07 - API Specification](<api/api-specification.md>) - REST API endpoints
+- [08 - WebSocket API](<api/websocket-api.md>) - Real-time events
+- [09 - Webhook Events](<api/webhook-events.md>) - Event payloads
+
+### Features
+- [10 - Messaging](<features/messaging.md>) - Sending messages, media, polls
+- [11 - Groups](<features/groups.md>) - Group management API
+- [12 - Automation](<features/automation.md>) - Auto-reply and flow builder
+
+### SDKs & Integrations
+- [13 - Python SDK](<sdks/python-sdk.md>) - Installation and usage
+- [14 - PHP SDK](<sdks/php-sdk.md>) - Installation and usage
+- [15 - n8n Integration](<sdks/n8n-integration.md>) - Workflow automation
+
+### Deployment
+- [16 - Docker Deployment](<operations/deployment-docker.md>) - Production setup
+- [17 - Development Guide](<operations/development.md>) - Contributing to MultiWA
+
+### Operations
+- [18 - Configuration Reference](<operations/configuration-reference.md>) - Environment variables
+- [19 - Database Backup](<operations/database-backup.md>) - Backup & restore guide
+
+### Guides & Examples
+- [20 - Examples](<guides/examples.md>) - End-to-end usage examples
+
+### Releasing
+- [21 - Releasing & Distribution](<operations/releasing-and-distribution.md>) - Release flow, publishing SDKs and Docker images
+
+---
+
+## 🚀 Quick Links
+
+- **GitHub**: [github.com/ribato22/MultiWA](https://github.com/ribato22/MultiWA)
+- **Docker image (API)**: [hub.docker.com/r/ribato/multiwa-api](https://hub.docker.com/r/ribato/multiwa-api)
+- **TypeScript SDK source**: [`packages/sdk`](../packages/sdk)
+- **Python SDK source**: [`packages/sdk-python`](../packages/sdk-python)
+- **PHP SDK source**: [`packages/sdk-php`](../packages/sdk-php)
+
+> The TypeScript SDK is live on npm (`npm install @multiwa/sdk`), the Python SDK on PyPI (`pip install multiwa`), and the n8n community node on npm (`npm install n8n-nodes-multiwa`). The PHP SDK (`multiwa/sdk`) still ships as an in-repo package; its Packagist entry is tracked as a release follow-up — until then, install it from this repository or via the package's local path.
+
+---
+
+## 🆘 Support
+
+- [Issue Tracker](https://github.com/ribato22/MultiWA/issues)
+- [Discussions](https://github.com/ribato22/MultiWA/discussions)
+- [Security Policy](https://github.com/ribato22/MultiWA/blob/main/SECURITY.md)
+
+---
+
+Made with ❤️ by the MultiWA Community

--- a/docs-site/docs/operations/configuration-reference.md
+++ b/docs-site/docs/operations/configuration-reference.md
@@ -13,10 +13,20 @@ Complete documentation of environment variables for MultiWA Gateway.
 |----------|----------|---------|-------------|
 | `DATABASE_URL` | ✅ | - | PostgreSQL connection string |
 | `REDIS_URL` | ✅ | - | Redis connection string |
-| `JWT_SECRET` | ✅ | - | Secret key for JWT |
-| `SESSIONS_PATH` | ❌ | `/data/sessions` | WhatsApp session storage path |
-| `API_PORT` | ❌ | `3000` | API server port |
+| `JWT_SECRET` | ✅ | - | Secret key for JWT access tokens |
+| `JWT_REFRESH_SECRET` | ✅ | - | Secret key for JWT refresh tokens |
+| `SESSIONS_DIR` | ❌ | `/data/sessions` (Docker) | WhatsApp session storage path (env name in compose is `SESSIONS_DIR`) |
+| `API_PORT` | ❌ | `3000` (code) / `3333` (Docker compose) | API server port |
+| `API_HOST` | ❌ | `0.0.0.0` | API bind address |
 | `NODE_ENV` | ❌ | `development` | Environment mode |
+| `CORS_ORIGINS` | ❌ | `http://localhost:3001,http://localhost:3333` (Docker) | Comma-separated allowed origins |
+| `NEXT_PUBLIC_API_URL` | ❌ | `http://localhost:3333` (Docker) | URL the browser uses to reach the API. **Build-time** in the admin image. |
+| `DEFAULT_ENGINE` | ❌ | `whatsapp-web-js` | WhatsApp engine (`whatsapp-web-js` or `baileys`) |
+| `ENGINE_HOST` | ❌ | `api` | Where the engine runs: `api` or `worker` |
+| `DURABLE_SEND` | ❌ | `false` | Enqueue outbound sends in Redis (BullMQ) with retry |
+| `OUTBOUND_SEND_CONCURRENCY` | ❌ | `10` | Max concurrent durable send deliveries |
+| `WEBHOOK_TIMEOUT_MS` | ❌ | `30000` | Webhook delivery timeout |
+| `WEBHOOK_ALLOW_PRIVATE_TARGETS` | ❌ | `false` | Allow webhook/AI targets on private networks (SSRF guard) |
 
 ---
 
@@ -95,9 +105,9 @@ openssl rand -hex 16
 ## API Server
 
 ### `API_PORT`
-**Optional** | Number | Default: `3000`
+**Optional** | Number | Default: `3000` (when running locally with `pnpm --filter api dev`) or `3333` (Docker compose default)
 
-Port for the NestJS API server.
+Port for the NestJS API server. The Docker Compose file overrides this to `3333` so the in-container port and the host port mapping line up (`"${API_PORT:-3333}:3333"`). Public docs and examples use `3333` because that is the Docker default.
 
 ### `API_HOST`
 **Optional** | String | Default: `0.0.0.0`
@@ -121,20 +131,20 @@ CORS_ORIGINS=https://admin.yourdomain.com,https://app.yourdomain.com
 
 ## WhatsApp Sessions
 
-### `SESSIONS_PATH`
-**Optional** | String | Default: `/data/sessions`
+### `SESSIONS_DIR`
+**Optional** | String | Default: `/data/sessions` (Docker)
 
-Directory for storing WhatsApp session data (Baileys auth files).
+Directory for storing WhatsApp session data (whatsapp-web.js auth files and Baileys keystore). The Docker compose file maps this to the `sessions_data` named volume.
 
 ```env
-# Development
-SESSIONS_PATH=./sessions
+# Local development
+SESSIONS_DIR=./sessions
 
-# Production (Docker volume)
-SESSIONS_PATH=/data/sessions
+# Docker (matches compose default)
+SESSIONS_DIR=/data/sessions
 ```
 
-> ⚠️ **Important**: This path must be persistent (Docker volume) so sessions are not lost when the container restarts.
+> ⚠️ **Important**: This path must be persistent (a named Docker volume or a host bind mount) so sessions are not lost when the container restarts. Treat session files like a credential: anyone with the files can impersonate the connected WhatsApp number.
 
 ---
 
@@ -177,17 +187,87 @@ WORKER_CONCURRENCY=20
 
 ---
 
+## Engine Hosting
+
+Where the WhatsApp engine runs — `api` (default) or `worker`.
+
+### `ENGINE_HOST`
+**Optional** | `api` | `worker` | Default: `api`
+
+Selects the process that owns the WhatsApp engine sessions:
+- `api` (default) — the engine lives in the API process (current behaviour).
+- `worker` — the engine runs in `apps/worker`; the API delegates engine
+  operations over BullMQ. The worker must be running and share the API's
+  sessions volume.
+
+```env
+ENGINE_HOST=api
+```
+
+---
+
+## Durable Sending
+
+Outbound sends are synchronous by default. When `DURABLE_SEND=true` they are
+enqueued in Redis (BullMQ) and delivered by an in-process consumer with retry —
+the API returns `202 { status: "queued" }` immediately and delivery is reported
+via `message.status` and `message.sent`/`message.failed` webhooks.
+
+### `DURABLE_SEND`
+**Optional** | Boolean | Default: `false`
+
+```env
+DURABLE_SEND=true
+```
+
+### `OUTBOUND_SEND_CONCURRENCY`
+**Optional** | Number | Default: `10`
+
+Maximum concurrent deliveries from the durable send queue.
+
+```env
+OUTBOUND_SEND_CONCURRENCY=10
+```
+
+---
+
 ## Webhook
 
-### `WEBHOOK_TIMEOUT`
+> Delivery knobs: the retry policy (attempts/backoff) and per-attempt timeout
+> are read from these env vars by the worker's webhook dispatcher/processor.
+
+### `WEBHOOK_TIMEOUT_MS`
 **Optional** | Number | Default: `30000`
 
 Timeout in milliseconds for webhook delivery.
 
 ### `WEBHOOK_RETRY_ATTEMPTS`
-**Optional** | Number | Default: `3`
+**Optional** | Number | Default: `5`
 
-Number of retry attempts if webhook delivery fails.
+Number of delivery attempts (BullMQ job attempts) if a webhook delivery fails.
+Defaults to the historical fixed policy of 5 attempts.
+
+### `WEBHOOK_RETRY_DELAY_MS`
+**Optional** | Number | Default: `30000`
+
+Base delay (ms) between retries (exponential backoff). Defaults to the
+historical fixed policy of 30s.
+
+### `WEBHOOK_ALLOW_PRIVATE_TARGETS`
+**Optional** | Boolean | Default: `false`
+
+SSRF guard for tenant-controlled URLs (webhook targets, custom-AI endpoints).
+By default targets that resolve to loopback, private, link-local or reserved
+addresses are **blocked** (cloud metadata `169.254.169.254` is always blocked,
+even when this is `true`). Self-hosted deployments that deliver to internal
+services on the same network (Chatwoot, Typebot, n8n, localhost) set this to
+`true` to allow private targets. Leave `false` for public / multi-tenant
+deployments.
+
+```env
+# Allow webhooks to reach internal services on the same network
+WEBHOOK_ALLOW_PRIVATE_TARGETS=true
+```
 
 ---
 
@@ -218,14 +298,22 @@ Environment mode: `development`, `production`, `test`.
 ### `NEXT_PUBLIC_API_URL`
 **Required for Admin** | String
 
-API backend URL for the Admin UI.
+API backend URL for the Admin UI. **This value is baked into the Next.js client bundle at build time.** Changing it in `.env` alone is not enough — you must rebuild the admin image, for example:
+
+```bash
+docker compose build --no-cache admin
+docker compose up -d --no-deps --force-recreate admin
+```
 
 ```env
-# Development
-NEXT_PUBLIC_API_URL=http://localhost:3000
+# Docker default (matches docker-compose.yml)
+NEXT_PUBLIC_API_URL=http://localhost:3333
 
-# Production
-NEXT_PUBLIC_API_URL=https://api.yourdomain.com
+# Production behind a reverse proxy on the same origin
+NEXT_PUBLIC_API_URL=https://multiwa.example.com
+
+# Production with a dedicated API subdomain
+NEXT_PUBLIC_API_URL=https://api.example.com
 ```
 
 ---
@@ -273,10 +361,13 @@ NODE_ENV=development
 DATABASE_URL=postgresql://user:password@db.host.com:5432/multiwa?sslmode=require
 REDIS_URL=redis://:password@redis.host.com:6379
 JWT_SECRET=your-secure-generated-secret-key-here
+JWT_REFRESH_SECRET=another-independent-secret-here
+ENCRYPTION_KEY=32-hex-chars-from-openssl-rand-hex-32
 JWT_EXPIRES_IN=7d
-API_PORT=3000
+API_PORT=3333
 CORS_ORIGINS=https://admin.yourdomain.com
-SESSIONS_PATH=/data/sessions
+NEXT_PUBLIC_API_URL=https://multiwa.yourdomain.com
+SESSIONS_DIR=/data/sessions
 LOG_LEVEL=warn
 NODE_ENV=production
 RATE_LIMIT_MAX=100
@@ -287,8 +378,11 @@ RATE_LIMIT_TTL=60
 
 ## Security Checklist
 
-- [ ] `JWT_SECRET` uses a random string of 32+ characters
-- [ ] `DATABASE_URL` uses SSL in production
-- [ ] `CORS_ORIGINS` only whitelists required domains
-- [ ] `LOG_LEVEL` set to `warn` or `error` in production
-- [ ] `SESSIONS_PATH` uses a persistent volume
+- [ ] `JWT_SECRET` and `JWT_REFRESH_SECRET` are independent random strings of 32+ characters (generated with `openssl rand -base64 64`).
+- [ ] `ENCRYPTION_KEY` is set (`openssl rand -hex 32`) so credential fields are encrypted at rest.
+- [ ] `DATABASE_URL` uses SSL in production.
+- [ ] `CORS_ORIGINS` only whitelists required domains (no `localhost` in production).
+- [ ] `LOG_LEVEL` set to `warn` or `error` in production.
+- [ ] `SESSIONS_DIR` uses a persistent volume and is backed up like credentials.
+- [ ] `NEXT_PUBLIC_API_URL` matches the public URL the browser will hit, and the admin image was rebuilt after setting it.
+- [ ] `NODE_ENV=production` is set.

--- a/docs-site/docs/operations/deployment-docker.md
+++ b/docs-site/docs/operations/deployment-docker.md
@@ -7,187 +7,248 @@ title: "Docker Deployment"
 
 Production deployment with Docker and Docker Compose.
 
+The repository ships with a working `docker-compose.yml` at the project root that defines five services — `postgres`, `redis`, `api`, `admin`, and an optional `minio` plus `nginx` for the full stack. Use that file as the source of truth for ports, environment variables, and healthchecks; the snippets in this guide are illustrations only.
+
 ---
 
 ## Quick Deploy
 
 ```bash
-# Clone repository
-git clone https://github.com/ribato22/multiwa.git
-cd multiwa
+# 1. Clone the repository
+git clone https://github.com/ribato22/MultiWA.git
+cd MultiWA
 
-# Configure environment
-cp .env.example .env
-# Edit .env with production values
+# 2. Copy the Docker environment template and review it
+cp .env.docker .env
+# Edit .env: set strong values for JWT_SECRET, JWT_REFRESH_SECRET, ENCRYPTION_KEY,
+# DB_PASSWORD, NEXT_PUBLIC_API_URL, and CORS_ORIGINS.
 
-# Start services
-docker compose -f docker-compose.prod.yml up -d
+# 3. Start the stack
+docker compose up -d
+
+# 4. (Optional) Bring up the full stack with S3 storage and Nginx reverse proxy
+docker compose --profile full up -d
 ```
+
+Default exposed endpoints once the stack is up:
+
+| Service | URL |
+|---------|-----|
+| Admin Dashboard | http://localhost:3001 |
+| API | http://localhost:3333/api/v1 |
+| Swagger UI | http://localhost:3333/api/docs |
+| PostgreSQL | localhost:5432 (mapped from `postgres:5432`) |
+| Redis | localhost:6379 (mapped from `redis:6379`) |
+
+The API container listens on `3333` because `docker-compose.yml` sets `API_PORT=3333`. The Admin container listens on `3001`.
 
 ---
 
-## docker-compose.prod.yml
+## Service Definitions (excerpt from `docker-compose.yml`)
 
 ```yaml
-version: '3.8'
-
 services:
   api:
-    image: multiwa/api:latest
     build:
       context: .
-      dockerfile: apps/api/Dockerfile
-    ports:
-      - "3001:3001"
+      dockerfile: Dockerfile
+      target: api
+    container_name: multiwa-api
     environment:
-      - NODE_ENV=production
-      - DATABASE_URL=postgresql://postgres:password@db:5432/multiwa
-      - REDIS_URL=redis://redis:6379
-      - JWT_SECRET=${JWT_SECRET}
+      NODE_ENV: production
+      DATABASE_URL: postgresql://multiwa:${DB_PASSWORD:-multiwa123}@postgres:5432/${DB_NAME:-multiwa}?schema=public
+      REDIS_URL: redis://redis:6379
+      API_PORT: 3333
+      API_HOST: 0.0.0.0
+      JWT_SECRET: ${JWT_SECRET:-change-this-to-a-random-secret}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET:-change-this-refresh-secret}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
+      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3001,http://localhost:3333}
+      WHATSAPP_ENGINE: ${DEFAULT_ENGINE:-whatsapp-web-js}
+      SESSIONS_DIR: /data/sessions
+    ports:
+      - "${API_PORT:-3333}:3333"
+    volumes:
+      - sessions_data:/data/sessions
     depends_on:
-      - db
-      - redis
-    restart: unless-stopped
+      postgres: { condition: service_healthy }
+      redis:    { condition: service_healthy }
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3333/api/docs"]
 
   admin:
-    image: multiwa/admin:latest
     build:
       context: .
-      dockerfile: apps/admin/Dockerfile
+      dockerfile: Dockerfile
+      target: admin
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3333}
+    container_name: multiwa-admin
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3333}
     ports:
-      - "3000:3000"
-    environment:
-      - NEXT_PUBLIC_API_URL=http://api:3001
-    depends_on:
-      - api
-    restart: unless-stopped
+      - "${ADMIN_PORT:-3001}:3001"
 
-  db:
-    image: postgres:15-alpine
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=password
-      - POSTGRES_DB=multiwa
-    restart: unless-stopped
+  postgres:
+    image: postgres:16-alpine
+    container_name: multiwa-postgres
 
   redis:
     image: redis:7-alpine
-    volumes:
-      - redis_data:/data
-    restart: unless-stopped
-
-volumes:
-  postgres_data:
-  redis_data:
+    container_name: multiwa-redis
 ```
+
+> `NEXT_PUBLIC_API_URL` is **baked into the admin client bundle at build time**. If you change its value, you must rebuild the admin image: `docker compose build --no-cache admin && docker compose up -d --no-deps --force-recreate admin`.
 
 ---
 
-## Environment Variables
+## Required Environment Variables
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection | `postgresql://user:pass@host:5432/db` |
-| `REDIS_URL` | Redis connection | `redis://localhost:6379` |
-| `JWT_SECRET` | Secret for JWT tokens | Random 32+ char string |
-| `API_KEY_SECRET` | Secret for API keys | Random 32+ char string |
-| `OPENAI_API_KEY` | OpenAI API key (for AI features) | `sk-...` |
+| Variable | Description | Notes |
+|----------|-------------|-------|
+| `DB_PASSWORD` | PostgreSQL password | Set a strong value before first `up -d`; it becomes the password baked into the volume. |
+| `JWT_SECRET` | Secret for JWT access tokens | `openssl rand -base64 64` |
+| `JWT_REFRESH_SECRET` | Secret for JWT refresh tokens | Independent of `JWT_SECRET` |
+| `ENCRYPTION_KEY` | Encrypts sensitive fields at rest | `openssl rand -hex 32` |
+| `NEXT_PUBLIC_API_URL` | Public URL the browser uses to reach the API | Must match the origin users hit (e.g., `https://api.example.com`); build-time |
+| `CORS_ORIGINS` | Comma-separated allowed origins | Include the admin origin (e.g., `https://admin.example.com`) |
+| `DEFAULT_ENGINE` | `whatsapp-web-js` or `baileys` | Defaults to `whatsapp-web-js` |
+
+Optional S3-compatible media storage (MinIO or external):
+
+| Variable | Description |
+|----------|-------------|
+| `S3_ENDPOINT` | e.g., `http://minio:9000` or `https://s3.amazonaws.com` |
+| `S3_ACCESS_KEY` / `S3_SECRET_KEY` | Storage credentials |
+| `S3_BUCKET` | Defaults to `multiwa-media` |
+
+The full reference is in [18-configuration-reference.md](<configuration-reference.md>).
 
 ---
 
 ## Reverse Proxy (Nginx)
 
+Single public origin serving the Admin UI, with API calls reverse-proxied under `/api`:
+
 ```nginx
 server {
-    listen 80;
-    server_name api.multiwa.io;
+    listen 443 ssl http2;
+    server_name multiwa.example.com;
 
+    ssl_certificate     /etc/letsencrypt/live/multiwa.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/multiwa.example.com/privkey.pem;
+
+    # Admin (Next.js)
     location / {
-        proxy_pass http://localhost:3001;
+        proxy_pass         http://127.0.0.1:3001;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
-    location /ws {
-        proxy_pass http://localhost:3001;
+    # API + Swagger
+    location /api/ {
+        proxy_pass         http://127.0.0.1:3333;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
     }
-}
 
-server {
-    listen 80;
-    server_name admin.multiwa.io;
-
-    location / {
-        proxy_pass http://localhost:3000;
+    # Socket.IO (WebSocket upgrade)
+    location /socket.io/ {
+        proxy_pass         http://127.0.0.1:3333;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header   Upgrade    $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   Host       $host;
     }
 }
 ```
 
----
-
-## SSL with Traefik
-
-```yaml
-# Add to docker-compose.prod.yml
-traefik:
-  image: traefik:v2.10
-  command:
-    - --providers.docker=true
-    - --entrypoints.web.address=:80
-    - --entrypoints.websecure.address=:443
-    - --certificatesresolvers.letsencrypt.acme.email=admin@example.com
-    - --certificatesresolvers.letsencrypt.acme.storage=/acme.json
-    - --certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web
-  ports:
-    - "80:80"
-    - "443:443"
-  volumes:
-    - /var/run/docker.sock:/var/run/docker.sock:ro
-    - ./acme.json:/acme.json
-
-api:
-  labels:
-    - traefik.http.routers.api.rule=Host(`api.multiwa.io`)
-    - traefik.http.routers.api.tls.certresolver=letsencrypt
-```
+If you put the Admin on a different subdomain than the API (e.g., `admin.example.com` and `api.example.com`), update `NEXT_PUBLIC_API_URL` and `CORS_ORIGINS` accordingly, then **rebuild the admin image** so the new API URL is baked into the client bundle.
 
 ---
 
 ## Health Checks
 
 ```bash
-# API Health
-curl http://localhost:3001/api/health
+# API (matches the compose healthcheck)
+curl -fsSI http://localhost:3333/api/docs
 
-# Database
-docker compose exec db pg_isready
+# PostgreSQL
+docker exec multiwa-postgres pg_isready -U multiwa
 
 # Redis
-docker compose exec redis redis-cli ping
+docker exec multiwa-redis redis-cli ping
+# Expected: PONG
+
+# Admin
+curl -fsSI http://localhost:3001/
+
+# Worker logs (last 40 lines)
+docker logs --tail 40 multiwa-worker
 ```
+
+The compose file ships container-level healthchecks for the API (`/api/docs`), PostgreSQL (`pg_isready`), and Redis. `docker ps` shows `(healthy)` once they pass.
 
 ---
 
-## Backup
+## Backup and Restore
 
 ```bash
-# Database backup
-docker compose exec db pg_dump -U postgres multiwa > backup.sql
+# Dump the database from inside the container
+docker exec -t multiwa-postgres pg_dump -U multiwa multiwa > multiwa-backup-$(date -u +%Y%m%d).sql
 
-# Restore
-docker compose exec -T db psql -U postgres multiwa < backup.sql
+# Restore (assumes an empty target database)
+cat multiwa-backup-YYYYMMDD.sql | docker exec -i multiwa-postgres psql -U multiwa -d multiwa
+```
+
+WhatsApp session files live in the `sessions_data` named volume and should be backed up alongside the database. They contain device authentication material and must be protected like a secret.
+
+---
+
+## Production Checklist
+
+Before exposing the deployment to real users, confirm:
+
+- [ ] Strong, unique values for `JWT_SECRET`, `JWT_REFRESH_SECRET`, `ENCRYPTION_KEY`, and `DB_PASSWORD` (no defaults from `.env.docker`).
+- [ ] `NODE_ENV=production` is set in the API container.
+- [ ] `CORS_ORIGINS` only lists the real public origins; localhost removed.
+- [ ] `NEXT_PUBLIC_API_URL` matches the URL the browser will use, and the admin image has been rebuilt after any change.
+- [ ] TLS is terminated in front of the stack (Nginx, Traefik, Caddy, or a managed load balancer).
+- [ ] Database and Redis are not exposed to the public internet.
+- [ ] Daily database backups are scheduled and tested (restore at least once).
+- [ ] `sessions_data` volume is backed up and access-controlled.
+- [ ] Webhook delivery uses HTTPS endpoints and HMAC secrets where applicable.
+- [ ] Logs and metrics are shipped somewhere persistent (Loki, ELK, CloudWatch, etc.).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `Bind for 0.0.0.0:3333 failed: port is already allocated` | Another process or container holds the port | Stop the conflicting process, or override `API_PORT` / `ADMIN_PORT` in `.env`. |
+| `multiwa-api` keeps restarting | `JWT_SECRET` missing or DB URL wrong | `docker logs multiwa-api` and fix the env, then `docker compose up -d`. |
+| Admin loads but every API call is `Network Error` | `NEXT_PUBLIC_API_URL` mismatched, or CORS blocking | Verify `NEXT_PUBLIC_API_URL` in `.env`, rebuild admin (`docker compose build --no-cache admin`), and confirm the value appears in `CORS_ORIGINS`. |
+| Admin shows `localhost:3333` from a browser on another machine | Build-time `NEXT_PUBLIC_API_URL` was left as the default | Set `NEXT_PUBLIC_API_URL` to a reachable URL, then rebuild the admin image. |
+| WhatsApp keeps asking for the QR code on every restart | `sessions_data` volume not persistent or wrong mount | Confirm the volume is declared (`docker volume inspect multiwa_sessions_data`) and not pruned. |
+| `pg_isready` fails | Postgres container unhealthy or wrong credentials | Check `docker logs multiwa-postgres`; common causes are `DB_PASSWORD` changed after the volume was initialized. |
+| `redis-cli ping` returns no PONG | Redis not started or different password | `docker logs multiwa-redis`; if you set a Redis password ensure `REDIS_URL` uses it. |
+| `curl http://localhost:3333/api/docs` returns 404 | Wrong port, or the API is still booting | Wait for `MultiWA Gateway API running` in the API logs; verify port mapping with `docker port multiwa-api`. |
+
+You can also use these as a quick sanity probe:
+
+```bash
+docker exec multiwa-api sh -c 'echo NODE_ENV=$NODE_ENV'   # expect: production
+docker exec multiwa-api sh -c 'echo PORT=$API_PORT'       # expect: 3333
 ```
 
 ---
 
-[← n8n Integration](/sdks/n8n-integration) · [Documentation Index](/getting-started/project-overview) · [Development Guide →](/operations/development)
+[← n8n Integration](<../sdks/n8n-integration.md>) · [Documentation Index](<../intro.md>) · [Development Guide →](<development.md>)

--- a/docs-site/docs/operations/development.md
+++ b/docs-site/docs/operations/development.md
@@ -134,4 +134,4 @@ pnpm format
 
 ---
 
-[← Docker Deployment](/operations/deployment-docker) · [Documentation Index](/getting-started/project-overview)
+[← Docker Deployment](<deployment-docker.md>) · [Documentation Index](<../intro.md>)

--- a/docs-site/docs/operations/releasing-and-distribution.md
+++ b/docs-site/docs/operations/releasing-and-distribution.md
@@ -1,0 +1,130 @@
+---
+sidebar_position: 6
+title: "Releasing & Distribution"
+---
+
+# Releasing & Distribution
+
+How MultiWA's artifacts get published, and the one-time setup each registry needs.
+
+The repo ships **keyless** publish automation wherever the registry supports it
+(GitHub OIDC → npm Trusted Publishing, PyPI Trusted Publishing, Sigstore cosign,
+GitHub build-provenance) so **no long-lived tokens** live in the repo in steady
+state. Each SDK versions independently via a **dedicated tag prefix**, decoupled
+from the monorepo-wide `v*` GitHub Release (`.github/workflows/release.yml`).
+
+| Artifact | Registry | Workflow | Release trigger | Keyless? |
+|---|---|---|---|---|
+| `@multiwa/sdk` (TS) | npm | `publish-sdk.yml` | tag `sdk-v*` | ✅ OIDC + provenance |
+| `multiwa` (Python) | PyPI | `publish-sdk-python.yml` | tag `sdk-python-v*` | ✅ Trusted Publishing |
+| `n8n-nodes-multiwa` | npm | `publish-n8n-node.yml` | tag `n8n-v*` | ✅ OIDC + provenance |
+| api / admin / worker images | GHCR (+ Docker Hub) | `docker-publish.yml` | GitHub Release / dispatch | ✅ cosign + SLSA provenance |
+| `multiwa/multiwa-php` (PHP) | Packagist | _deferred_ (needs split repo) | tag `v*` | GitHub App webhook |
+| WordPress plugin | WordPress.org | _deferred_ (needs review) | — | ❌ SVN user/pass |
+
+---
+
+## npm — TypeScript SDK (`@multiwa/sdk`)
+
+**One-time (maintainer):**
+1. Create/own the `@multiwa` org on npmjs.com (free plan → unlimited public
+   packages). Confirm the scope is free: `npm view @multiwa/sdk`. If taken,
+   rename the package (e.g. `@ribato22/multiwa-sdk`) in `packages/sdk/package.json`.
+2. Enable 2FA (auth-and-writes) on the npm account.
+3. **Bootstrap the first publish** (OIDC can only attach to a package that already
+   exists): create a Granular Access Token scoped to `@multiwa/*` with publish
+   rights, add it as the repo secret `NPM_TOKEN`. The workflow's `NODE_AUTH_TOKEN`
+   fallback uses it for the first release.
+4. After the package exists, switch to keyless: npmjs.com → @multiwa/sdk →
+   Settings → **Trusted Publishing** → add a GitHub Actions publisher for
+   `ribato22/MultiWA`, workflow `publish-sdk.yml`. Then delete `NPM_TOKEN`.
+
+**Each release:** bump `version` in `packages/sdk/package.json`, then
+`git tag sdk-v<version> && git push origin sdk-v<version>`.
+
+## PyPI — Python SDK (`multiwa`)
+
+**One-time (maintainer):**
+1. Confirm `multiwa` is free at https://pypi.org/project/multiwa/. If taken,
+   rename `name` in `pyproject.toml` (e.g. `multiwa-sdk`).
+2. Create a PyPI account + enable 2FA.
+3. Add a **pending** Trusted Publisher (project doesn't exist yet): PyPI →
+   Account → Publishing → *Add a pending publisher* → Publisher=GitHub,
+   Owner=`ribato22`, Repo=`MultiWA`, Workflow=`publish-sdk-python.yml`,
+   Environment=`pypi`.
+4. Create the GitHub Actions environment `pypi` (Settings → Environments). No
+   secrets — OIDC mints the token.
+
+**Each release:** bump `version` in `pyproject.toml` +
+`multiwa/__init__.py`, then `git tag sdk-python-v<version> && git push origin sdk-python-v<version>`.
+
+## npm — n8n community node (`n8n-nodes-multiwa`)
+
+Same model as the TS SDK (Trusted Publisher for `publish-n8n-node.yml`, or
+`NPM_TOKEN` bootstrap). Once live on npm it is installable via n8n → Settings →
+Community Nodes; optionally submit it to n8n's verified-node program.
+
+**Each release:** bump the package version, `git tag n8n-v<version> && git push origin n8n-v<version>`.
+
+## Docker images (GHCR primary, Docker Hub optional)
+
+`docker-publish.yml` now builds **api, admin, and worker**, and for every image
+emits an **SBOM**, a **max-mode SLSA provenance** attestation, a **keyless cosign
+signature**, and a **GitHub build-provenance** attestation — all via OIDC, no
+stored key.
+
+**One-time (maintainer):**
+- **GHCR visibility:** after the first publish, set each package
+  (`multiwa-api/admin/worker`) to **Public** and connect it to the repo — GHCR
+  defaults to private, so public `docker pull` fails until flipped.
+- **Docker Hub (optional):** add a Read/Write token as repo secret
+  `DOCKERHUB_TOKEN`; without it the Docker Hub push silently no-ops (the README
+  pulls badge then points at images that were never pushed). Note: Docker Hub may
+  reject the OCI referrer attestations — if a push fails, publish attestations to
+  GHCR only.
+
+**Verify a signed image:**
+```bash
+cosign verify ghcr.io/ribato22/multiwa-api:latest \
+  --certificate-identity-regexp 'https://github.com/ribato22/MultiWA/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+gh attestation verify oci://ghcr.io/ribato22/multiwa-api:latest --owner ribato22
+```
+
+## One-click deploy (Render)
+
+`render.yaml` is a Render Blueprint provisioning Postgres + Key Value (Redis,
+`noeviction`) + api/admin/worker from the GHCR images. See the header of
+`render.yaml` for the three values you confirm at deploy time (public images,
+`ENCRYPTION_KEY` via `openssl rand -hex 32`, and the admin's public API URL).
+
+---
+
+## Deferred (need external infrastructure — separate follow-up)
+
+### Packagist — PHP SDK (`multiwa/multiwa-php`)
+Packagist reads `composer.json` from a **repo root**, but the SDK lives in
+`packages/sdk-php` of this JS monorepo, so the monorepo URL cannot be submitted.
+Path to publish:
+1. Create a standalone read-only repo (e.g. `ribato22/multiwa-php`).
+2. Add a **subtree-split** workflow (`split-sdk-php.yml`, on `v*`) that pushes
+   `packages/sdk-php` + the semver tag to that repo. It needs a fine-grained PAT
+   with `contents:write` on the split repo as `SPLIT_REPO_TOKEN` (the only
+   long-lived secret — `GITHUB_TOKEN` can't push cross-repo).
+3. Submit the standalone repo once on packagist.org and install the **Packagist
+   GitHub App** on it (secretless auto-update on every tag).
+4. Also fix the README error-handling example, which references
+   `MultiWA\Exceptions\*` classes that don't exist yet.
+
+### WordPress.org plugin directory
+No OIDC/keyless path exists. Requires a **one-time manual Plugins Team review**
+of a submitted ZIP, then per-plugin SVN with `SVN_USERNAME`/`SVN_PASSWORD`
+secrets and a `10up/action-wordpress-plugin-deploy` workflow. Blockers to clear
+first: add a compliant `readme.txt` (Stable tag, Tested up to, Requires at least,
+License URI) and complete the `multiwa.php` header. Slug must not imply
+"whatsapp" (a Meta trademark) — request `multiwa`.
+
+### arm64 multi-arch images
+Deferred pending validation that the Chromium/Puppeteer install in the
+Dockerfiles builds cleanly under `linux/arm64` (QEMU). Once verified, add
+`docker/setup-qemu-action` + `platforms: linux/amd64,linux/arm64`.

--- a/docs-site/docs/sdks/n8n-integration.md
+++ b/docs-site/docs/sdks/n8n-integration.md
@@ -30,7 +30,7 @@ Or install via n8n UI:
 1. In n8n, go to **Credentials** → **Add Credential**
 2. Search for **MultiWA API**
 3. Enter:
-   - **API Base URL**: `http://localhost:3001/api`
+   - **API Base URL**: `http://localhost:3333/api/v1`
    - **API Key**: Your MultiWA API key
 
 ---
@@ -146,4 +146,4 @@ Receive WhatsApp events in real-time:
 
 ---
 
-[← PHP SDK](/sdks/php-sdk) · [Documentation Index](/getting-started/project-overview) · [Docker Deployment →](/operations/deployment-docker)
+[← PHP SDK](<php-sdk.md>) · [Documentation Index](<../intro.md>) · [Docker Deployment →](<../operations/deployment-docker.md>)

--- a/docs-site/docs/sdks/php-sdk.md
+++ b/docs-site/docs/sdks/php-sdk.md
@@ -12,7 +12,7 @@ Official PHP SDK for MultiWA.
 ## Installation
 
 ```bash
-composer require multiwa/multiwa
+composer require multiwa/multiwa-php
 ```
 
 ---
@@ -34,7 +34,7 @@ require_once 'vendor/autoload.php';
 use MultiWA\MultiWA;
 
 $client = new MultiWA(
-    baseUrl: 'http://localhost:3001/api',
+    baseUrl: 'http://localhost:3333/api/v1',
     apiKey: 'YOUR_API_KEY'
 );
 
@@ -154,7 +154,7 @@ try {
 ```php
 // config/services.php
 'multiwa' => [
-    'base_url' => env('MULTIWA_BASE_URL', 'http://localhost:3001/api'),
+    'base_url' => env('MULTIWA_BASE_URL', 'http://localhost:3333/api/v1'),
     'api_key' => env('MULTIWA_API_KEY'),
 ],
 
@@ -177,4 +177,4 @@ public function send(MultiWA $client)
 
 ---
 
-[← Python SDK](/sdks/python-sdk) · [Documentation Index](/getting-started/project-overview) · [n8n Integration →](/sdks/n8n-integration)
+[← Python SDK](<python-sdk.md>) · [Documentation Index](<../intro.md>) · [n8n Integration →](<n8n-integration.md>)

--- a/docs-site/docs/sdks/python-sdk.md
+++ b/docs-site/docs/sdks/python-sdk.md
@@ -24,7 +24,7 @@ from multiwa import MultiWA
 
 # Initialize client
 client = MultiWA(
-    base_url="http://localhost:3001/api",
+    base_url="http://localhost:3333/api/v1",
     api_key="YOUR_API_KEY"
 )
 
@@ -48,7 +48,7 @@ import asyncio
 
 async def main():
     client = AsyncMultiWA(
-        base_url="http://localhost:3001/api",
+        base_url="http://localhost:3333/api/v1",
         api_key="YOUR_API_KEY"
     )
 
@@ -159,4 +159,4 @@ contact: Contact = client.contacts.get(...)
 
 ---
 
-[← Automation](/features/automation) · [Documentation Index](/getting-started/project-overview) · [PHP SDK →](/sdks/php-sdk)
+[← Automation](<../features/automation.md>) · [Documentation Index](<../intro.md>) · [PHP SDK →](<php-sdk.md>)

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -7,6 +7,7 @@ const sidebars: SidebarsConfig = {
       label: 'Getting Started',
       collapsed: false,
       items: [
+        'intro',
         'getting-started/project-overview',
         'getting-started/requirements',
         'getting-started/quick-start',
@@ -64,6 +65,7 @@ const sidebars: SidebarsConfig = {
         'operations/configuration-reference',
         'operations/demo-mode',
         'operations/database-backup',
+        'operations/releasing-and-distribution',
       ],
     },
   ],

--- a/docs/18-configuration-reference.md
+++ b/docs/18-configuration-reference.md
@@ -17,6 +17,11 @@ Complete documentation of environment variables for MultiWA Gateway.
 | `CORS_ORIGINS` | ❌ | `http://localhost:3001,http://localhost:3333` (Docker) | Comma-separated allowed origins |
 | `NEXT_PUBLIC_API_URL` | ❌ | `http://localhost:3333` (Docker) | URL the browser uses to reach the API. **Build-time** in the admin image. |
 | `DEFAULT_ENGINE` | ❌ | `whatsapp-web-js` | WhatsApp engine (`whatsapp-web-js` or `baileys`) |
+| `ENGINE_HOST` | ❌ | `api` | Where the engine runs: `api` or `worker` |
+| `DURABLE_SEND` | ❌ | `false` | Enqueue outbound sends in Redis (BullMQ) with retry |
+| `OUTBOUND_SEND_CONCURRENCY` | ❌ | `10` | Max concurrent durable send deliveries |
+| `WEBHOOK_TIMEOUT_MS` | ❌ | `30000` | Webhook delivery timeout |
+| `WEBHOOK_ALLOW_PRIVATE_TARGETS` | ❌ | `false` | Allow webhook/AI targets on private networks (SSRF guard) |
 
 ---
 
@@ -177,17 +182,87 @@ WORKER_CONCURRENCY=20
 
 ---
 
+## Engine Hosting
+
+Where the WhatsApp engine runs — `api` (default) or `worker`.
+
+### `ENGINE_HOST`
+**Optional** | `api` | `worker` | Default: `api`
+
+Selects the process that owns the WhatsApp engine sessions:
+- `api` (default) — the engine lives in the API process (current behaviour).
+- `worker` — the engine runs in `apps/worker`; the API delegates engine
+  operations over BullMQ. The worker must be running and share the API's
+  sessions volume.
+
+```env
+ENGINE_HOST=api
+```
+
+---
+
+## Durable Sending
+
+Outbound sends are synchronous by default. When `DURABLE_SEND=true` they are
+enqueued in Redis (BullMQ) and delivered by an in-process consumer with retry —
+the API returns `202 { status: "queued" }` immediately and delivery is reported
+via `message.status` and `message.sent`/`message.failed` webhooks.
+
+### `DURABLE_SEND`
+**Optional** | Boolean | Default: `false`
+
+```env
+DURABLE_SEND=true
+```
+
+### `OUTBOUND_SEND_CONCURRENCY`
+**Optional** | Number | Default: `10`
+
+Maximum concurrent deliveries from the durable send queue.
+
+```env
+OUTBOUND_SEND_CONCURRENCY=10
+```
+
+---
+
 ## Webhook
 
-### `WEBHOOK_TIMEOUT`
+> Delivery knobs: the retry policy (attempts/backoff) and per-attempt timeout
+> are read from these env vars by the worker's webhook dispatcher/processor.
+
+### `WEBHOOK_TIMEOUT_MS`
 **Optional** | Number | Default: `30000`
 
 Timeout in milliseconds for webhook delivery.
 
 ### `WEBHOOK_RETRY_ATTEMPTS`
-**Optional** | Number | Default: `3`
+**Optional** | Number | Default: `5`
 
-Number of retry attempts if webhook delivery fails.
+Number of delivery attempts (BullMQ job attempts) if a webhook delivery fails.
+Defaults to the historical fixed policy of 5 attempts.
+
+### `WEBHOOK_RETRY_DELAY_MS`
+**Optional** | Number | Default: `30000`
+
+Base delay (ms) between retries (exponential backoff). Defaults to the
+historical fixed policy of 30s.
+
+### `WEBHOOK_ALLOW_PRIVATE_TARGETS`
+**Optional** | Boolean | Default: `false`
+
+SSRF guard for tenant-controlled URLs (webhook targets, custom-AI endpoints).
+By default targets that resolve to loopback, private, link-local or reserved
+addresses are **blocked** (cloud metadata `169.254.169.254` is always blocked,
+even when this is `true`). Self-hosted deployments that deliver to internal
+services on the same network (Chatwoot, Typebot, n8n, localhost) set this to
+`true` to allow private targets. Leave `false` for public / multi-tenant
+deployments.
+
+```env
+# Allow webhooks to reach internal services on the same network
+WEBHOOK_ALLOW_PRIVATE_TARGETS=true
+```
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,12 @@ Welcome to the MultiWA documentation. MultiWA is a free, open-source WhatsApp AP
 - [18 - Configuration Reference](./18-configuration-reference.md) - Environment variables
 - [19 - Database Backup](./19-database-backup.md) - Backup & restore guide
 
+### Guides & Examples
+- [20 - Examples](./20-examples.md) - End-to-end usage examples
+
+### Releasing
+- [21 - Releasing & Distribution](./21-releasing-and-distribution.md) - Release flow, publishing SDKs and Docker images
+
 ---
 
 ## 🚀 Quick Links

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "check:public-boundary": "bash scripts/check-public-boundary.sh",
     "check:api-contract": "node scripts/check-api-contract.mjs",
     "check:api-contract:update": "node scripts/check-api-contract.mjs --update",
-    "check:release": "git diff --check && pnpm run check:public-boundary && pnpm run check:api-contract"
+    "sync:docsite": "node scripts/sync-docsite.mjs",
+    "check:docsite": "node scripts/sync-docsite.mjs --check",
+    "check:release": "git diff --check && pnpm run check:public-boundary && pnpm run check:api-contract && pnpm run check:docsite"
   },
   "devDependencies": {
     "@eslint/js": "^9",

--- a/render.yaml
+++ b/render.yaml
@@ -40,8 +40,9 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
+      # Must match the API_PORT the image listens on (also used by nginx upstream).
       - key: API_PORT
-        value: "3000"
+        value: "3333"
       - key: API_HOST
         value: 0.0.0.0
       - key: DATABASE_URL

--- a/scripts/sync-docsite.mjs
+++ b/scripts/sync-docsite.mjs
@@ -104,7 +104,12 @@ for (const p of PAGES) {
     continue;
   }
   const dstFile = path.join(DST_ROOT, p.dst);
-  const current = fs.existsSync(dstFile) ? fs.readFileSync(dstFile, 'utf8') : null;
+  let current = null;
+  try {
+    current = fs.readFileSync(dstFile, 'utf8');
+  } catch {
+    // First sync (or missing target) — the generated page is written below.
+  }
 
   if (CHECK) {
     if (current !== generated) {

--- a/scripts/sync-docsite.mjs
+++ b/scripts/sync-docsite.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Syncs the public docs (docs/) into the Docusaurus site (docs-site/docs/).
+ *
+ * docs/ is the single source of truth. Each docs-site page is generated as:
+ *
+ *     <sidebar frontmatter> + docs/<NN-...>.md
+ *
+ * with the internal `./NN-*.md` cross-links rewritten to paths that resolve
+ * within docs-site/docs/ (Docusaurus resolves relative links against the
+ * current page's directory).
+ *
+ * Usage:
+ *   node scripts/sync-docsite.mjs            # rewrite docs-site/docs from docs/
+ *   node scripts/sync-docsite.mjs --check    # fail if any page is out of sync
+ *
+ * Docs-site pages that have NO source in docs/ (e.g. operations/demo-mode.md)
+ * are left untouched. The mapping below must be kept in sync with the docs-site
+ * sidebar (docs-site/sidebars.ts).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC_ROOT = path.join(ROOT, 'docs');
+const DST_ROOT = path.join(ROOT, 'docs-site', 'docs');
+const CHECK = process.argv.includes('--check');
+
+// docs/<src> → docs-site/docs/<dst> + Docusaurus frontmatter
+const PAGES = [
+  { src: 'README.md', dst: 'intro.md', title: 'Documentation Index', pos: 0 },
+  { src: '01-project-overview.md', dst: 'getting-started/project-overview.md', title: 'Project Overview', pos: 1 },
+  { src: '02-requirements.md', dst: 'getting-started/requirements.md', title: 'Requirements', pos: 2 },
+  { src: '03-quick-start.md', dst: 'getting-started/quick-start.md', title: 'Quick Start', pos: 3 },
+  { src: '04-system-architecture.md', dst: 'architecture/system-architecture.md', title: 'System Architecture', pos: 1 },
+  { src: '05-database-design.md', dst: 'architecture/database-design.md', title: 'Database Design', pos: 2 },
+  { src: '06-engine-abstraction.md', dst: 'architecture/engine-abstraction.md', title: 'Engine Abstraction', pos: 3 },
+  { src: '07-api-specification.md', dst: 'api/api-specification.md', title: 'API Specification', pos: 1 },
+  { src: '08-websocket-api.md', dst: 'api/websocket-api.md', title: 'WebSocket API', pos: 2 },
+  { src: '09-webhook-events.md', dst: 'api/webhook-events.md', title: 'Webhook Events', pos: 3 },
+  { src: '10-messaging.md', dst: 'features/messaging.md', title: 'Messaging', pos: 1 },
+  { src: '11-groups.md', dst: 'features/groups.md', title: 'Groups', pos: 2 },
+  { src: '12-automation.md', dst: 'features/automation.md', title: 'Automation', pos: 3 },
+  { src: '13-sdk-python.md', dst: 'sdks/python-sdk.md', title: 'Python SDK', pos: 1 },
+  { src: '14-sdk-php.md', dst: 'sdks/php-sdk.md', title: 'PHP SDK', pos: 2 },
+  { src: '15-n8n-integration.md', dst: 'sdks/n8n-integration.md', title: 'n8n Integration', pos: 3 },
+  { src: '16-deployment-docker.md', dst: 'operations/deployment-docker.md', title: 'Docker Deployment', pos: 1 },
+  { src: '17-development.md', dst: 'operations/development.md', title: 'Development', pos: 2 },
+  { src: '18-configuration-reference.md', dst: 'operations/configuration-reference.md', title: 'Configuration Reference', pos: 3 },
+  { src: '19-database-backup.md', dst: 'operations/database-backup.md', title: 'Database Backup', pos: 4 },
+  { src: '20-examples.md', dst: 'guides/examples.md', title: 'Examples & Recipes', pos: 1 },
+  { src: '21-releasing-and-distribution.md', dst: 'operations/releasing-and-distribution.md', title: 'Releasing & Distribution', pos: 6 },
+];
+
+function frontmatter(p) {
+  return `---\nsidebar_position: ${p.pos}\ntitle: "${p.title}"\n---\n\n`;
+}
+
+/** Rewrite `./NN-xx.md(#anchor)` and `./README.md` links to docs-site links. */
+function rewriteLinks(body, currentDst) {
+  const targetFromSrc = (file) => PAGES.find((p) => p.src === file) || null;
+  const toRel = (target) => path.posix.relative(path.posix.dirname(currentDst), target.dst);
+
+  // ./NN-xx.md → mapped docs-site page (relative path, Docusaurus-resolvable)
+  body = body.replace(/\[([^\]]*)\]\(\.\/([0-9]{2}-[a-z0-9-]+\.md)(#[^)]*)?\)/g, (m, text, file, hash) => {
+    const target = targetFromSrc(file);
+    if (!target) return m;
+    return `[${text}](<${toRel(target)}${hash ?? ''}>)`;
+  });
+
+  // ./README.md ("Documentation Index") → the generated index page
+  body = body.replace(/\[([^\]]*)\]\(\.\/README\.md\)/g, (m, text) => {
+    const target = targetFromSrc('README.md');
+    return `[${text}](<${toRel(target)}>)`;
+  });
+
+  // Repo-relative links (../SECURITY.md) → point at the GitHub repo
+  body = body.replace(/\]\(\.\.\/([A-Za-z0-9.-]+\.md)\)/g, (m, file) => {
+    return `](https://github.com/ribato22/MultiWA/blob/main/${file})`;
+  });
+
+  return body;
+}
+
+function render(p) {
+  const src = path.join(SRC_ROOT, p.src);
+  if (!fs.existsSync(src)) {
+    console.error(`✗ source missing: docs/${p.src}`);
+    return null;
+  }
+  const body = fs.readFileSync(src, 'utf8');
+  return frontmatter(p) + rewriteLinks(body, p.dst);
+}
+
+let failures = 0;
+let synced = 0;
+
+for (const p of PAGES) {
+  const generated = render(p);
+  if (generated === null) {
+    failures++;
+    continue;
+  }
+  const dstFile = path.join(DST_ROOT, p.dst);
+  const current = fs.existsSync(dstFile) ? fs.readFileSync(dstFile, 'utf8') : null;
+
+  if (CHECK) {
+    if (current !== generated) {
+      console.error(`✗ out of sync: docs-site/docs/${p.dst} — run \`pnpm sync:docsite\` ` +
+        `(or update docs/${p.src} and re-sync)`);
+      failures++;
+    }
+  } else {
+    if (current !== generated) {
+      fs.mkdirSync(path.dirname(dstFile), { recursive: true });
+      fs.writeFileSync(dstFile, generated);
+      console.log(`✓ synced docs/${p.src} → docs-site/docs/${p.dst}`);
+      synced++;
+    }
+  }
+}
+
+if (CHECK) {
+  if (failures > 0) {
+    console.error(`Docs-site sync check FAILED (${failures} page(s) drifted).`);
+    process.exit(1);
+  }
+  console.log('Docs-site sync check PASSED — all pages match docs/.');
+} else {
+  console.log(`Docs-site sync complete (${synced} page(s) updated, ${PAGES.length - synced} already in sync).`);
+}


### PR DESCRIPTION
## Description

Fixes the documented-but-stale deployment and documentation layer found during the codebase review:

- **nginx**: upstream `api:3000` → `api:3333`; `proxy_pass` no longer strips the `/api/v1/*` prefix; dedicated auth location; `/health` mapped to `/api/v1/health`; dead `/media/` location removed. Verified with `nginx -t`.
- **Port alignment**: `docker-compose.production.yml`, `render.yaml`, and `docker/nginx/example.conf` now use `API_PORT=3333` consistently with the main compose and the API `PORT` fallback.
- **Secrets fail-fast**: `KNOWN_WEAK` set in `apps/api/src/main.ts` + `docker/entrypoint-api.sh` cover the shipped example secret values so production cannot silently boot with forgeable JWT secrets.
- **Docs single-source-of-truth**: new `scripts/sync-docsite.mjs` generates `docs-site/docs` from `docs/` (frontmatter + link rewriting, `--check` mode); 21 pages regenerated (huge drift, e.g. api-specification 155 → 456 lines); new `intro.md` and `releasing-and-distribution.md`; `check:docsite` added to `check:release` and to the docs-deploy workflow.
- **CI**: new `nginx-config` job runs `nginx -t` against the shipped config.

## Related Issues

None (no issue filed).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🔧 Refactor

## Changes Made

- `docker/nginx/nginx.conf`, `docker/nginx/example.conf` — upstream port + `/api/v1` routing
- `docker-compose.production.yml`, `.env.production.example`, `render.yaml` — `API_PORT=3333`
- `docker/entrypoint-api.sh`, `apps/api/src/main.ts` — secret fail-fast
- `scripts/sync-docsite.mjs`, `package.json`, `.github/workflows/docs-deploy.yml` — docs sync tooling + CI step
- `.github/workflows/ci.yml` — `nginx-config` job
- `docs/*`, `docs-site/docs/*` — 21 pages regenerated, index entries, configuration reference additions

## Testing

- [x] Tested locally with `pnpm dev`
- [x] Added/updated tests
- [x] Existing tests pass

Verification: `nginx -t` (docker nginx:alpine) ok; docs-site build 0 broken links; `node scripts/sync-docsite.mjs --check` PASS; `pnpm check:release` green (public-boundary PASSED, api-contract 217/217, diff-check clean); eslint 0 warnings; typecheck 11/11.

## Checklist

- [x] Branched off `main` (not pushing directly to `main`)
- [ ] Linked the resolved issue(s) above with `Closes #`
- [x] Conventional Commit message(s) (e.g. `fix(engine): ...`)
- [x] Code follows the project's style guidelines
- [x] Self-review of the code completed
- [x] Documentation updated (if needed)
- [x] Release Gate passes locally (`pnpm check:release`)
- [x] No new warnings introduced