### PR TITLE
fix(deps): pin patched dependencies exactly so a build cannot drop the patch

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
     "@nestjs/websockets": "^11.2.1",
     "@types/qrcode": "^1.5.6",
     "bcrypt": "^6.0.0",
-    "bullmq": "^6.1.1",
+    "bullmq": "6.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "fastify": "5.11.3",

--- a/apps/api/src/patched-deps-pinned.spec.ts
+++ b/apps/api/src/patched-deps-pinned.spec.ts
@@ -1,0 +1,89 @@
+// Patched-dependency pin meta-test (silent-patch-loss regression guard).
+//
+// `pnpm.patchedDependencies` keys an EXACT version — `bullmq@6.1.1`. If the package
+// that declares that dependency uses a RANGE (`^6.1.1`), the two can drift apart and
+// the patch stops applying. That is not hypothetical here:
+//
+//   docker/Dockerfile.{api,worker,admin} install with `--no-frozen-lockfile`, because
+//   each stage copies only a SUBSET of the workspace package.json files, so a frozen
+//   install would fail the lockfile check. The consequence is that image builds
+//   RE-RESOLVE every `^` range at build time and ignore pnpm-lock.yaml entirely —
+//   verified on 2026-08-24, when an image built from 046d0c0 shipped @nestjs/swagger
+//   11.4.7 while that commit's lockfile pinned 11.4.6.
+//
+// So the moment BullMQ publishes 6.2.0, a `^6.1.1` spec would resolve to it, the
+// `bullmq@6.1.1` patch key would no longer match, and the reconnect ready-guard would
+// vanish from the image — silently reintroducing the worker wedge (see
+// apps/worker/src/bullmq-reconnect.spec.ts for what that costs).
+//
+// The Dockerfiles assert the patches are present at build time, which catches it. This
+// test prevents it instead: every patched dependency must be pinned EXACTLY wherever it
+// is declared.
+
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+
+function readJson(p: string): any {
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+/** Every workspace package.json in the repo (apps/* and packages/*), plus the root. */
+function workspacePackageJsons(): { file: string; pkg: any }[] {
+  const out: { file: string; pkg: any }[] = [{ file: 'package.json', pkg: readJson(path.join(REPO_ROOT, 'package.json')) }];
+  for (const group of ['apps', 'packages']) {
+    const dir = path.join(REPO_ROOT, group);
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      const file = path.join(dir, name, 'package.json');
+      if (existsSync(file)) out.push({ file: `${group}/${name}/package.json`, pkg: readJson(file) });
+    }
+  }
+  return out;
+}
+
+const EXACT_SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+describe('pnpm.patchedDependencies', () => {
+  const root = readJson(path.join(REPO_ROOT, 'package.json'));
+  const patched: Record<string, string> = root.pnpm?.patchedDependencies ?? {};
+  const patchedNames = Object.keys(patched).map((key) => {
+    const at = key.lastIndexOf('@');
+    return { key, name: key.slice(0, at), version: key.slice(at + 1) };
+  });
+
+  it('has at least one patched dependency (otherwise this guard is vacuous)', () => {
+    expect(patchedNames.length).toBeGreaterThan(0);
+  });
+
+  it('keys every patch to an exact version', () => {
+    for (const { key, version } of patchedNames) {
+      expect(version, `patch key "${key}" must end in an exact version`).toMatch(EXACT_SEMVER);
+    }
+  });
+
+  it('pins every patched dependency EXACTLY wherever it is declared', () => {
+    const offenders: string[] = [];
+    for (const { file, pkg } of workspacePackageJsons()) {
+      const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+      for (const { name, version } of patchedNames) {
+        const spec = deps[name];
+        if (spec === undefined) continue;
+        if (!EXACT_SEMVER.test(spec)) {
+          offenders.push(`${file}: "${name}": "${spec}" is a RANGE — pin it to "${version}"`);
+        } else if (spec !== version) {
+          offenders.push(`${file}: "${name}": "${spec}" does not match patch key version "${version}"`);
+        }
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+
+  it('ships a patch file for every patch key', () => {
+    for (const [key, file] of Object.entries(patched)) {
+      expect(existsSync(path.join(REPO_ROOT, file)), `${key} -> missing ${file}`).toBe(true);
+    }
+  });
+});

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -24,7 +24,7 @@
     "@nestjs/event-emitter": "^3.1.0",
     "@nestjs/schedule": "^6.1.3",
     "@prisma/client": "^7.9.1",
-    "bullmq": "^6.1.1",
+    "bullmq": "6.1.1",
     "ioredis": "^6.0.0",
     "nodemailer": "^9.0.5",
     "pino": "^10.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,7 +233,7 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       bullmq:
-        specifier: ^6.1.1
+        specifier: 6.1.1
         version: 6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@6.0.0)(pg@8.22.0)
       class-transformer:
         specifier: ^0.5.1
@@ -351,7 +351,7 @@ importers:
         specifier: ^7.9.1
         version: 7.9.1(prisma@7.9.1(@types/react-dom@18.3.7(@types/react@19.2.17))(@types/react@19.2.17)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
       bullmq:
-        specifier: ^6.1.1
+        specifier: 6.1.1
         version: 6.1.1(patch_hash=yrtq7penq7c7vh66hmw564uy5m)(ioredis@6.0.0)(pg@8.22.0)
       ioredis:
         specifier: ^6.0.0


### PR DESCRIPTION
## The gap

`pnpm.patchedDependencies` keys an **exact** version:

```json
"patchedDependencies": {
  "whatsapp-web.js@1.34.7": "patches/whatsapp-web.js@1.34.7.patch",
  "bullmq@6.1.1": "patches/bullmq@6.1.1.patch"
}
```

But `bullmq` was declared as a **range** — `^6.1.1` — in `apps/api` and `apps/worker`. The moment BullMQ publishes `6.2.0`, that range resolves past the patch key, **the patch silently stops applying**, and the reconnect ready-guard disappears from the image — reintroducing the wedge PR #168 fixed (BullMQ 6 parks the worker forever after any Redis outage >~6s, health checks staying green the whole time).

`whatsapp-web.js` was already safe: it is pinned exactly at `1.34.7`.

## Why this is not theoretical — the images ignore the lockfile

`docker/Dockerfile.{api,worker,admin}` install with **`--no-frozen-lockfile`**. Each stage copies only **6 of the 10** workspace `package.json` files, so a frozen install would fail pnpm's lockfile check. The consequence is that image builds **re-resolve every `^` range at build time and ignore `pnpm-lock.yaml` entirely**.

Verified on wagw 2026-08-24 — the running API container versus the lockfile of the commit its image was built from (`046d0c0`):

| package | lockfile @046d0c0 | actually shipped |
|---|---|---|
| `@nestjs/swagger` | 11.4.6 | **11.4.7** |
| `@fastify/helmet` | 13.1.0 | **13.1.1** |
| `@aws-sdk/client-s3` | 3.1112.0 | **3.1115.0** |

Production matched `main` by coincidence, not because it was deployed.

## What this PR does

1. **Pins `bullmq` to exactly `6.1.1`** in `apps/api` and `apps/worker`, matching what `whatsapp-web.js` already does.

2. **Adds `apps/api/src/patched-deps-pinned.spec.ts`**, which asserts for every `patchedDependencies` key:
   - the key ends in an exact version,
   - every workspace `package.json` declaring that dependency pins it **exactly to the same version**,
   - the referenced patch file exists.

   Negative-control verified — restoring `^6.1.1` turns it red with a directive message:
   ```
   apps/api/package.json: "bullmq": "^6.1.1" is a RANGE — pin it to "6.1.1"
   ```

The Dockerfiles already assert the patches applied at build time, which catches this *after* the fact. This **prevents** it.

## Verification

- `pnpm install --frozen-lockfile` PASS
- `tsc --noEmit` PASS on api / worker / admin
- **api 361/361** (+4 new), **worker 37/37**
- bullmq reconnect guard still present after the re-pin

## Follow-up (separate PR)

Making the images actually honour the lockfile means copying all 10 workspace `package.json` files into each Dockerfile stage and switching to `--frozen-lockfile`. That is a real restructure of three Dockerfiles across two stages each, with production build risk, so it does not belong in this PR. Until then, every image build re-resolves `^` ranges — which is exactly why the exact pins above matter.