### PR TITLE
fix(worker): stop BullMQ 6 wedging the worker forever after a Redis outage

### DIFF
--- a/apps/worker/src/bullmq-reconnect.spec.ts
+++ b/apps/worker/src/bullmq-reconnect.spec.ts
@@ -1,0 +1,68 @@
+// Regression guard for the BullMQ 6 blocking-connection wedge.
+//
+// BullMQ 6 arms a watchdog around its blocking bzpopmin read and, on timeout, calls
+// `bclient.disconnect(false)` UNCONDITIONALLY. If Redis has already gone away the client is
+// in state 'reconnecting', and disconnect(false) cancels its retry timer without emitting
+// 'close' — the client becomes a zombie and the Worker never consumes another job. BullMQ 5
+// called `disconnect(!this.closing)`, which is why it recovered.
+//
+// The failure is SILENT and survives every health check we have: the base connection returns
+// to 'ready', `queue.add` keeps succeeding, `waiting` grows while `active` stays 0, and the
+// worker's readiness probe only inspects the base connection. On wagw the affected queue is
+// `webhooks`, so the symptom is "customer webhooks silently stop until someone restarts the
+// worker".
+//
+// patches/bullmq@6.1.1.patch adds the `status === 'ready'` guard. This spec asserts the guard
+// is present in BOTH the cjs and esm builds, so a bullmq bump that drops the patch fails CI
+// instead of shipping the wedge back to production.
+//
+// A full behavioural repro (kill Redis for 20s, assert the worker resumes) needs a Redis this
+// suite cannot restart, so the byte-level assertion is the guard that runs everywhere. The
+// behavioural matrix is recorded in the PR:
+//   bullmq 5.81.2            -> RECOVERED
+//   bullmq 6.1.0 (unpatched) -> STUCK (0/3 jobs, waiting=3, active=0)
+//   bullmq 6.1.0 + guard     -> RECOVERED
+
+import { readFileSync } from 'fs';
+import { createRequire } from 'module';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const require_ = createRequire(__filename);
+
+function backendSource(flavour: 'cjs' | 'esm'): string {
+  const entry = require_.resolve('bullmq');
+  // entry is <pkg>/dist/cjs/index.js — walk up to the package root, then into the flavour.
+  const pkgRoot = entry.slice(0, entry.indexOf(`${path.sep}dist${path.sep}`));
+  return readFileSync(
+    path.join(pkgRoot, 'dist', flavour, 'classes', 'redis-queue-backend.js'),
+    'utf8',
+  );
+}
+
+describe('bullmq blocking-connection reconnect patch', () => {
+  it.each(['cjs', 'esm'] as const)(
+    'guards the watchdog disconnect in the %s build',
+    (flavour) => {
+      const src = backendSource(flavour);
+
+      // The watchdog must never tear down a client that is already reconnecting.
+      expect(src).toContain("bclient.status === 'ready'");
+
+      // Every bclient.disconnect(false) must be paired with a guard. Counting is what makes
+      // this robust: if upstream adds a second unguarded teardown, the counts diverge.
+      const disconnects = src.match(/bclient\.disconnect\(false\)/g) ?? [];
+      const guards = src.match(/bclient\.status === 'ready'/g) ?? [];
+      expect(disconnects.length).toBeGreaterThan(0);
+      expect(guards).toHaveLength(disconnects.length);
+    },
+  );
+
+  it('is pinned to the exact bullmq version the patch was built against', () => {
+    // pnpm patches are keyed by exact version; a bump silently drops the patch, so the
+    // spec above would still pass against an unpatched-but-differently-shaped file only
+    // if the anchor changed. Assert the version explicitly to force a deliberate re-patch.
+    const pkg = require_('bullmq/package.json') as { version: string };
+    expect(pkg.version).toBe('6.1.1');
+  });
+});

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -28,6 +28,16 @@ RUN pnpm install --no-frozen-lockfile
 RUN test "$(grep -c getMsgKeyId packages/engines/node_modules/whatsapp-web.js/src/util/Injected/Utils.js)" -ge 1 \
     || (echo "::error::whatsapp-web.js patch NOT applied (patches/whatsapp-web.js@1.34.7.patch)" && exit 1)
 
+# Fail the build if the bullmq patch did not apply. Unpatched, BullMQ 6's blocking-read
+# watchdog calls bclient.disconnect(false) even when the client is already 'reconnecting',
+# which cancels its retry timer without emitting 'close'. The Worker then stops consuming
+# FOREVER after any Redis outage >~6s, silently: the base connection returns to 'ready',
+# queue.add keeps succeeding, `waiting` grows, `active` stays 0, health checks stay green.
+# The file lives under the pnpm store, so locate it rather than hardcoding a path.
+RUN f="$(find /app/node_modules/.pnpm -path '*bullmq*/dist/cjs/classes/redis-queue-backend.js' | head -1)" \
+    && test -n "$f" && grep -q "bclient.status === 'ready'" "$f" \
+    || (echo "::error::bullmq patch NOT applied (patches/bullmq@6.1.1.patch)" && exit 1)
+
 # Copy prisma schema first and generate
 COPY packages/database/prisma ./packages/database/prisma
 

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -35,6 +35,16 @@ RUN pnpm install --no-frozen-lockfile
 RUN test "$(grep -c getMsgKeyId packages/engines/node_modules/whatsapp-web.js/src/util/Injected/Utils.js)" -ge 1 \
     || (echo "::error::whatsapp-web.js patch NOT applied (patches/whatsapp-web.js@1.34.7.patch)" && exit 1)
 
