### PR TITLE
fix(docker): pin pnpm to the declared version so image builds stop drifting

### DIFF
--- a/apps/api/src/dockerfile-pnpm-pinned.spec.ts
+++ b/apps/api/src/dockerfile-pnpm-pinned.spec.ts
@@ -1,0 +1,80 @@
+// Dockerfile pnpm-pin meta-test (unpinned-toolchain regression guard).
+//
+// PR #174 made the images honour pnpm-lock.yaml. That only holds if the tool READING
+// the lockfile is itself pinned: `npm install -g pnpm` grabs whatever is latest at
+// build time, so the same commit could be built by a different pnpm on any given day.
+//
+// This is not theoretical. On 2026-08-30 every open PR failed `Build Admin Image` with
+// ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE: a pnpm release had added an engine-identity
+// check that fails on Alpine (Dockerfile.admin uses node:20-alpine; api/worker use
+// node:20-slim, which is why only admin broke). The repo declares pnpm@9.15.0 while npm
+// was by then serving pnpm 11.25.0 — two majors ahead, reading a lockfile written by 9.
+//
+// So: every `npm install -g pnpm` in every Dockerfile must pin the exact version the
+// root package.json declares in `packageManager`.
+
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+const DOCKER_DIR = path.join(REPO_ROOT, 'docker');
+
+/** The exact version from `packageManager: "pnpm@x.y.z"`. */
+function declaredPnpmVersion(): string {
+  const pm: string = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8')).packageManager;
+  const [name, version] = pm.split('@');
+  expect(name, `packageManager should declare pnpm, got "${pm}"`).toBe('pnpm');
+  return version;
+}
+
+function dockerfiles(): { name: string; body: string }[] {
+  return readdirSync(DOCKER_DIR)
+    .filter((f) => f.startsWith('Dockerfile'))
+    .map((f) => ({ name: f, body: readFileSync(path.join(DOCKER_DIR, f), 'utf8') }));
+}
+
+/** Command lines only — comment lines discuss the flag without running it. */
+function commandLines(body: string): { line: string; no: number }[] {
+  return body
+    .split('\n')
+    .map((line, i) => ({ line, no: i + 1 }))
+    .filter(({ line }) => !line.trimStart().startsWith('#'));
+}
+
+describe('Dockerfiles pin pnpm', () => {
+  const version = declaredPnpmVersion();
+
+  it('declares an exact pnpm version in packageManager', () => {
+    expect(version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('finds Dockerfiles to check (otherwise this guard is vacuous)', () => {
+    expect(dockerfiles().length).toBeGreaterThan(0);
+  });
+
+  it('never installs pnpm unpinned', () => {
+    const offenders: string[] = [];
+    for (const { name, body } of dockerfiles()) {
+      for (const { line, no } of commandLines(body)) {
+        if (/npm\s+(install|i)\s+-g\s+pnpm(?!@)/.test(line)) {
+          offenders.push(`docker/${name}:${no}: installs pnpm unpinned — use pnpm@${version}`);
+        }
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+
+  it('pins every pnpm install to the version packageManager declares', () => {
+    const offenders: string[] = [];
+    for (const { name, body } of dockerfiles()) {
+      for (const { line, no } of commandLines(body)) {
+        const found = line.match(/npm\s+(?:install|i)\s+-g\s+pnpm@(\S+)/);
+        if (found && found[1] !== version) {
+          offenders.push(`docker/${name}:${no}: pins pnpm@${found[1]}, but packageManager says ${version}`);
+        }
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+});

--- a/docker/Dockerfile.admin
+++ b/docker/Dockerfile.admin
@@ -4,7 +4,11 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 # Install pnpm and git (required for baileys dependency)
-RUN apk add --no-cache git && npm install -g pnpm
+# Pin pnpm to the version declared in the root package.json (pnpm@9.15.0). Unpinned,
+# `npm install -g pnpm` grabs whatever is latest at build time — and a pnpm release
+# in Aug 2026 added an engine-identity check that fails on Alpine with
+# ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE, breaking every admin image build.
+RUN apk add --no-cache git && npm install -g pnpm@9.15.0
 
 # Copy workspace and pnpm config files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -4,7 +4,11 @@ FROM node:20-slim AS builder
 WORKDIR /app
 
 # Install pnpm and git
-RUN apt-get update && apt-get install -y git && npm install -g pnpm
+# Pin pnpm to the version declared in the root package.json (pnpm@9.15.0). Unpinned,
+# `npm install -g pnpm` grabs whatever is latest at build time — and a pnpm release
+# in Aug 2026 added an engine-identity check that fails on Alpine with
+# ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE, breaking every admin image build.
+RUN apt-get update && apt-get install -y git && npm install -g pnpm@9.15.0
 
 # Copy workspace files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
@@ -100,7 +104,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm and git (required for baileys dependency)
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* && npm install -g pnpm
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* && npm install -g pnpm@9.15.0
 
 # Copy package files for pnpm install
 COPY --from=builder /app/package.json ./package.json

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -4,7 +4,11 @@ FROM node:20-slim AS builder
 WORKDIR /app
 
 # Install pnpm and git
-RUN apt-get update && apt-get install -y git && npm install -g pnpm
+# Pin pnpm to the version declared in the root package.json (pnpm@9.15.0). Unpinned,
+# `npm install -g pnpm` grabs whatever is latest at build time — and a pnpm release
+# in Aug 2026 added an engine-identity check that fails on Alpine with
+# ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE, breaking every admin image build.
+RUN apt-get update && apt-get install -y git && npm install -g pnpm@9.15.0
 
 # Copy workspace files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
@@ -83,7 +87,7 @@ RUN apt-get update && apt-get install -y \
       chromium libnss3 libfreetype6 libharfbuzz0b \
       ca-certificates fonts-freefont-ttf libxshmfence1 libgbm1 \
       git --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/* && npm install -g pnpm
+    rm -rf /var/lib/apt/lists/* && npm install -g pnpm@9.15.0
 
 # Copy workspace definition and lockfile
 COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./


### PR DESCRIPTION
## Why all 10 open PRs are red

Every open PR is failing `Build Admin Image`:

```
Error: ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE
> [builder 16/19] RUN pnpm install --frozen-lockfile --filter @multiwa/admin...
```

**The cause is not in any of those PRs.** #175 only bumps `n8n-workflow` and `turbo`; it fails identically. The build toolchain is what broke.

All three Dockerfiles ran `npm install -g pnpm` — **unpinned**, so every build used whatever pnpm was latest that day:

| | |
|---|---|
| root `packageManager` declares | **pnpm@9.15.0** |
| npm currently serves | **pnpm 11.25.0** |

So builds were running **pnpm 11 against a lockfile written by pnpm 9**, and a recent pnpm release added an engine-identity check that cannot verify on musl.

**Only admin broke** because only `Dockerfile.admin` uses `node:20-alpine`; api and worker use `node:20-slim`. That also explains the timing: `main`'s last CI run (2026-08-24) was green while every PR built on 2026-08-30 failed. Nothing in the repo changed — the published pnpm did.

## The fix

This completes what #174 started. That PR made the images honour `pnpm-lock.yaml` — which only means something if the tool *reading* the lockfile is itself pinned.

1. **Pin all 5 `npm install -g pnpm` sites to `pnpm@9.15.0`**, matching `packageManager`.

2. **Add `apps/api/src/dockerfile-pnpm-pinned.spec.ts`** asserting that no Dockerfile installs pnpm unpinned, and that every pin matches what `packageManager` declares. Comment lines are excluded so prose about the flag doesn't trip it.

   Both negative controls verified:
   ```
   docker/Dockerfile.admin:11: installs pnpm unpinned — use pnpm@9.15.0
   docker/Dockerfile.api:11: pins pnpm@10.0.0, but packageManager says 9.15.0
   ```

## Verification

- `tsc --noEmit` PASS on api / worker / admin
- **api 365/365** (+4 new), **worker 37/37**

## Effect on the other 9 PRs

Once this lands, the remaining PRs need a rebase to pick it up. Expect the 8 NestJS 12 PRs to *still* fail afterwards — but on their real problem (a framework major that must move as one coordinated migration, not eight independent bumps) rather than on this toolchain issue masking it.