### PR TITLE
chore(deps): ignore NestJS majors — they must cross as one migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,41 @@ updates:
       # moves together in a hand-made PR; a fastify-only security patch is unusable
       # until Nest ships a matching platform-fastify anyway.
       - dependency-name: "fastify"
+      # The NestJS family is ONE framework and must cross a major as a single
+      # coordinated migration. Bumping one package alone pairs mismatched majors and
+      # the app cannot even load: Nest 12 PRs failed with
+      #   Cannot find module '.../@nestjs+core@12.0.1_@nestjs+common@11.2.1_...'
+      # Dependabot opened EIGHT such PRs (#177-#184) on 2026-08-30, each individually
+      # unbuildable. Note @nestjs/config jumps 4.x -> 12.x, so it is not even the same
+      # numbering. Do Nest majors as one deliberate PR, then unignore if desired.
+      - dependency-name: "@nestjs/common"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/platform-fastify"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/platform-socket.io"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/websockets"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/jwt"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/config"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/schematics"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/testing"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/swagger"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/event-emitter"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/schedule"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/passport"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@nestjs/throttler"
+        update-types: ["version-update:semver-major"]
       # TypeScript 7 (native/Go preview) and Node 26 types outrun the pinned
       # runtime (Node 20/22, TS 5.x). Bump these deliberately, not automatically.
       - dependency-name: "typescript"


### PR DESCRIPTION
## Why

Dependabot opened **eight individually-unbuildable PRs** on 2026-08-30 (#177–#184), each bumping one NestJS package from 11 to 12 while the rest stayed on 11. The app cannot load in that state:

```
Cannot find module '.../@nestjs+core@12.0.1_@nestjs+common@11.2.1_...'
```

The NestJS family is **one framework**. A major has to move as a single coordinated migration or not at all.

This is the same shape as the `fastify` / `@nestjs/platform-fastify` pairing already ignored in this file — just across 8 packages instead of 2.

Also worth noting: `@nestjs/config` jumps **4.0.4 → 12.0.0**. It is not even on the same numbering as the rest, so "bump them all to 12" would not have been a mechanical edit either.

## What this does

Ignores **major** updates only, for the 14 `@nestjs/*` packages in the workspace. Minor and patch keep flowing as usual — Nest ships those constantly and they have been merging cleanly all along.

When Nest 12 is worth doing, it should be one deliberate PR with the breaking changes handled, after which these entries can be dropped.

## Related

- #185 (merged) fixed the *other* reason all 10 PRs were red — an unpinned pnpm in the Dockerfiles. That was masking this one.
- #175 and #176 are unaffected by this change; they are ordinary minor/patch group bumps and should go green once rebased onto #185.