+# Fail the build if the bullmq patch did not apply. Unpatched, BullMQ 6's blocking-read
+# watchdog calls bclient.disconnect(false) even when the client is already 'reconnecting',
+# which cancels its retry timer without emitting 'close'. The Worker then stops consuming
+# FOREVER after any Redis outage >~6s, silently: the base connection returns to 'ready',
+# queue.add keeps succeeding, `waiting` grows, `active` stays 0, health checks stay green.
+# The file lives under the pnpm store, so locate it rather than hardcoding a path.
+RUN f="$(find /app/node_modules/.pnpm -path '*bullmq*/dist/cjs/classes/redis-queue-backend.js' | head -1)" \
+    && test -n "$f" && grep -q "bclient.status === 'ready'" "$f" \
+    || (echo "::error::bullmq patch NOT applied (patches/bullmq@6.1.1.patch)" && exit 1)
+
 # Generate Prisma client FIRST (before worker build)
 RUN cd packages/database && npx prisma generate
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
       "isolated-vm"
     ],
     "patchedDependencies": {
-      "whatsapp-web.js@1.34.7": "patches/whatsapp-web.js@1.34.7.patch"
+      "whatsapp-web.js@1.34.7": "patches/whatsapp-web.js@1.34.7.patch",
+      "bullmq@6.1.1": "patches/bullmq@6.1.1.patch"
     }
   }
 }

