### PR TITLE
fix(send-gate): suppress stuttered identical replies that burn the daily cap

### DIFF
--- a/apps/api/src/modules/messages/messages.service.ts
+++ b/apps/api/src/modules/messages/messages.service.ts
@@ -25,6 +25,7 @@ import {
   isColdCircuitBlocking,
   COLD_CIRCUIT_COOLDOWN_MS,
   isSystemMessageType,
+  repeatDedupeText,
 } from '@multiwa/engine-runtime';
 import { AppEvents, isWhatsAppRecipient } from '@multiwa/core';
 import {
@@ -313,6 +314,7 @@ export class MessagesService {
         () => this.dispatchToEngine(engine, type, jid, content, quotedMessageId),
         jid,
         isCold,
+        repeatDedupeText(type, content),
       );
     } catch (error: any) {
       await prisma.message.update({
@@ -465,6 +467,7 @@ export class MessagesService {
         () => this.dispatchToEngine(engine, type, to, content, quotedMessageId),
         to,
         laneRow?.lane === 'cold',
+        repeatDedupeText(type, content),
       );
       await prisma.message.update({
         where: { id: messageDbId },

--- a/apps/api/src/modules/messages/send-gate-repeat.spec.ts
+++ b/apps/api/src/modules/messages/send-gate-repeat.spec.ts
@@ -1,0 +1,131 @@
+// Repeat-reply suppressor tests.
+//
+// This guard sits in front of EVERY outbound send, so the risk it carries is
+// swallowing a message a customer should have received. The negative cases below
+// matter more than the positive one: different text, different recipient,
+// different profile, non-text payloads, and anything past the window must all
+// still go out.
+//
+// Context: 2026-08-23, a mass power-cut drove an 18x inbound surge and the bot
+// answered every message with the same "belum memahami" fallback — 1463 identical
+// replies, 74% of a 2000/day cap, in two hours.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const profileUpdate = vi.fn();
+vi.mock('@multiwa/database', () => ({
+  prisma: {
+    profile: {
+      findUnique: vi.fn(async () => ({
+        messageDelayMs: 0,
+        messageDelayJitterMs: 0,
+        dailyMessageLimit: null,
+        dailyMessageCount: 0,
+        dailyResetAt: null,
+        warmupEnabled: false,
+        warmupStartPerDay: null,
+        warmupRampDays: null,
+        warmupStartedAt: null,
+        serviceWindowHours: 24,
+        coldDailyLimit: null,
+        coldMessageCount: 0,
+        coldCircuitState: 'closed',
+        coldCircuitOpenedAt: null,
+      })),
+      update: (...a: any[]) => profileUpdate(...a),
+      updateMany: vi.fn(async () => ({ count: 0 })),
+    },
+    message: { findMany: vi.fn(async () => []), findUnique: vi.fn(async () => null) },
+  },
+}));
+
+import { SendGateService, repeatDedupeText } from '@multiwa/engine-runtime';
+
+const PROFILE = 'p1';
+const TO = '628111@c.us';
+const FALLBACK = 'Mohon maaf, VirA belum memahami maksud Anda.';
+
+function send(gate: SendGateService, text?: string, to = TO, profile = PROFILE) {
+  return gate.executeWithGate(profile, async () => ({ messageId: 'm' }), to, false, text);
+}
+
+describe('repeatDedupeText', () => {
+  it('opts in plain text only', () => {
+    expect(repeatDedupeText('text', { text: 'hi' })).toBe('hi');
+  });
+
+  it('opts OUT every non-text payload, so media is never suppressed', () => {
+    for (const type of ['image', 'video', 'document', 'audio', 'location', 'contact', 'sticker']) {
+      expect(repeatDedupeText(type, { text: 'caption', url: 'https://x/y.png' })).toBeUndefined();
+    }
+  });
+
+  it('opts out when there is no usable text', () => {
+    expect(repeatDedupeText('text', {})).toBeUndefined();
+    expect(repeatDedupeText('text', { text: '' })).toBeUndefined();
+    expect(repeatDedupeText('text', { text: 123 })).toBeUndefined();
+  });
+});
+
+describe('SendGateService repeat suppression', () => {
+  let gate: SendGateService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    profileUpdate.mockReset().mockResolvedValue({});
+    gate = new SendGateService();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('suppresses an identical reply inside the window (the incident)', async () => {
+    await expect(send(gate, FALLBACK)).resolves.toBeTruthy();
+    await expect(send(gate, FALLBACK)).rejects.toMatchObject({ status: 429 });
+  });
+
+  it('suppressed sends cost no quota — the counter advances once, not twice', async () => {
+    await send(gate, FALLBACK);
+    await send(gate, FALLBACK).catch(() => undefined);
+    // Count only the quota increment: profile.update is also called for the
+    // daily-window reset, which is unrelated to how much quota was consumed.
+    const increments = profileUpdate.mock.calls.filter(
+      ([arg]: any[]) => arg?.data?.dailyMessageCount?.increment === 1,
+    );
+    expect(increments).toHaveLength(1);
+  });
+
+  it('lets the same text through again once the window has passed', async () => {
+    await send(gate, FALLBACK);
+    vi.advanceTimersByTime(60_000);
+    await expect(send(gate, FALLBACK)).resolves.toBeTruthy();
+  });
+
+  // ---- negative controls: none of these may ever be suppressed ----
+
+  it('does NOT suppress different text to the same recipient', async () => {
+    await send(gate, FALLBACK);
+    await expect(send(gate, 'Laporan Anda kami terima.')).resolves.toBeTruthy();
+  });
+
+  it('does NOT suppress the same text to a DIFFERENT recipient', async () => {
+    await send(gate, FALLBACK);
+    await expect(send(gate, FALLBACK, '628999@c.us')).resolves.toBeTruthy();
+  });
+
+  it('does NOT suppress across profiles', async () => {
+    await send(gate, FALLBACK);
+    await expect(send(gate, FALLBACK, TO, 'p2')).resolves.toBeTruthy();
+  });
+
+  it('does NOT suppress when no dedupe text is supplied (media path)', async () => {
+    await send(gate, undefined);
+    await expect(send(gate, undefined)).resolves.toBeTruthy();
+  });
+
+  it('does NOT arm the window when the send itself failed', async () => {
+    await gate
+      .executeWithGate(PROFILE, async () => { throw new Error('engine down'); }, TO, false, FALLBACK)
+      .catch(() => undefined);
+    // The customer never got it, so the retry must go out.
+    await expect(send(gate, FALLBACK)).resolves.toBeTruthy();
+  });
+});

--- a/apps/worker/src/engine/messages.service.ts
+++ b/apps/worker/src/engine/messages.service.ts
@@ -9,7 +9,7 @@
 import { Injectable, Logger, HttpException, HttpStatus, Inject, forwardRef } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { prisma } from '@multiwa/database';
-import { SendGateService, classifyColdSend } from '@multiwa/engine-runtime';
+import { SendGateService, classifyColdSend, repeatDedupeText } from '@multiwa/engine-runtime';
 import { AppEvents, isWhatsAppRecipient } from '@multiwa/core';
 import { EngineManagerService } from './engine-manager.service';
 
@@ -101,6 +101,7 @@ export class WorkerMessagesService {
         () => this.dispatchToEngine(engine, type, jid, content, quotedMessageId),
         jid,
         isCold,
+        repeatDedupeText(type, content),
       );
       if (result?.messageId) {
         await prisma.message.update({ where: { id: message.id }, data: { messageId: result.messageId, status: 'sent' } });
@@ -133,6 +134,7 @@ export class WorkerMessagesService {
         () => this.dispatchToEngine(engine, type, to, content, quotedMessageId),
         to,
         laneRow?.lane === 'cold',
+        repeatDedupeText(type, content),
       );
       await prisma.message.update({
         where: { id: messageDbId },

--- a/packages/engine-runtime/src/send-gate.service.ts
+++ b/packages/engine-runtime/src/send-gate.service.ts
@@ -249,6 +249,35 @@ export async function evaluateColdCircuit(
   return null;
 }
 
+// Repeat-reply suppressor. An automation that answers every inbound message with
+// the same text turns one upstream incident into a quota outage: on 2026-08-23 a
+// mass power-cut drove an 18x inbound surge, and 1463 identical "VirA belum
+// memahami maksud Anda" replies burned 74% of a 2000/day cap in two hours — one
+// conversation alone took 596. The customers were real and their messages were
+// distinct; only the REPLY was stuttering, so nothing upstream of the gate could
+// see it. Suppress an identical text to the same recipient inside the window.
+//
+// Deliberately scoped tight so it cannot eat real traffic: same profile, same
+// recipient, byte-identical text, short window. Distinct texts (OTPs, answers,
+// media) never match. Set SEND_REPEAT_SUPPRESS_MS=0 to disable entirely.
+export const REPEAT_SUPPRESS_MS = Number(process.env.SEND_REPEAT_SUPPRESS_MS ?? 60_000);
+/** Cap on remembered (recipient, text) pairs, so a long-running process cannot grow unbounded. */
+const REPEAT_MEMO_MAX = 5000;
+
+/**
+ * The suppressor key for an outbound send, or undefined to opt this send out.
+ *
+ * Only plain `text` opts in. Media, location, contacts, buttons and everything
+ * else return undefined and are never suppressed: their payloads are large or
+ * structured, two of them are rarely byte-identical by accident, and wrongly
+ * dropping one is far more costly than the quota it saves.
+ */
+export function repeatDedupeText(type: string, content: any): string | undefined {
+  if (type !== 'text') return undefined;
+  const text = content?.text;
+  return typeof text === 'string' && text.length > 0 ? text : undefined;
+}
+
 @Injectable()
 export class SendGateService {
   private readonly logger = new Logger(SendGateService.name);
@@ -258,24 +287,47 @@ export class SendGateService {
   // promise carries the real result/error. Single-instance only (see SOP).
   private readonly profileChains = new Map<string, Promise<unknown>>();
   private readonly lastSentAt = new Map<string, number>();
+  /** key -> epoch ms of the last IDENTICAL text accepted for that recipient. */
+  private readonly lastRepeatAt = new Map<string, number>();
+
+  /**
+   * Drop memo entries older than the window, then hard-cap the map. Called on
+   * every check, so the map tracks only what the window can still match.
+   */
+  private pruneRepeatMemo(now: number): void {
+    for (const [k, t] of this.lastRepeatAt) {
+      if (now - t >= REPEAT_SUPPRESS_MS) this.lastRepeatAt.delete(k);
+    }
+    // Insertion-ordered: deleting from the front drops the oldest first.
+    while (this.lastRepeatAt.size > REPEAT_MEMO_MAX) {
+      const oldest = this.lastRepeatAt.keys().next().value;
+      if (oldest === undefined) break;
+      this.lastRepeatAt.delete(oldest);
+    }
+  }
 
   /**
    * Serialize the send for this profile, apply the inter-message delay, enforce
    * the daily limit (429 when reached), run sendFn, and increment the daily
    * counter on success. Returns sendFn's result, or rejects with the send error
    * / a 429 HttpException.
+   *
+   * `dedupeText` opts this send into the repeat-reply suppressor. Pass the plain
+   * message text for text sends; omit it (media, or any send that must always go
+   * out) and the suppressor is skipped for that call.
    */
   async executeWithGate<T>(
     profileId: string,
     sendFn: () => Promise<T>,
     recipient?: string,
     isCold?: boolean,
+    dedupeText?: string,
   ): Promise<T> {
     const prev = this.profileChains.get(profileId) ?? Promise.resolve();
     // Run after the previous send for this profile, whether it resolved or rejected.
     const runResult = prev.then(
-      () => this.gatedRun(profileId, sendFn, recipient, isCold),
-      () => this.gatedRun(profileId, sendFn, recipient, isCold),
+      () => this.gatedRun(profileId, sendFn, recipient, isCold, dedupeText),
+      () => this.gatedRun(profileId, sendFn, recipient, isCold, dedupeText),
     );
     // The stored tail must never reject (or it poisons the chain).
     this.profileChains.set(
@@ -293,7 +345,32 @@ export class SendGateService {
     sendFn: () => Promise<T>,
     recipient?: string,
     isColdArg?: boolean,
+    dedupeText?: string,
   ): Promise<T> {
+    // 0. Repeat-reply suppression. Runs FIRST: a stuttered reply must cost neither
+    //    the inter-message delay nor a slot of the daily cap. Rejected with 429 so
+    //    existing callers mark the row 'failed' (excluded from cold-circuit
+    //    accounting) rather than reporting a send that never happened.
+    const repeatKey =
+      REPEAT_SUPPRESS_MS > 0 && recipient && dedupeText
+        ? `${profileId}|${recipient}|${dedupeText}`
+        : null;
+    if (repeatKey) {
+      const now = Date.now();
+      this.pruneRepeatMemo(now);
+      const previous = this.lastRepeatAt.get(repeatKey);
+      if (previous !== undefined && now - previous < REPEAT_SUPPRESS_MS) {
+        const retryInMs = REPEAT_SUPPRESS_MS - (now - previous);
+        this.logger.warn(
+          `Suppressed repeat reply to ${recipient.replace(/[\r\n]/g, '')} on profile ${profileId.replace(/[\r\n]/g, '')} (identical text ${now - previous}ms ago)`,
+        );
+        throw new HttpException(
+          { error: 'REPEAT_SUPPRESSED', retryInMs },
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+    }
+
     const profile = await prisma.profile.findUnique({
       where: { id: profileId },
       select: {
@@ -385,6 +462,10 @@ export class SendGateService {
     // 4. Send, then increment counters only on a real successful send. Cold sends
     // advance both the total and the cold counter; replies advance only the total.
     const result = await sendFn();
+    // Arm the repeat window only on a send that actually went out. Arming before
+    // sendFn would let one engine failure suppress the legitimate retry of a
+    // message the customer never received.
+    if (repeatKey) this.lastRepeatAt.set(repeatKey, Date.now());
     await prisma.profile.update({
       where: { id: profileId },
       data: {


### PR DESCRIPTION
## The incident

On **2026-08-23** a mass power-cut drove an **18× inbound surge** on the PLN Batam gateway. Same two-hour window, day over day:

| | 2026-08-22 | 2026-08-23 |
|---|---|---|
| inbound | 44 | **788** |
| outbound | 64 | **1977** |
| active conversations | — | **116** |

The bot answered every message with the same fallback. Where the day's quota went:

| reply | count |
|---|---|
| `Mohon maaf, VirA belum memahami maksud Anda` | **1463 (74%)** |
| greetings | 258 |
| complaint menu | 84 |
| report acknowledgements | 92 |

One conversation alone took **596** — 30% of a 2000/day cap. The profile then held every customer reply for the remaining ~18 hours until the WIB reset, right after an outage, for an electricity utility.

## What it was *not*

Worth stating plainly, because the alert pointed the other way:

- **Not a counter bug.** 2094 real outbound messages were sent since WIB midnight. The counter was right.
- **Not a timezone bug.** `dailyResetAt` was `17:00 UTC` = exactly WIB midnight; the gate uses an explicit `WIB_OFFSET_MS`.
- **Not a loop or duplicate delivery.** All 596 outbound and all 279 inbound message ids in the worst conversation were **distinct**. A real, increasingly frustrated human was typing `woiiiiii` / `nyalain lampunya` / `p` / `p` / `udh sejam`, and the bot replied to each one.

So raising `dailyMessageLimit` — what the alert suggested — treats the symptom and makes the next surge bigger. The cap exists to protect the number.

## The fix

A repeat-reply suppressor in the send gate, the one choke point every outbound path already passes through:

- Same profile + same recipient + **byte-identical** text inside the window → `429 REPEAT_SUPPRESSED`, rejected **before** the inter-message delay and **before** any quota is spent.
- The window is armed **only after a send that actually went out** — an engine failure must never suppress the legitimate retry of a message the customer never received.
- Only `type === 'text'` opts in (`repeatDedupeText`). Media, location, contacts, buttons are never suppressed: wrongly dropping one costs far more than the quota it saves.
- `SEND_REPEAT_SUPPRESS_MS` tunes the window (default **60s**); `0` disables it entirely.
- Memo pruned to the window, hard-capped at 5000 entries.

## Replayed against the real incident

1977 outbound rows were dumped from production and replayed through the suppressor logic:

| window | sent | suppressed | saved | fallbacks saved |
|---|---|---|---|---|
| 30s | 968 | 1009 | 51% | 913 |
| **60s** | **649** | **1328** | **67%** | **1110** |
| 120s | 402 | 1575 | 80% | 1257 |

At the 60s default the day's **2094 sends become 766** — comfortably under the 2000 cap. **The outage would not have happened.**

(An earlier back-of-envelope model that assumed evenly-spread traffic showed 0% savings. It was wrong: the real traffic is bursty. These numbers come from the production timestamps, not a model.)

## Tests

11 tests, of which the six negative controls matter more than the positive case — this guard sits in front of every send, so its real risk is swallowing a message a customer should have received:

- different text → sent
- same text, different recipient → sent
- same text, different profile → sent
- non-text payload (7 types) → never suppressed
- past the window → sent
- **send failed → the retry still goes out**

## Verification

- **api 357/357**, **worker 37/37**
- `tsc --noEmit` PASS on api / worker / admin
- api + worker build PASS

## Operational note

Emergency relief is already applied on wagw: profile `EXTERNAL 459` was raised `2000 → 3000` to unblock customer replies, and sending resumed. That is a stopgap — this PR is what makes it unnecessary. Consider returning the cap to 2000 once this is deployed.