### PR TITLE
build(deps): bump ioredis from 5.11.1 to 6.0.0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "fastify": "5.11.3",
-    "ioredis": "^5.11.1",
+    "ioredis": "^6.0.0",
     "nodemailer": "^9.0.5",
     "passport": "^0.7.0",
     "passport-custom": "^1.2.1",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -25,7 +25,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@prisma/client": "^7.9.1",
     "bullmq": "^6.1.1",
-    "ioredis": "^5.11.1",
+    "ioredis": "^6.0.0",
     "nodemailer": "^9.0.5",
     "pino": "^10.3.1",
     "prom-client": "^15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,7 +234,7 @@ importers:
         version: 6.0.0
       bullmq:
         specifier: ^6.1.1
-        version: 6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@5.11.1)(pg@8.22.0)
+        version: 6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@6.0.0)(pg@8.22.0)
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -245,8 +245,8 @@ importers:
         specifier: 5.11.3
         version: 5.11.3
       ioredis:
-        specifier: ^5.11.1
-        version: 5.11.1
+        specifier: ^6.0.0
+        version: 6.0.0
       nodemailer:
         specifier: ^9.0.5
         version: 9.0.5
@@ -352,10 +352,10 @@ importers:
         version: 7.9.1(prisma@7.9.1(@types/react-dom@18.3.7(@types/react@19.2.17))(@types/react@19.2.17)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
       bullmq:
         specifier: ^6.1.1
-        version: 6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@5.11.1)(pg@8.22.0)
+        version: 6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@6.0.0)(pg@8.22.0)
       ioredis:
-        specifier: ^5.11.1
-        version: 5.11.1
+        specifier: ^6.0.0
+        version: 6.0.0
       nodemailer:
         specifier: ^9.0.5
         version: 9.0.5
@@ -1453,8 +1453,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@ioredis/commands@1.10.0':
-    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+  '@ioredis/commands@2.0.0':
+    resolution: {integrity: sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -5024,9 +5024,9 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ioredis@5.11.1:
-    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
-    engines: {node: '>=12.22.0'}
+  ioredis@6.0.0:
+    resolution: {integrity: sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==}
+    engines: {node: '>=20.0.0'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -6273,10 +6273,6 @@ packages:
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
-    engines: {node: '>=4'}
-
-  redis-parser@3.0.0:
-    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
   redux-thunk@3.1.0:
@@ -8195,7 +8191,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
-  '@ioredis/commands@1.10.0': {}
+  '@ioredis/commands@2.0.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -10772,7 +10768,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bullmq@6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@5.11.1)(pg@8.22.0):
+  bullmq@6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@6.0.0)(pg@8.22.0):
     dependencies:
       cron-parser: 5.8.1
       msgpackr: 2.0.5
@@ -10780,7 +10776,7 @@ snapshots:
       semver: 7.8.5
       tslib: 2.8.1
     optionalDependencies:
-      ioredis: 5.11.1
+      ioredis: 6.0.0
       pg: 8.22.0
 
   bundle-require@5.1.0(esbuild@0.27.2):
@@ -12192,14 +12188,13 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ioredis@5.11.1:
+  ioredis@6.0.0:
     dependencies:
-      '@ioredis/commands': 1.10.0
+      '@ioredis/commands': 2.0.0
       cluster-key-slot: 1.1.1
       debug: 4.4.3
       denque: 2.1.0
       redis-errors: 1.2.0
-      redis-parser: 3.0.0
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -13482,10 +13477,6 @@ snapshots:
       - redux
 
   redis-errors@1.2.0: {}
-
-  redis-parser@3.0.0:
-    dependencies:
-      redis-errors: 1.2.0
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:


### PR DESCRIPTION
Supersedes #154 — same bump, rebased onto main after the BullMQ patch landed, and applied with targeted `pnpm add` so the lockfile churn stays scoped.

## Why this is safe

ioredis 6.0.0's **only** documented breaking change is *"requires Node.js 20 or newer and uses RESP3 by default; set `protocol: 2` to retain the v5 wire protocol"*. Our Docker base images are already Node 20.

RESP3's blast radius is contained because ioredis 6 defaults `replyMapping: "legacy"` — map replies stay flat arrays, doubles stay strings, so reply shapes are RESP2-identical and BullMQ's Lua-script-driven core is unaffected.

MultiWA's ioredis surface is small and boring: 11 `new IORedis(...)` sites across `apps/api` and `apps/worker`, **zero** Cluster, **zero** Sentinel, no pub/sub protocol assumptions.

Two default changes are *absent from the release notes* and worth knowing (found by diffing `RedisOptions.js`):

| default | v5.11.1 | v6.0.0 |
|---|---|---|
| `retryStrategy` | `min(times*50, 2000)` | `min(2^(times-1)*50, 5000)` + 0–200ms jitter |
| `keepAlive` | `0` | `30000` |

Reconnect backoff therefore caps at ~5.2s instead of 2s. The api cache adapter overrides `retryStrategy` so its 3-strikes-then-memory-fallback is unaffected, and `keepAlive: 30000` is benign-to-beneficial on a Docker bridge network.

## The check that mattered

**pnpm keys patched packages by a directory name that embeds the ioredis peer**, so bumping ioredis re-resolves that directory — an ioredis bump can silently drop the BullMQ patch that fixes the worker wedge.

Verified after a clean `--frozen-lockfile` install: the ready-guard is present in **both** the cjs and esm builds, and `apps/worker/src/bullmq-reconnect.spec.ts` (which asserts exactly that) passes.

## Outage test on the shipping combination

The wedge repro was re-run on what this actually ships — **bullmq 6.1.1 (patched) + ioredis 6.0.0**, real Redis killed for 20s:

```
baseline processed = 1
processed after outage: 3 of 3
queue counts: {"waiting":0,"active":0,"completed":7}
RESULT: RECOVERED
```

So the fix holds on the new pairing, not just the old one.

## Verification

- `pnpm install --frozen-lockfile` PASS
- `tsc --noEmit` PASS on api / worker / admin
- **api 346/346**, **worker 37/37**, api + worker build PASS
- Single `ioredis@6.0.0` copy; `fastify@5.11.3`, `bullmq@6.1.1`, `@typescript-eslint` (51 lines) and the 0-`ssh://` guard all unchanged