### PR TITLE
fix(docker): make image builds honour the lockfile

### DIFF
--- a/docker/Dockerfile.admin
+++ b/docker/Dockerfile.admin
@@ -19,8 +19,14 @@ COPY packages/engines/package.json ./packages/engines/
 COPY packages/engine-runtime/package.json ./packages/engine-runtime/
 COPY packages/sdk/package.json ./packages/sdk/
 
+# Every workspace package.json must be present or `--frozen-lockfile` fails its
+# lockfile check. These four are manifest-only: they are copied so pnpm can verify
+# the lockfile, and `--filter` below keeps them out of the actual install.
+COPY packages/chatwoot-bridge/package.json ./packages/chatwoot-bridge/
+COPY packages/n8n-nodes-multiwa/package.json ./packages/n8n-nodes-multiwa/
+
 # Install all dependencies with frozen lockfile
-RUN pnpm install --no-frozen-lockfile
+RUN pnpm install --frozen-lockfile --filter @multiwa/admin...
 
 # Copy source
 COPY . .

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -19,8 +19,16 @@ COPY packages/engines/package.json ./packages/engines/
 COPY packages/engine-runtime/package.json ./packages/engine-runtime/
 COPY packages/sdk/package.json ./packages/sdk/
 
+# Every workspace package.json must be present or `--frozen-lockfile` fails its
+# lockfile check. These four are manifest-only: they are copied so pnpm can verify
+# the lockfile, and `--filter` below keeps them out of the actual install.
+COPY apps/worker/package.json ./apps/worker/
+COPY apps/admin/package.json ./apps/admin/
+COPY packages/chatwoot-bridge/package.json ./packages/chatwoot-bridge/
+COPY packages/n8n-nodes-multiwa/package.json ./packages/n8n-nodes-multiwa/
+
 # Install dependencies (allow lockfile updates for missing deps)
-RUN pnpm install --no-frozen-lockfile
+RUN pnpm install --frozen-lockfile --filter @multiwa/api...
 
 # Fail the build if the whatsapp-web.js patch did not apply. A silently-unpatched
 # image reintroduces the WhatsApp Web `$1` MsgKey break (getChats/getGroups/
@@ -106,9 +114,13 @@ COPY --from=builder /app/packages/database/package.json ./packages/database/pack
 COPY --from=builder /app/packages/engines/package.json ./packages/engines/package.json
 COPY --from=builder /app/packages/engine-runtime/package.json ./packages/engine-runtime/package.json
 COPY --from=builder /app/packages/sdk/package.json ./packages/sdk/package.json
+COPY --from=builder /app/apps/worker/package.json ./apps/worker/package.json
+COPY --from=builder /app/apps/admin/package.json ./apps/admin/package.json
+COPY --from=builder /app/packages/chatwoot-bridge/package.json ./packages/chatwoot-bridge/package.json
+COPY --from=builder /app/packages/n8n-nodes-multiwa/package.json ./packages/n8n-nodes-multiwa/package.json
 
 # Install production dependencies in runner
-RUN pnpm install --no-frozen-lockfile --prod
+RUN pnpm install --frozen-lockfile --prod --filter @multiwa/api...
 
 # Copy built artifacts
 COPY --from=builder /app/apps/api/dist ./apps/api/dist

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -17,6 +17,14 @@ COPY packages/engines/package.json ./packages/engines/
 COPY packages/engine-runtime/package.json ./packages/engine-runtime/
 COPY packages/sdk/package.json ./packages/sdk/
 
+# Every workspace package.json must be present or `--frozen-lockfile` fails its
+# lockfile check. These four are manifest-only: they are copied so pnpm can verify
+# the lockfile, and `--filter` below keeps them out of the actual install.
+COPY apps/api/package.json ./apps/api/
+COPY apps/admin/package.json ./apps/admin/
+COPY packages/chatwoot-bridge/package.json ./packages/chatwoot-bridge/
+COPY packages/n8n-nodes-multiwa/package.json ./packages/n8n-nodes-multiwa/
+
 # Copy all source BEFORE install to avoid BuildKit COPY overlay conflict
 COPY apps/worker ./apps/worker
 COPY packages/core ./packages/core
@@ -27,7 +35,7 @@ COPY packages/sdk ./packages/sdk
 COPY tsconfig.json ./tsconfig.json
 
 # Install dependencies
-RUN pnpm install --no-frozen-lockfile
+RUN pnpm install --frozen-lockfile --filter @multiwa/worker...
 
 # Fail the build if the whatsapp-web.js patch did not apply. A silently-unpatched
 # image reintroduces the WhatsApp Web `$1` MsgKey break (getChats/getGroups/
@@ -88,7 +96,7 @@ COPY --from=builder /app/packages/engines/package.json ./packages/engines/
 COPY --from=builder /app/packages/engine-runtime/package.json ./packages/engine-runtime/
 
 # Install production dependencies only
-RUN pnpm install --no-frozen-lockfile --prod
+RUN pnpm install --frozen-lockfile --prod --filter @multiwa/worker...
 
 # Copy built worker and workspace packages
 COPY --from=builder /app/apps/worker/dist ./apps/worker/dist


### PR DESCRIPTION
Follow-up to #173, which pinned the patched dependencies. This fixes the underlying reason those pins were necessary.

## The problem

All three Dockerfiles installed with **`--no-frozen-lockfile`**, so every image build **re-resolved each `^` range at build time and ignored `pnpm-lock.yaml` entirely**.

Two consequences:

1. **Images are not reproducible** — two builds of the same commit can ship different dependency versions.
2. **None of the lockfile hygiene this repo enforces in CI actually applied to the shipped artifact** — the single-fastify-copy guard, the typescript-eslint drift checks, the exact patch pins. All of it was validated against a lockfile the image then discarded.

Verified on wagw 2026-08-24 — running API container versus the lockfile of the commit its image was built from (`046d0c0`):

| package | lockfile @046d0c0 | actually shipped |
|---|---|---|
| `@nestjs/swagger` | 11.4.6 | **11.4.7** |
| `@fastify/helmet` | 13.1.0 | **13.1.1** |
| `@aws-sdk/client-s3` | 3.1112.0 | **3.1115.0** |

Production matched `main` by coincidence, not because it was deployed.

## Why the flag was there

It was not gratuitous. Each stage copied only **6 of the 10** workspace `package.json` files, and pnpm's frozen check validates the lockfile against *every* workspace manifest — so a frozen install genuinely could not pass. The comment in the file even said so: *"allow lockfile updates for missing deps"*.

## The fix — both halves

1. **Copy the 4 missing manifests** into every stage that installs: `apps/worker`, `apps/admin`, `packages/chatwoot-bridge`, `packages/n8n-nodes-multiwa`. Manifest-only — no source is copied.

2. **Scope each install with `--filter <target>...`** so those extra manifests satisfy the lockfile check *without* dragging their dependency trees in. This matters: without it, the API image would start pulling Next.js simply because admin's manifest is now present.

3. **Switch every install to `--frozen-lockfile`** (6 install commands across 3 files).

## Verification

⚠️ **Not validated locally** — there is no Docker on the workstation. CI's `Docker Build Test` builds all three images (`Dockerfile.api`, `Dockerfile.worker`, `Dockerfile.admin`) and is the real gate for this change.

The existing in-Dockerfile assertions still guard the outcome: each build fails if the `whatsapp-web.js` or `bullmq` patch did not apply.

## Merge order

Merge #173 first (the exact pins). If this PR's Docker builds fail in CI, #173 still stands on its own and keeps the acute patch-drift risk closed.