### PR TITLE
chore(admin): drop unused framer-motion dependency

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -26,7 +26,6 @@
     "axios": "^1.19.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.43.0",
     "lucide-react": "^0.577.0",
     "next": "14.2.35",
     "qrcode": "^1.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      framer-motion:
-        specifier: ^12.43.0
-        version: 12.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@18.3.1)
@@ -4772,20 +4769,6 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  framer-motion@12.43.0:
-    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -5523,12 +5506,6 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
-  motion-dom@12.43.0:
-    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
-
-  motion-utils@12.39.0:
-    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   mpg123-decoder@1.0.3:
     resolution: {integrity: sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==}
@@ -11923,15 +11900,6 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@12.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      motion-dom: 12.43.0
-      motion-utils: 12.39.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   fresh@0.5.2: {}
 
   fs-extra@10.1.0:
@@ -12616,12 +12584,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
-
-  motion-dom@12.43.0:
-    dependencies:
-      motion-utils: 12.39.0
-
-  motion-utils@12.39.0: {}
 
   mpg123-decoder@1.0.3:
     dependencies:


### PR DESCRIPTION
Closes #155.

## Why

`framer-motion` is declared in `apps/admin/package.json` but **never imported**. Zero matches across every `.ts`/`.tsx` in `apps/` and `packages/` for:

- `framer-motion`
- `<motion.`
- `AnimatePresence`
- `useAnimation`

(The only other hit in the tree is `apps/admin/.next/standalone/apps/admin/package.json` — a stale build artifact, not source.)

So it has been pure bundle/install weight, plus a recurring Dependabot major: **#155** proposes `12.43.0 → 13.0.0`. Removing the dependency resolves that PR without spending a review on a major upgrade for a library we do not use.

## Verification

- `tsc --noEmit` on admin — PASS
- `pnpm --filter admin build` (`next build`) — **PASS**
- Lockfile churn is deletion-only (one `specifier` + one `version` line removed, nothing re-resolved)

## Merge order

#157, #158 and this PR all touch `pnpm-lock.yaml`. Suggested order: **#156 → #157 → #158 → this**, each later one needing a trivial lockfile rebase. Once #158 lands, #153 can be closed as superseded.