--- a/patches/bullmq@6.1.1.patch
+++ b/patches/bullmq@6.1.1.patch
@@ -1,0 +1,42 @@
+diff --git a/dist/cjs/classes/redis-queue-backend.js b/dist/cjs/classes/redis-queue-backend.js
+index 25c6c720eb3f61694f658083e930ac6f4d12b92f..77bb12559dcd9a5009648c37a8111cc6ad56c9c5 100644
+--- a/dist/cjs/classes/redis-queue-backend.js
++++ b/dist/cjs/classes/redis-queue-backend.js
+@@ -1850,7 +1850,15 @@ class RedisQueueBackend extends events_1.EventEmitter {
+         const timeout = new Promise(resolve => {
+             watchdog = setTimeout(() => {
+                 timedOut = true;
+-                bclient.disconnect(false);
++                // PATCH (MultiWA): only tear down the blocking client if it is actually
++                // connected. When Redis has already gone away the client is 'reconnecting',
++                // and disconnect(false) cancels its retry timer WITHOUT emitting 'close' —
++                // the client becomes a zombie and the Worker never consumes again.
++                // Upstream calls this unconditionally; bullmq 5 used disconnect(!this.closing),
++                // which is why v5 recovered. See patches/README or the PR for the repro.
++                if (bclient.status === 'ready') {
++                    bclient.disconnect(false);
++                }
+                 resolve(null);
+             }, roundedTimeout * 1000 + 1000);
+         });
+diff --git a/dist/esm/classes/redis-queue-backend.js b/dist/esm/classes/redis-queue-backend.js
+index 762f18308074d23cf5e3f126ed63183ede10a2e0..6a1a9471cced11f0d185a65919edf9aba75b871d 100644
+--- a/dist/esm/classes/redis-queue-backend.js
++++ b/dist/esm/classes/redis-queue-backend.js
+@@ -1847,7 +1847,15 @@ export class RedisQueueBackend extends EventEmitter {
+         const timeout = new Promise(resolve => {
+             watchdog = setTimeout(() => {
+                 timedOut = true;
+-                bclient.disconnect(false);
++                // PATCH (MultiWA): only tear down the blocking client if it is actually
++                // connected. When Redis has already gone away the client is 'reconnecting',
++                // and disconnect(false) cancels its retry timer WITHOUT emitting 'close' —
++                // the client becomes a zombie and the Worker never consumes again.
++                // Upstream calls this unconditionally; bullmq 5 used disconnect(!this.closing),
++                // which is why v5 recovered. See patches/README or the PR for the repro.
++                if (bclient.status === 'ready') {
++                    bclient.disconnect(false);
++                }
+                 resolve(null);
+             }, roundedTimeout * 1000 + 1000);
+         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
   libsignal: https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
 
 patchedDependencies:
+  bullmq@6.1.1:
+    hash: yrtq7penq7c7vh66hmw564uy5m
+    path: patches/bullmq@6.1.1.patch
   whatsapp-web.js@1.34.7:
     hash: zlba2mg5cqyu7nc5sjbgdbzlo4
     path: patches/whatsapp-web.js@1.34.7.patch
@@ -231,7 +234,7 @@ importers:
         version: 6.0.0
       bullmq:
         specifier: ^6.1.1
-        version: 6.1.1(ioredis@5.11.1)(pg@8.22.0)
+        version: 6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@5.11.1)(pg@8.22.0)
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -349,7 +352,7 @@ importers:
         version: 7.9.1(prisma@7.9.1(@types/react-dom@18.3.7(@types/react@19.2.17))(@types/react@19.2.17)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
       bullmq:
         specifier: ^6.1.1
-        version: 6.1.1(ioredis@5.11.1)(pg@8.22.0)
+        version: 6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@5.11.1)(pg@8.22.0)
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
@@ -10769,7 +10772,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bullmq@6.1.1(ioredis@5.11.1)(pg@8.22.0):
+  bullmq@6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@5.11.1)(pg@8.22.0):
     dependencies:
       cron-parser: 5.8.1
       msgpackr: 2.0.5


### PR DESCRIPTION
> **This is live on wagw right now.** The worker was cut over to BullMQ 6.1.0 earlier today and is exposed to the next Redis blip longer than ~6s. It is not urgent-as-in-broken — it needs an outage to trigger — but it should go out with the next worker image.

## The defect

BullMQ 6 arms a watchdog around its blocking `bzpopmin` read and, on timeout, calls `bclient.disconnect(false)` **unconditionally**:

```js
watchdog = setTimeout(() => {
    timedOut = true;
    bclient.disconnect(false);   // <-- even when the client is already 'reconnecting'
    resolve(null);
}, roundedTimeout * 1000 + 1000);
```

When Redis has already gone away the client is in state `reconnecting`, and `disconnect(false)` cancels its retry timer **without emitting `close`**. The client becomes a zombie and the Worker never consumes another job.

BullMQ 5 called `disconnect(!this.closing)` — which is why v5 recovered. That one-word change is the whole regression.

## Reproduced, with a control

Real Redis, wagw's flags (`--requirepass --appendonly yes --maxmemory 512mb --maxmemory-policy noeviction`), 20s outage, **same harness and same ioredis 5.11.1 throughout** — the only variable is BullMQ:

| BullMQ | Result |
|---|---|
| 5.81.2 | **RECOVERED** — 3/3 jobs |
| 6.1.0 *(what wagw runs)* | **STUCK** — 0/3, `waiting: 3`, `active: 0` |
| 6.1.0 + this guard | **RECOVERED** — 3/3 |

Threshold is `drainDelay` (5s) + 1s watchdog: a 3s outage recovers, an 8s one wedges.

## Why it is dangerous

It is silent and defeats every check we have:

- the **base** connection returns to `ready`, so the worker readiness probe passes and the Docker HEALTHCHECK stays green
- `queue.add` keeps succeeding, so producers see no error
- `waiting` grows unbounded while `active` stays `0`

On wagw the affected queue is `webhooks` (API produces, worker consumes — the only cross-process queue at `ENGINE_HOST=api`). So the real symptom is **customer webhook delivery silently stops until someone restarts `multiwa-worker`**. There is precedent for a long Redis stall: the 2026-07-17 disk-full incident crash-looped Postgres.

## ioredis is not involved

The 2×2 holds identically on ioredis 6.0.0 — both `6.1.0 + ioredis 5` and `6.1.0 + ioredis 6` wedge; both `5.81.2 + ioredis 5` and `5.81.2 + ioredis 6` recover. **This must not be used as a reason to hold #154.**

## Changes

1. **`patches/bullmq@6.1.1.patch`** via `pnpm.patchedDependencies` — guards the teardown with `if (bclient.status === 'ready')`, in **both** the `cjs` and `esm` builds. The Cluster-only `disconnect(false)` in `redis-connection.js` is deliberate (it calls `connect()` immediately after) and is left alone.

2. **`apps/worker/src/bullmq-reconnect.spec.ts`** — asserts the guard exists in both builds and that guards and disconnects are *balanced*, so an upstream bump that silently drops the patch fails CI instead of shipping the wedge back to production. Verified with a negative control: reverting the patched file turns the spec red.

3. **Build assertions in `Dockerfile.worker` and `Dockerfile.api`**, mirroring the existing whatsapp-web.js one, so an unpatched image cannot be built at all. The path is located with `find` because the file lives under the pnpm store (a hardcoded path gave a false alarm during the BullMQ 6 deploy).

## Verification

- `pnpm install --frozen-lockfile` PASS; guard present in cjs and esm after a clean install
- `tsc --noEmit` PASS on api / worker / admin
- **api 346/346**, **worker 37/37** (3 new), worker build PASS

## Follow-up (not in this PR)

The worker readiness probe inspects only the base connection, so it cannot detect this class of failure at all. Worth hardening to assert queue depth is draining rather than that a socket is `ready` — tracked separately.