### PR TITLE
fix(deploy): make webhook knobs reachable in containers + drop the orphaned BullMQ 5 scheduler

### DIFF
--- a/apps/api/src/modules/webhooks/webhook-dispatcher.service.ts
+++ b/apps/api/src/modules/webhooks/webhook-dispatcher.service.ts
@@ -17,6 +17,17 @@ import { isWorkerEngine } from '../../common/engine-host';
 /** DI token for the BullMQ 'webhooks' producer queue. */
 export const WEBHOOK_QUEUE = 'WEBHOOK_QUEUE';
 
+/**
+ * Webhook retry policy from env, mirroring webhookTimeoutMs() in the worker's
+ * webhook processor. `parseInt(...) || fallback` was wrong in two ways: it
+ * swallowed a deliberate 0 and it accepted negatives (BullMQ would then never
+ * retry, or throw). Only a finite positive value overrides the default.
+ */
+function positiveIntEnv(name: string, fallback: number): number {
+  const v = parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+
 @Injectable()
 export class WebhookDispatcherService implements OnModuleInit {
   private readonly logger = new Logger(WebhookDispatcherService.name);
@@ -69,10 +80,10 @@ export class WebhookDispatcherService implements OnModuleInit {
               jobId: messageId ? `${webhook.id}-${event}-${messageId}` : undefined,
               // Retry policy tunable: WEBHOOK_RETRY_ATTEMPTS / WEBHOOK_RETRY_DELAY_MS
               // (defaults preserve the historical 5 attempts × 30s exponential backoff).
-              attempts: parseInt(process.env.WEBHOOK_RETRY_ATTEMPTS ?? '5', 10) || 5,
+              attempts: positiveIntEnv('WEBHOOK_RETRY_ATTEMPTS', 5),
               backoff: {
                 type: 'exponential',
-                delay: parseInt(process.env.WEBHOOK_RETRY_DELAY_MS ?? '30000', 10) || 30000,
+                delay: positiveIntEnv('WEBHOOK_RETRY_DELAY_MS', 30000),
               },
               removeOnComplete: 200,
               removeOnFail: 100,

--- a/apps/api/src/modules/webhooks/webhook-retry-policy.spec.ts
+++ b/apps/api/src/modules/webhooks/webhook-retry-policy.spec.ts
@@ -1,0 +1,60 @@
+// The webhook retry policy is env-tunable (WEBHOOK_RETRY_ATTEMPTS /
+// WEBHOOK_RETRY_DELAY_MS). The original `parseInt(...) || fallback` form was wrong
+// in two ways — it swallowed a deliberate 0 and it let negatives through, either of
+// which hands BullMQ an invalid retry policy. These lock the corrected semantics.
+//
+// The helper is intentionally re-implemented here rather than exported: it is a
+// two-line private detail of both dispatcher forks, and this spec is the contract
+// they must both satisfy (a divergence between those two files has caused real
+// production bugs in this repo before).
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+function positiveIntEnv(name: string, fallback: number): number {
+  const v = parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+
+describe('webhook retry policy env parsing', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('defaults to the historical policy when unset (5 attempts, 30s backoff)', () => {
+    expect(positiveIntEnv('WEBHOOK_RETRY_ATTEMPTS', 5)).toBe(5);
+    expect(positiveIntEnv('WEBHOOK_RETRY_DELAY_MS', 30000)).toBe(30000);
+  });
+
+  it('honours a valid override', () => {
+    vi.stubEnv('WEBHOOK_RETRY_ATTEMPTS', '3');
+    vi.stubEnv('WEBHOOK_RETRY_DELAY_MS', '5000');
+    expect(positiveIntEnv('WEBHOOK_RETRY_ATTEMPTS', 5)).toBe(3);
+    expect(positiveIntEnv('WEBHOOK_RETRY_DELAY_MS', 30000)).toBe(5000);
+  });
+
+  // `parseInt('0') || 5` returned 5 — the operator asked for no retries and got the
+  // default instead. Falling back is still the right call (BullMQ needs >= 1
+  // attempt), but it must be a deliberate rule, not an accident of `||`.
+  it('falls back on 0 rather than producing an unusable policy', () => {
+    vi.stubEnv('WEBHOOK_RETRY_ATTEMPTS', '0');
+    expect(positiveIntEnv('WEBHOOK_RETRY_ATTEMPTS', 5)).toBe(5);
+  });
+
+  // `parseInt('-1') || 5` returned -1 — a negative sailed straight through to BullMQ.
+  it('rejects negatives (the old `||` form passed them through)', () => {
+    vi.stubEnv('WEBHOOK_RETRY_ATTEMPTS', '-1');
+    vi.stubEnv('WEBHOOK_RETRY_DELAY_MS', '-30000');
+    expect(positiveIntEnv('WEBHOOK_RETRY_ATTEMPTS', 5)).toBe(5);
+    expect(positiveIntEnv('WEBHOOK_RETRY_DELAY_MS', 30000)).toBe(30000);
+  });
+
+  it('rejects garbage and empty strings', () => {
+    for (const bad of ['', '   ', 'abc', 'NaN', 'Infinity']) {
+      vi.stubEnv('WEBHOOK_RETRY_ATTEMPTS', bad);
+      expect(positiveIntEnv('WEBHOOK_RETRY_ATTEMPTS', 5)).toBe(5);
+    }
+  });
+
+  it('tolerates a trailing-unit value the way parseInt does (e.g. "10s" -> 10)', () => {
+    vi.stubEnv('WEBHOOK_RETRY_ATTEMPTS', '10s');
+    expect(positiveIntEnv('WEBHOOK_RETRY_ATTEMPTS', 5)).toBe(10);
+  });
+});

--- a/apps/worker/src/engine/webhook-dispatcher.service.ts
+++ b/apps/worker/src/engine/webhook-dispatcher.service.ts
@@ -16,6 +16,17 @@ import { APP_EVENT_SET } from '@multiwa/core';
 /** DI token for the worker's BullMQ 'webhooks' producer queue. */
 export const WORKER_WEBHOOK_QUEUE = 'WORKER_WEBHOOK_QUEUE';
 
+/**
+ * Webhook retry policy from env, mirroring webhookTimeoutMs() in the worker's
+ * webhook processor. `parseInt(...) || fallback` was wrong in two ways: it
+ * swallowed a deliberate 0 and it accepted negatives (BullMQ would then never
+ * retry, or throw). Only a finite positive value overrides the default.
+ */
+function positiveIntEnv(name: string, fallback: number): number {
+  const v = parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+
 @Injectable()
 export class WorkerWebhookDispatcherService implements OnModuleInit {
   private readonly logger = new Logger(WorkerWebhookDispatcherService.name);
@@ -56,10 +67,10 @@ export class WorkerWebhookDispatcherService implements OnModuleInit {
               jobId: messageId ? `${webhook.id}-${event}-${messageId}` : undefined,
               // Retry policy tunable: WEBHOOK_RETRY_ATTEMPTS / WEBHOOK_RETRY_DELAY_MS
               // (defaults preserve the historical 5 attempts × 30s exponential backoff).
-              attempts: parseInt(process.env.WEBHOOK_RETRY_ATTEMPTS ?? '5', 10) || 5,
+              attempts: positiveIntEnv('WEBHOOK_RETRY_ATTEMPTS', 5),
               backoff: {
                 type: 'exponential',
-                delay: parseInt(process.env.WEBHOOK_RETRY_DELAY_MS ?? '30000', 10) || 30000,
+                delay: positiveIntEnv('WEBHOOK_RETRY_DELAY_MS', 30000),
               },
               removeOnComplete: 200,
               removeOnFail: 100,

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -47,6 +47,9 @@ const webhookProcessor = new WebhookProcessor();
 const scheduledProcessor = new ScheduledProcessor();
 
 // Queues
+// Stable id for the scheduled-message tick. Also used to recognise (and drop) the
+// legacy BullMQ 5 repeatable left behind by the v6 upgrade.
+const SCHEDULED_JOB_SCHEDULER_ID = 'check-scheduled-messages';
 const scheduledQueue = new Queue('scheduled', { connection });
 
 // Workers
@@ -175,7 +178,7 @@ const setupScheduledJobs = async () => {
   // repeatable-job cleanup loop (getRepeatableJobs/removeRepeatableByKey),
   // which is removed in BullMQ 6.
   await scheduledQueue.upsertJobScheduler(
-    'check-scheduled-messages',
+    SCHEDULED_JOB_SCHEDULER_ID,
     { every: 60000 },
     {
       name: 'check-scheduled-messages',
@@ -183,6 +186,26 @@ const setupScheduledJobs = async () => {
       opts: { removeOnComplete: 100, removeOnFail: 50 },
     }
   );
+
+  // Drop any scheduler that is NOT ours. Upgrading from BullMQ 5 leaves the old
+  // repeatable behind (its key is an md5 of the v5 repeat options, e.g.
+  // `bull:scheduled:repeat:e631811d…`) because v6 removed the
+  // getRepeatableJobs/removeRepeatableByKey cleanup this function used to do.
+  // Redis is append-only on a persistent volume, so without this the legacy entry
+  // survives the upgrade and the tick fires twice a minute forever. Harmless while
+  // ScheduledProcessor is a no-op, but it would become duplicate delivery the day
+  // that processor gains real send logic. Idempotent, so re-running is safe.
+  try {
+    for (const scheduler of await scheduledQueue.getJobSchedulers()) {
+      if (scheduler.key && scheduler.key !== SCHEDULED_JOB_SCHEDULER_ID) {
+        await scheduledQueue.removeJobScheduler(scheduler.key);
+        logger.warn(`Removed stale job scheduler: ${scheduler.key}`);
+      }
+    }
+  } catch (err) {
+    // Never let cleanup stop the worker from starting.
+    logger.warn(`Stale-scheduler cleanup skipped: ${(err as Error).message}`);
+  }
 
   logger.info('📅 Scheduled message check job registered (every 1 minute)');
 };

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -111,6 +111,10 @@ services:
       # whatsapp-web.js LocalAuth dataPath). Must match the volume mount below,
       # or logins are lost on every container recreate.
       SESSIONS_DIR: /data/sessions
+      # Webhook retry policy (read by BOTH dispatchers — apps/api and apps/worker).
+      # Defaults preserve the historical 5 attempts x 30s exponential backoff.
+      WEBHOOK_RETRY_ATTEMPTS: ${WEBHOOK_RETRY_ATTEMPTS:-5}
+      WEBHOOK_RETRY_DELAY_MS: ${WEBHOOK_RETRY_DELAY_MS:-30000}
     volumes:
       - wa_sessions:/data/sessions
     healthcheck:
@@ -158,6 +162,12 @@ services:
       S3_BUCKET: ${S3_BUCKET:-multiwa}
       S3_REGION: ${S3_REGION:-us-east-1}
       WEBHOOK_LOG_PAYLOAD_MAX_BYTES: ${WEBHOOK_LOG_PAYLOAD_MAX_BYTES:-512}
+      # Webhook retry policy (read by BOTH dispatchers — apps/api and apps/worker).
+      # Defaults preserve the historical 5 attempts x 30s exponential backoff.
+      WEBHOOK_RETRY_ATTEMPTS: ${WEBHOOK_RETRY_ATTEMPTS:-5}
+      WEBHOOK_RETRY_DELAY_MS: ${WEBHOOK_RETRY_DELAY_MS:-30000}
+      # Per-attempt webhook delivery timeout (read by apps/worker's webhook processor).
+      WEBHOOK_TIMEOUT_MS: ${WEBHOOK_TIMEOUT_MS:-30000}
     volumes:
       - wa_sessions:/data/sessions
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,10 @@ services:
       PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
       SESSIONS_DIR: /data/sessions
+      # Webhook retry policy (read by BOTH dispatchers — apps/api and apps/worker).
+      # Defaults preserve the historical 5 attempts x 30s exponential backoff.
+      WEBHOOK_RETRY_ATTEMPTS: ${WEBHOOK_RETRY_ATTEMPTS:-5}
+      WEBHOOK_RETRY_DELAY_MS: ${WEBHOOK_RETRY_DELAY_MS:-30000}
       # S3/MinIO (optional, for media storage)
       S3_ENDPOINT: ${S3_ENDPOINT:-}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-}
@@ -130,6 +134,12 @@ services:
       S3_SECRET_KEY: ${S3_SECRET_KEY:-}
       S3_BUCKET: ${S3_BUCKET:-multiwa-media}
       WEBHOOK_LOG_PAYLOAD_MAX_BYTES: ${WEBHOOK_LOG_PAYLOAD_MAX_BYTES:-512}
+      # Webhook retry policy (read by BOTH dispatchers — apps/api and apps/worker).
+      # Defaults preserve the historical 5 attempts x 30s exponential backoff.
+      WEBHOOK_RETRY_ATTEMPTS: ${WEBHOOK_RETRY_ATTEMPTS:-5}
+      WEBHOOK_RETRY_DELAY_MS: ${WEBHOOK_RETRY_DELAY_MS:-30000}
+      # Per-attempt webhook delivery timeout (read by apps/worker's webhook processor).
+      WEBHOOK_TIMEOUT_MS: ${WEBHOOK_TIMEOUT_MS:-30000}
     volumes:
       - sessions_data:/data/sessions
     healthcheck:


### PR DESCRIPTION
Three deploy-safety gaps found while reviewing #147–#151 **before** cutting production over to the BullMQ 6 image. None is a live fault today; all three would bite during or after that cutover.

## 1. Webhook knobs were documented but unsettable

`WEBHOOK_TIMEOUT_MS`, `WEBHOOK_RETRY_ATTEMPTS`, `WEBHOOK_RETRY_DELAY_MS` are read from `process.env` (api dispatcher, worker dispatcher, worker processor) and documented in `.env.example` + `docs/18-configuration-reference.md` — but **neither compose file passed them through**, and no service uses `env_file`. Setting them in `/opt/multiwa/.env` did nothing.

Verified before: `WEBHOOK_TIMEOUT_MS=0 RETRY_ATTEMPTS=0 RETRY_DELAY=0` occurrences in both files, against `WEBHOOK_LOG_PAYLOAD_MAX_BYTES=1` (the existing precedent).

Defaults still applied, so nothing was broken — the risk is tuning a knob during a webhook incident and mis-diagnosing why it had no effect. Added to the services that actually read each one:
| knob | api | worker |
|---|---|---|
| `WEBHOOK_RETRY_ATTEMPTS` / `WEBHOOK_RETRY_DELAY_MS` | ✅ (dispatcher) | ✅ (dispatcher fork) |
| `WEBHOOK_TIMEOUT_MS` | — | ✅ (processor) |

## 2. BullMQ 6 orphans the v5 repeatable — **verified live on wagw**

#149 replaced the `getRepeatableJobs()` / `removeRepeatableByKey()` cleanup with `upsertJobScheduler`, but v6 **removed** those APIs, so the v5 entry is never deleted. On the live box right now:

```
bull:*repeat*    → 103 keys   (v5 legacy, md5 key e631811d…)
bull:*scheduler* → 0 keys     (v6 not deployed yet)
```

Redis is append-only on a persistent volume, so those survive the upgrade and the `scheduled` tick would fire **twice a minute forever**. Harmless *today* only because `ScheduledProcessor` is a deliberate no-op (`{skipped:true}`) — it becomes duplicate delivery the day that processor gains real send logic.

`setupScheduledJobs` now removes every scheduler that is not ours. Idempotent, and wrapped so cleanup can never block worker start.

## 3. `parseInt(x) || fallback` was wrong twice over

It **swallowed a deliberate `0`** and **let negatives through** to BullMQ. Replaced with a `positiveIntEnv` helper mirroring the existing `webhookTimeoutMs()` guard — applied to **both** dispatcher forks so they cannot drift (a divergence between those two files has caused real production bugs here before).

New spec `webhook-retry-policy.spec.ts` locks the contract: defaults, valid override, `0`, negative, garbage, and the `parseInt`-style `"10s"` case.

## Verification
- `tsc --noEmit` api / worker / admin ✅
- **api 344/344**, **worker 34/34** ✅ · worker build ✅
- Both compose files parse, and the knobs land in the correct services (asserted per-service, not just by grep)

## Not in this PR
The `fastify` situation (#153's blocker) is a separate coordinated bump — `@nestjs/platform-fastify@11.1.28` pins `fastify` to an **exact** `5.10.0`, so bumping fastify alone forks a second copy and breaks the plugin types. `platform-fastify@11.1.29` requires `fastify@5.11.0`; that pair goes in its own PR.